### PR TITLE
fix: 杜林的命之座「流溢之原」出现文本错误

### DIFF
--- a/src/launcher/UI/Xaml/Control/TextBlock/Syntax/MiHoYo/MiHoYoSyntaxLinkElement.cs
+++ b/src/launcher/UI/Xaml/Control/TextBlock/Syntax/MiHoYo/MiHoYoSyntaxLinkElement.cs
@@ -29,6 +29,7 @@ internal sealed class MiHoYoSyntaxLinkElement : MiHoYoSyntaxElement
             'P' => MiHoYoSyntaxLinkKind.Inherent,
             'N' => MiHoYoSyntaxLinkKind.Name,
             'S' => MiHoYoSyntaxLinkKind.Skill,
+            'T' => MiHoYoSyntaxLinkKind.Talent,
             _ => throw LauncherException.Throw($"Unexpected link kind :{source[IdPosition.Start]}"),
         };
     }

--- a/src/launcher/UI/Xaml/Control/TextBlock/Syntax/MiHoYo/MiHoYoSyntaxLinkKind.cs
+++ b/src/launcher/UI/Xaml/Control/TextBlock/Syntax/MiHoYo/MiHoYoSyntaxLinkKind.cs
@@ -14,5 +14,6 @@ internal enum MiHoYoSyntaxLinkKind
     None,
     Name,
     Skill,
+    Talent,
     Inherent,
 }

--- a/src/launcher/ViewModel/Wiki/LinkMetadataContext.cs
+++ b/src/launcher/ViewModel/Wiki/LinkMetadataContext.cs
@@ -21,6 +21,8 @@ internal sealed class LinkMetadataContext
 
     public ImmutableArray<ProudSkill> Skills { get; init; }
 
+    public ImmutableArray<Skill> Talents { get; init; }
+
     public ImmutableArray<ProudSkill> Inherents { get; init; }
 
     public bool TryGetNameAndDescription(MiHoYoSyntaxLinkKind kind, uint id, out string name, out string description)
@@ -48,6 +50,11 @@ internal sealed class LinkMetadataContext
 
                 name = inherent.Name;
                 description = inherent.Description;
+                break;
+            case MiHoYoSyntaxLinkKind.Talent:
+                Skill talent = Talents.Single(s => s.Id == id);
+                name = talent.Name;
+                description = talent.Description;
                 break;
             case MiHoYoSyntaxLinkKind.Skill:
                 ProudSkill? skill = Skills.SingleOrDefault(s => s.Id == id);

--- a/src/launcher/ViewModel/Wiki/WikiAvatarViewModel.cs
+++ b/src/launcher/ViewModel/Wiki/WikiAvatarViewModel.cs
@@ -150,6 +150,7 @@ internal sealed partial class WikiAvatarViewModel : Abstraction.ViewModel
             IdNameMap = metadataContext.IdHyperLinkNameMap,
             Inherents = avatar.SkillDepot.Inherents,
             Skills = avatar.SkillDepot.CompositeSkillsNoInherents,
+            Talents = avatar.SkillDepot.Talents,
         };
     }
 


### PR DESCRIPTION
增加对 Talent (T) 链接类型的支持，修复流溢之原等含天赋链接的文本解析失败问题。

(cherry picked from Snap.Hutao.Remastered commit 20c17d70)

---
name: Pull Request
about: ''
---

## 变更内容

<!-- 简述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 重构
- [ ] 性能优化
- [ ] 依赖更新
- [ ] CI/基建

## 测试

- [ ] 已通过本地测试
- [ ] 已添加/更新相关测试用例

## 相关 Issue

closes #
