### PR TITLE
i18n: add complete Vietnamese (vi-VN) localization

### DIFF
--- a/src/launcher/Resource/Localization/SH.vi-VN.resx
+++ b/src/launcher/Resource/Localization/SH.vi-VN.resx
@@ -118,5630 +118,5629 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDevNameAndVersion" xml:space="preserve">
-    <value>ky3 Launcher Dev {0}</value>
+    <value>ky3 Launcher Dev {0}</value> 
   </data>
   <data name="AppElevatedDevNameAndVersion" xml:space="preserve">
-    <value>ky3 Launcher Dev {0} [管理员]</value>
-  </data>
+    <value>ky3 Launcher Dev {0} [Quản Trị Viên]</value>  
+  </data>  
   <data name="AppElevatedNameAndVersion" xml:space="preserve">
-    <value>ky3 Launcher {0} [管理员]</value>
-  </data>
+    <value>ky3 Launcher {0} [Quản Trị Viên]</value>  
+  </data>  
   <data name="AppName" xml:space="preserve">
-    <value>ky3 Launcher</value>
-  </data>
+    <value>ky3 Launcher</value>  
+  </data>  
   <data name="AppNameAndVersion" xml:space="preserve">
-    <value>ky3 Launcher {0}</value>
-  </data>
+    <value>ky3 Launcher {0}</value>  
+  </data>  
   <data name="ContentDialogCancelCloseButtonText" xml:space="preserve">
-    <value>取消</value>
-  </data>
+    <value>Hủy</value>  
+  </data>  
   <data name="ContentDialogCompletePrimaryButtonText" xml:space="preserve">
-    <value>完成</value>
+    <value>Hoàn thành</value> 
   </data>
   <data name="ContentDialogConfirmPrimaryButtonText" xml:space="preserve">
-    <value>确认</value>
+    <value>Xác nhận</value> 
   </data>
   <data name="ContentDialogSavePrimaryButtonText" xml:space="preserve">
-    <value>保存</value>
+    <value>Lưu</value> 
   </data>
   <data name="ControlAutoSuggestBoxNotFoundValue" xml:space="preserve">
-    <value>未找到结果</value>
+    <value>Không tìm thấy kết quả</value> 
   </data>
   <data name="ControlAutoSuggestTokenBoxRemoveMenuItem" xml:space="preserve">
-    <value>删除</value>
+    <value>Xóa</value> 
   </data>
   <data name="ControlAutoSuggestTokenBoxSelectAllMenuItem" xml:space="preserve">
-    <value>选择全部</value>
+    <value>Chọn tất cả</value> 
   </data>
   <data name="ControlImageCachedImageInvalidResourceUri" xml:space="preserve">
-    <value>无效的 URI</value>
+    <value>URI không hợp lệ</value> 
   </data>
   <data name="ControlPanelPanelSelectorDropdownGridName" xml:space="preserve">
-    <value>网格</value>
+    <value>Lưới</value> 
   </data>
   <data name="ControlPanelPanelSelectorDropdownListName" xml:space="preserve">
-    <value>列表</value>
+    <value>Danh sách</value> 
   </data>
   <data name="CoreLifeCycleAppActivationNotifyIconCreateFailed" xml:space="preserve">
-    <value>通知区域图标创建失败</value>
+    <value>Tạo biểu tượng khu vực thông báo thất bại</value> 
   </data>
   <data name="CoreThreadingSemaphoreSlimDisposed" xml:space="preserve">
-    <value>信号量已经被释放，操作取消</value>
+    <value>Semaphore đã bị giải phóng, thao tác bị hủy</value> 
   </data>
   <data name="CoreWebView2HelperVersionUndetected" xml:space="preserve">
-    <value>未检测到 WebView2 运行时</value>
+    <value>Không phát hiện Runtime WebView2</value> 
   </data>
   <data name="CoreWindowHotkeyCombinationRegisterFailed" xml:space="preserve">
-    <value>[{0}] 热键 [{1}] 注册失败</value>
+    <value>Đăng ký phím tắt [{1}] cho [{0}] thất bại</value> 
   </data>
   <data name="CoreWindowThemeDark" xml:space="preserve">
-    <value>深色</value>
+    <value>Tối</value> 
   </data>
   <data name="CoreWindowThemeLight" xml:space="preserve">
-    <value>浅色</value>
+    <value>Sáng</value> 
   </data>
   <data name="CoreWindowThemeSystem" xml:space="preserve">
-    <value>跟随系统</value>
+    <value>Theo hệ thống</value> 
   </data>
   <data name="CoreWindowingNotifyIconExitLabel" xml:space="preserve">
-    <value>退出</value>
+    <value>Thoát</value> 
   </data>
   <data name="CoreWindowingNotifyIconLaunchGameLabel" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value> 
   </data>
   <data name="CoreWindowingNotifyIconPromotedHint" xml:space="preserve">
-    <value>已进入后台运行</value>
+    <value>Đã thu nhỏ chạy ngầm</value> 
   </data>
   <data name="CoreWindowingNotifyIconViewLabel" xml:space="preserve">
-    <value>窗口</value>
+    <value>Cửa sổ</value> 
   </data>
   <data name="GuideWindowTitle" xml:space="preserve">
-    <value>欢迎使用-ky3 Launcher</value>
+    <value>Chào mừng sử dụng-ky3 Launcher</value> 
   </data>
   <data name="GuideWindowTitleAllCultures" xml:space="preserve">
-    <value>欢迎使用-ky3 Launcher+Welcome to ky3 Launcher+歡迎使用-ky3 Launcher</value>
+    <value>Chào mừng sử dụng-ky3 Launcher+Welcome to ky3 Launcher+歡迎使用-ky3 Launcher</value> 
   </data>
   <data name="MetadataSpecialNameMetaAvatarSexProInfoPronounBoyGirlD" xml:space="preserve">
-    <value>&lt;color=#1E90FF&gt;王子&lt;/color&gt;/&lt;color=#FFB6C1&gt;公主&lt;/color&gt;</value>
+    <value>&lt;color=#1E90FF&gt;Hoàng Tử&lt;/color&gt;/&lt;color=#FFB6C1&gt;Công Chúa&lt;/color&gt;</value> 
   </data>
   <data name="MetadataSpecialNameMetaAvatarSexProInfoPronounBoyGirlFirst" xml:space="preserve">
-    <value>&lt;color=#1E90FF&gt;我&lt;/color&gt;/&lt;color=#FFB6C1&gt;我&lt;/color&gt;</value>
+    <value>&lt;color=#1E90FF&gt;Tôi&lt;/color&gt;/&lt;color=#FFB6C1&gt;Tôi&lt;/color&gt;</value> 
   </data>
   <data name="MetadataSpecialNameNickname" xml:space="preserve">
-    <value>旅行者</value>
+    <value>Nhà Lữ Hành</value> 
   </data>
   <data name="MetadataSpecialNamePlayerAvatarSexProInfoPronounHeShe" xml:space="preserve">
-    <value>&lt;color=#1E90FF&gt;他&lt;/color&gt;/&lt;color=#FFB6C1&gt;她&lt;/color&gt;</value>
+    <value>&lt;color=#1E90FF&gt;Cậu ấy&lt;/color&gt;/&lt;color=#FFB6C1&gt;Cô ấy&lt;/color&gt;</value> 
   </data>
   <data name="MetadataSpecialNameRealNameId1" xml:space="preserve">
-    <value>流浪者</value>
+    <value>Kẻ Lang Thang</value> 
   </data>
   <data name="MetadataSpecialNameServerTimeZone" xml:space="preserve">
-    <value>服务器时区</value>
+    <value>Múi giờ máy chủ</value> 
   </data>
   <data name="ModelBindingAvatarPropertyWeaponAffix" xml:space="preserve">
-    <value>精炼 {0}</value>
+    <value>Tinh Luyện {0}</value> 
   </data>
   <data name="ModelBindingCultivationDaysOfWeek14" xml:space="preserve">
-    <value>周一/周四/周日</value>
+    <value>Thứ 2/Thứ 4/Chủ Nhật</value> 
   </data>
   <data name="ModelBindingCultivationDaysOfWeek25" xml:space="preserve">
-    <value>周二/周五/周日</value>
+    <value>Thứ 3/Thứ 6/Chủ Nhật</value> 
   </data>
   <data name="ModelBindingCultivationDaysOfWeek36" xml:space="preserve">
-    <value>周三/周六/周日</value>
+    <value>Thứ 4/Thứ 7/Chủ Nhật</value> 
   </data>
   <data name="ModelBindingGachaTypedWishSummaryAveragePull" xml:space="preserve">
-    <value>{0:f2} 抽</value>
+    <value>{0:f2} lần rút</value> 
   </data>
   <data name="ModelBindingGachaTypedWishSummaryMaxOrangePull" xml:space="preserve">
-    <value>最非 {0} 抽</value>
+    <value>Xui nhất {0} lần rút</value> 
   </data>
   <data name="ModelBindingGachaTypedWishSummaryMinOrangePull" xml:space="preserve">
-    <value>最欧 {0} 抽</value>
+    <value>Hên nhất {0} lần rút</value> 
   </data>
   <data name="ModelBindingGachaWishBaseTotalCount" xml:space="preserve">
-    <value>{0} 抽</value>
+    <value>{0} lần rút</value> 
   </data>
   <data name="ModelBindingLauncherComplexRankFloor" xml:space="preserve">
-    <value>第 {0} 层</value>
+    <value>Tầng {0}</value> 
   </data>
   <data name="ModelBindingLauncherComplexRankLevel" xml:space="preserve">
-    <value>第 {0} 间</value>
+    <value>Phòng {0}</value> 
   </data>
   <data name="ModelBindingLauncherTeamUpCount" xml:space="preserve">
-    <value>上场 {0} 次</value>
+    <value>Ra trận {0} lần</value> 
   </data>
   <data name="ModelBindingLaunchGameLaunchSchemeBilibili" xml:space="preserve">
-    <value>渠道服</value>
+    <value>Server Kênh</value> 
   </data>
   <data name="ModelBindingLaunchGameLaunchSchemeChinese" xml:space="preserve">
-    <value>官方服</value>
+    <value>Server Chính Thức</value> 
   </data>
   <data name="ModelBindingLaunchGameLaunchSchemeOversea" xml:space="preserve">
-    <value>国际服</value>
+    <value>Server Quốc Tế</value> 
   </data>
   <data name="ModelBindingUserInitializationFailed" xml:space="preserve">
-    <value>网络异常</value>
+    <value>Mạng bất thường</value> 
   </data>
   <data name="ModelEntityDailyNoteNotRefreshed" xml:space="preserve">
-    <value>尚未刷新</value>
+    <value>Chưa làm mới</value> 
   </data>
   <data name="ModelEntityDailyNoteRefreshTime" xml:space="preserve">
-    <value>刷新于 {0:MM.dd HH:mm:ss}</value>
+    <value>Làm mới lúc {0:MM.dd HH:mm:ss}</value> 
   </data>
   <data name="ModelEntityHardChallengeSchedule" xml:space="preserve">
-    <value>第 {0} 期：{1}</value>
+    <value>Kỳ {0}: {1}</value> 
   </data>
   <data name="ModelEntityPrimitiveCultivateTypeAvatarAndSkill" xml:space="preserve">
-    <value>角色</value>
+    <value>Nhân vật</value> 
   </data>
   <data name="ModelEntityPrimitiveCultivateTypeFurniture" xml:space="preserve">
-    <value>家具</value>
+    <value>Đồ trang trí</value> 
   </data>
   <data name="ModelEntityPrimitiveCultivateTypeWeapon" xml:space="preserve">
-    <value>武器</value>
+    <value>Vũ khí</value> 
   </data>
   <data name="ModelEntitySpiralAbyssSchedule" xml:space="preserve">
-    <value>第 {0} 期</value>
+    <value>Kỳ {0}</value> 
   </data>
   <data name="ModelInterchangeUIGFItemTypeAvatar" xml:space="preserve">
-    <value>角色</value>
+    <value>Nhân vật</value>
     <comment>Need EXACT same string in official API</comment>
   </data>
   <data name="ModelInterchangeUIGFItemTypeWeapon" xml:space="preserve">
-    <value>武器</value>
+    <value>Vũ khí</value>
     <comment>Need EXACT same string in official API</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeFatui" xml:space="preserve">
-    <value>愚人众</value>
+    <value>Fatui</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeFontaine" xml:space="preserve">
-    <value>枫丹</value>
+    <value>Fontaine</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeInazuma" xml:space="preserve">
-    <value>稻妻</value>
+    <value>Inazuma</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeLiyue" xml:space="preserve">
-    <value>璃月</value>
+    <value>Liyue</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeMondstadt" xml:space="preserve">
-    <value>蒙德</value>
+    <value>Mondstadt</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeNatlan" xml:space="preserve">
-    <value>纳塔</value>
+    <value>Natlan</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeNodkrai" xml:space="preserve">
-    <value>挪德卡莱</value>
+    <value>Nodkrai</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeOmniScourge" xml:space="preserve">
-    <value>寰宇劫灭</value>
+    <value>Thôn Tinh Kình Ngư</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeRanger" xml:space="preserve">
-    <value>游侠</value>
+    <value>Kẻ Lãng Du</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeSnezhnaya" xml:space="preserve">
-    <value>至冬</value>
+    <value>Snezhnaya</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicAssociationTypeSumeru" xml:space="preserve">
-    <value>须弥</value>
+    <value>Sumeru</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicBodyTypeBoy" xml:space="preserve">
-    <value>少男</value>
+    <value>Thiếu niên</value> 
   </data>
   <data name="ModelIntrinsicBodyTypeGirl" xml:space="preserve">
-    <value>少女</value>
+    <value>Thiếu nữ</value> 
   </data>
   <data name="ModelIntrinsicBodyTypeLady" xml:space="preserve">
-    <value>成女</value>
+    <value>Nữ trưởng thành</value> 
   </data>
   <data name="ModelIntrinsicBodyTypeLoli" xml:space="preserve">
-    <value>萝莉</value>
+    <value>Loli</value> 
   </data>
   <data name="ModelIntrinsicBodyTypeMale" xml:space="preserve">
-    <value>成男</value>
+    <value>Nam trưởng thành</value> 
   </data>
   <data name="ModelIntrinsicElementNameElec" xml:space="preserve">
-    <value>雷</value>
+    <value>Lôi</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameFire" xml:space="preserve">
-    <value>火</value>
+    <value>Hỏa</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameGrass" xml:space="preserve">
-    <value>草</value>
+    <value>Thảo</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameIce" xml:space="preserve">
-    <value>冰</value>
+    <value>Băng</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameRock" xml:space="preserve">
-    <value>岩</value>
+    <value>Nham</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameWater" xml:space="preserve">
-    <value>水</value>
+    <value>Thủy</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicElementNameWind" xml:space="preserve">
-    <value>风</value>
+    <value>Phong</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelAdvancing" xml:space="preserve">
-    <value>进阶</value>
+    <value>Nâng cao</value> 
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelDire" xml:space="preserve">
-    <value>绝境</value>
+    <value>Tuyệt cảnh</value> 
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelFearless" xml:space="preserve">
-    <value>无畏</value>
+    <value>Dũng Cảm</value> 
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelHard" xml:space="preserve">
-    <value>困难</value>
+    <value>Khó</value> 
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelMenacing" xml:space="preserve">
-    <value>险恶</value>
+    <value>Hiểm ác</value> 
   </data>
   <data name="ModelIntrinsicHardChallengeDifficultyLevelNormal" xml:space="preserve">
-    <value>普通</value>
+    <value>Thường</value> 
   </data>
   <data name="ModelIntrinsicItemQualityBlue" xml:space="preserve">
-    <value>三星</value>
+    <value>3 Sao</value> 
   </data>
   <data name="ModelIntrinsicItemQualityGreen" xml:space="preserve">
-    <value>二星</value>
+    <value>2 Sao</value> 
   </data>
   <data name="ModelIntrinsicItemQualityOrange" xml:space="preserve">
-    <value>五星</value>
+    <value>5 Sao</value> 
   </data>
   <data name="ModelIntrinsicItemQualityPurple" xml:space="preserve">
-    <value>四星</value>
+    <value>4 Sao</value> 
   </data>
   <data name="ModelIntrinsicItemQualityRed" xml:space="preserve">
-    <value>限定五星</value>
+    <value>5 Sao Giới Hạn</value> 
   </data>
   <data name="ModelIntrinsicItemQualityWhite" xml:space="preserve">
-    <value>一星</value>
+    <value>1 Sao</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeNovice" xml:space="preserve">
-    <value>新手祈愿</value>
+    <value>Cầu Nguyện Tân Thủ</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeStandard" xml:space="preserve">
-    <value>常驻祈愿</value>
+    <value>Cầu Nguyện Thường</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeAvatarEvent" xml:space="preserve">
-    <value>角色活动祈愿</value>
+    <value>Cầu Nguyện Sự Kiện Nhân Vật</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeWeaponEvent" xml:space="preserve">
-    <value>武器活动祈愿</value>
+    <value>Cầu Nguyện Sự Kiện Vũ Khí</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeAvatarEvent2" xml:space="preserve">
-    <value>角色活动祈愿-2</value>
+    <value>Cầu Nguyện Sự Kiện Nhân Vật-2</value> 
   </data>
   <data name="ModelIntrinsicGachaTypeChronicled" xml:space="preserve">
-    <value>集录祈愿</value>
+    <value>Cầu Nguyện Sử Kí</value> 
   </data>
   <data name="ModelIntrinsicRoleCombatDifficultyLevelEasy" xml:space="preserve">
-    <value>轻简模式</value>
+    <value>Chế độ Dễ</value> 
   </data>
   <data name="ModelIntrinsicRoleCombatDifficultyLevelHard" xml:space="preserve">
-    <value>困难模式</value>
+    <value>Chế độ Khó</value> 
   </data>
   <data name="ModelIntrinsicRoleCombatDifficultyLevelLunar" xml:space="preserve">
-    <value>月谕模式</value>
+    <value>Chế độ Ánh Trăng</value> 
   </data>
   <data name="ModelIntrinsicRoleCombatDifficultyLevelNormal" xml:space="preserve">
-    <value>普通模式</value>
+    <value>Chế độ Thường</value> 
   </data>
   <data name="ModelIntrinsicRoleCombatDifficultyLevelVisionary" xml:space="preserve">
-    <value>卓越模式</value>
+    <value>Chế độ Xuất Sắc</value> 
   </data>
   <data name="ModelIntrinsicWeaponTypeBow" xml:space="preserve">
-    <value>弓</value>
+    <value>Cung</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicWeaponTypeCatalyst" xml:space="preserve">
-    <value>法器</value>
+    <value>Pháp Khí</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicWeaponTypeClaymore" xml:space="preserve">
-    <value>双手剑</value>
+    <value>Trọng Kiếm</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicWeaponTypePole" xml:space="preserve">
-    <value>长柄武器</value>
+    <value>Vũ Khí Cán Dài</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelIntrinsicWeaponTypeSwordOneHand" xml:space="preserve">
-    <value>单手剑</value>
+    <value>Kiếm Đơn</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataAvatarPlayerName" xml:space="preserve">
-    <value>旅行者</value>
+    <value>Nhà Lữ Hành</value> 
   </data>
   <data name="ModelMetadataFetterInfoBirthday" xml:space="preserve">
-    <value>{0} 月 {1} 日</value>
+    <value>Ngày {1} tháng {0}</value> 
   </data>
   <data name="ModelMetadataMaterialCharacterAndWeaponEnhancementMaterial" xml:space="preserve">
-    <value>角色与武器培养素材</value>
+    <value>Nguyên Liệu Bồi Dưỡng Nhân Vật Và Vũ Khí</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialCharacterAscensionMaterial" xml:space="preserve">
-    <value>角色突破素材</value>
+    <value>Nguyên Liệu Đột Phá Nhân Vật</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialCharacterEXPMaterial" xml:space="preserve">
-    <value>角色经验素材</value>
+    <value>Nguyên Liệu Kinh Nghiệm Nhân Vật</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialCharacterLevelUpMaterial" xml:space="preserve">
-    <value>角色培养素材</value>
+    <value>Nguyên Liệu Bồi Dưỡng Nhân Vật</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialCharacterTalentMaterial" xml:space="preserve">
-    <value>角色天赋素材</value>
+    <value>Nguyên Liệu Thiên Phú Nhân Vật</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialWeaponAscensionMaterial" xml:space="preserve">
-    <value>武器突破素材</value>
+    <value>Nguyên Liệu Đột Phá Vũ Khí</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataMaterialWeaponEnhancementMaterial" xml:space="preserve">
-    <value>武器强化素材</value>
+    <value>Nguyên Liệu Cường Hóa Vũ Khí</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ModelMetadataTowerGoalTypeDefeatMonsters" xml:space="preserve">
-    <value>击败怪物</value>
+    <value>Tiêu diệt quái</value> 
   </data>
   <data name="ModelMetadataTowerGoalTypeDefendTarget" xml:space="preserve">
-    <value>守护目标</value>
+    <value>Bảo vệ mục tiêu</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeAdditional" xml:space="preserve">
-    <value>附加：增援怪物</value>
+    <value>Bổ sung: Quái tăng viện</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeDefault" xml:space="preserve">
-    <value>本间怪物</value>
+    <value>Quái phòng này</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupA" xml:space="preserve">
-    <value>A组：不同的组同时在场，各自分波独立</value>
+    <value>Nhóm A: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupAWave1" xml:space="preserve">
-    <value>A组第一波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 1 Nhóm A: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupAWave2" xml:space="preserve">
-    <value>A组第二波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 2 Nhóm A: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupAWave3" xml:space="preserve">
-    <value>A组第三波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 3 Nhóm A: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupB" xml:space="preserve">
-    <value>B组：不同的组同时在场，各自分波独立</value>
+    <value>Nhóm B: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupBWave1" xml:space="preserve">
-    <value>B组第一波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 1 Nhóm B: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupBWave2" xml:space="preserve">
-    <value>B组第二波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 2 Nhóm B: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupBWave3" xml:space="preserve">
-    <value>B组第三波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 3 Nhóm B: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupC" xml:space="preserve">
-    <value>C组：不同的组同时在场，各自分波独立</value>
+    <value>Nhóm C: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupCWave1" xml:space="preserve">
-    <value>C组第一波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 1 Nhóm C: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupCWave2" xml:space="preserve">
-    <value>C组第二波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 2 Nhóm C: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupCWave3" xml:space="preserve">
-    <value>C组第三波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 3 Nhóm C: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupD" xml:space="preserve">
-    <value>D组：不同的组同时在场，各自分波独立</value>
+    <value>Nhóm D: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupDWave1" xml:space="preserve">
-    <value>D组第一波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 1 Nhóm D: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupDWave2" xml:space="preserve">
-    <value>D组第二波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 2 Nhóm D: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeGroupDWave3" xml:space="preserve">
-    <value>D组第三波：不同的组同时在场，各自分波独立</value>
+    <value>Đợt 3 Nhóm D: Các nhóm khác nhau cùng xuất hiện, tự phân đợt độc lập</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeIndependent" xml:space="preserve">
-    <value>与其他怪物独立</value>
+    <value>Độc lập với các quái khác</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeSuppressed" xml:space="preserve">
-    <value>暂时没有分波信息</value>
+    <value>Tạm thời chưa có thông tin phân đợt</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave1" xml:space="preserve">
-    <value>第一波：击败所有怪物，下一波才会出现</value>
+    <value>Đợt 1: Tiêu diệt toàn bộ quái vật, đợt tiếp theo mới xuất hiện</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave1Additional" xml:space="preserve">
-    <value>第一波附加：增援第一波怪物</value>
+    <value>Bổ sung Đợt 1: Tăng viện quái Đợt 1</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave2" xml:space="preserve">
-    <value>第二波：击败所有怪物，下一波才会出现</value>
+    <value>Đợt 2: Tiêu diệt toàn bộ quái vật, đợt tiếp theo mới xuất hiện</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave3" xml:space="preserve">
-    <value>第三波：击败所有怪物，下一波才会出现</value>
+    <value>Đợt 3: Tiêu diệt toàn bộ quái vật, đợt tiếp theo mới xuất hiện</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave4" xml:space="preserve">
-    <value>第四波：击败所有怪物，下一波才会出现</value>
+    <value>Đợt 4: Tiêu diệt toàn bộ quái vật, đợt tiếp theo mới xuất hiện</value> 
   </data>
   <data name="ModelMetadataTowerWaveTypeWave99999" xml:space="preserve">
-    <value>维持场上 4 个盗宝团怪物，击杀后立即替换，总数 12 个</value>
+    <value>Duy trì 4 Đạo Bảo Đoàn trên sân, tiêu diệt sẽ thay thế ngay, tổng cộng 12 tên</value> 
   </data>
   <data name="ModelNameValueDefaultDescription" xml:space="preserve">
-    <value>请更新角色橱窗数据</value>
+    <value>Vui lòng cập nhật dữ liệu tủ kính nhân vật</value> 
   </data>
   <data name="ModelNameValueDefaultName" xml:space="preserve">
-    <value>暂无数据</value>
+    <value>Tạm không có dữ liệu</value> 
   </data>
   <data name="ModelWeaponAffix" xml:space="preserve">
-    <value>精炼 {0} 阶</value>
+    <value>Tinh Luyện Bậc {0}</value> 
   </data>
   <data name="MustSelectUserAndUid" xml:space="preserve">
-    <value>必须登录 米游社 / HoYoLAB 并选择一个用户与角色</value>
+    <value>Phải đăng nhập HoyoLAB và chọn một người dùng cùng nhân vật</value> 
   </data>
   <data name="ServerCdnServiceInsufficientTime" xml:space="preserve">
-    <value>未开通云 CDN 或已到期</value>
+    <value>Chưa mở Cloud CDN hoặc đã hết hạn</value> 
   </data>
   <data name="ServerGachaLogServiceDeleteEntrySucceed" xml:space="preserve">
-    <value>删除了 UID：{0} 的 {1} 条祈愿记录</value>
+    <value>Đã xóa {1} bản ghi Cầu Nguyện của UID: {0}</value> 
   </data>
   <data name="ServerGachaLogServiceInsufficientRecordSlot" xml:space="preserve">
-    <value>云保存的祈愿记录存档数已达当前账号上限</value>
+    <value>Số lượng bản lưu Cầu Nguyện trên Cloud đã đạt giới hạn của tài khoản</value> 
   </data>
   <data name="ServerGachaLogServiceInsufficientTime" xml:space="preserve">
-    <value>未开通祈愿记录上传服务或已到期</value>
+    <value>Chưa mở dịch vụ tải lên lịch sử Cầu Nguyện hoặc đã hết hạn</value> 
   </data>
   <data name="ServerGachaLogServiceInvalidGachaLogData" xml:space="preserve">
-    <value>祈愿数据存在无效的物品，无法保存至云</value>
+    <value>Dữ liệu Cầu Nguyện chứa vật phẩm không hợp lệ, không thể lưu lên Cloud</value> 
   </data>
   <data name="ServerGachaLogServiceServerDatabaseError" xml:space="preserve">
-    <value>数据异常，无法保存至云端，请勿跨账号上传或尝试删除云端数据后重试</value>
+    <value>Dữ liệu bất thường, không thể lưu lên Cloud. Vui lòng không tải chéo tài khoản hoặc thử xóa dữ liệu Cloud rồi thử lại</value> 
   </data>
   <data name="ServerGachaLogServiceUploadEntrySucceed" xml:space="preserve">
-    <value>上传了 UID：{0} 的 {1} 条祈愿记录，存储了 {2} 条</value>
+    <value>Đã tải lên {1} lịch sử Cầu Nguyện của UID: {0}, đã lưu {2} bản ghi</value> 
   </data>
   <data name="ServerPassportDeviceIdEmpty" xml:space="preserve">
-    <value>设备 ID 不能为空</value>
+    <value>ID Thiết Bị không được để trống</value> 
   </data>
   <data name="ServerPassportLoginRequired" xml:space="preserve">
-    <value>请先登录或注册账号</value>
+    <value>Vui lòng đăng nhập hoặc đăng ký tài khoản trước</value> 
   </data>
   <data name="ServerPassportLoginSucceed" xml:space="preserve">
-    <value>登录成功</value>
+    <value>Đăng nhập thành công</value> 
   </data>
   <data name="ServerPassportPasswordTooShort" xml:space="preserve">
-    <value>密码长度不能小于 8 位</value>
+    <value>Độ dài mật khẩu không được nhỏ hơn 8 ký tự</value> 
   </data>
   <data name="ServerPassportRefreshTokenEmpty" xml:space="preserve">
-    <value>刷新令牌不能为空</value>
+    <value>Refresh Token không được để trống</value> 
   </data>
   <data name="ServerPassportRefreshTokenInvalid" xml:space="preserve">
-    <value>刷新令牌无效或已过期</value>
+    <value>Refresh Token không hợp lệ hoặc đã hết hạn</value> 
   </data>
   <data name="ServerPassportRegisterSucceed" xml:space="preserve">
-    <value>注册成功</value>
+    <value>Đăng ký thành công</value> 
   </data>
   <data name="ServerPassportResetPasswordSucceed" xml:space="preserve">
-    <value>新密码设置成功</value>
+    <value>Cài đặt mật khẩu mới thành công</value> 
   </data>
   <data name="ServerPassportResetPasswordTheSamePassword" xml:space="preserve">
-    <value>新密码不能与旧密码相同</value>
+    <value>Mật khẩu mới không được trùng với mật khẩu cũ</value> 
   </data>
   <data name="ServerPassportServiceEmailHasNotRegistered" xml:space="preserve">
-    <value>当前邮箱尚未注册</value>
+    <value>Email hiện tại chưa được đăng ký</value> 
   </data>
   <data name="ServerPassportServiceEmailHasRegistered" xml:space="preserve">
-    <value>当前邮箱已被注册</value>
+    <value>Email hiện tại đã được đăng ký</value> 
   </data>
   <data name="ServerPassportServiceInternalException" xml:space="preserve">
-    <value>注册失败，服务器异常，请尽快联系开发者解决</value>
+    <value>Đăng ký thất bại, máy chủ bất thường, vui lòng liên hệ nhà phát triển để giải quyết</value> 
   </data>
   <data name="ServerPassportServiceUnregisterPasswordIncorrect" xml:space="preserve">
-    <value>密码错误，注销失败</value>
+    <value>Mật khẩu sai, hủy đăng ký thất bại</value> 
   </data>
   <data name="ServerPassportServiceUnregisterUserNotFound" xml:space="preserve">
-    <value>用户不存在，注销失败</value>
+    <value>Người dùng không tồn tại, hủy đăng ký thất bại</value> 
   </data>
   <data name="ServerPassportTokenRevokeFailed" xml:space="preserve">
-    <value>令牌撤销失败</value>
+    <value>Thu hồi Token thất bại</value> 
   </data>
   <data name="ServerPassportTokenRevokeSuccess" xml:space="preserve">
-    <value>令牌撤销成功</value>
+    <value>Thu hồi Token thành công</value> 
   </data>
   <data name="ServerPassportUnregisterSucceed" xml:space="preserve">
-    <value>用户注销成功</value>
+    <value>Hủy đăng ký tài khoản thành công</value> 
   </data>
   <data name="ServerPassportUserInfoNotExist" xml:space="preserve">
-    <value>用户不存在，获取用户信息失败</value>
+    <value>Người dùng không tồn tại, lấy thông tin thất bại</value> 
   </data>
   <data name="ServerPassportUserNameOrPasswordIncorrect" xml:space="preserve">
-    <value>用户名或密码错误</value>
+    <value>Tên người dùng hoặc mật khẩu không đúng</value> 
   </data>
   <data name="ServerPassportVerifyFailed" xml:space="preserve">
-    <value>验证失败</value>
+    <value>Xác minh thất bại</value> 
   </data>
   <data name="ServerPassportVerifyRequestNotCurrentUser" xml:space="preserve">
-    <value>验证请求失败，不是当前登录的账号</value>
+    <value>Yêu cầu xác minh thất bại, không phải là tài khoản đang đăng nhập</value> 
   </data>
   <data name="ServerPassportVerifyRequestSuccess" xml:space="preserve">
-    <value>验证码已发送至邮箱</value>
+    <value>Mã xác minh đã được gửi đến email</value> 
   </data>
   <data name="ServerPassportVerifyRequestUserAlreadyExisted" xml:space="preserve">
-    <value>验证请求失败，当前邮箱已被注册</value>
+    <value>Yêu cầu xác minh thất bại, email đã được đăng ký</value> 
   </data>
   <data name="ServerPassportVerifyRequestUserNotExisted" xml:space="preserve">
-    <value>验证请求失败，当前邮箱未注册</value>
+    <value>Yêu cầu xác minh thất bại, email chưa đăng ký</value> 
   </data>
   <data name="ServerPassportVerifyTooFrequent" xml:space="preserve">
-    <value>验证请求过快，请 1 分钟后再试</value>
+    <value>Yêu cầu xác minh quá nhanh, vui lòng thử lại sau 1 phút</value> 
   </data>
   <data name="ServerRecordBannedUid" xml:space="preserve">
-    <value>上传深渊记录失败，当前 UID 已被数据库封禁</value>
+    <value>Tải lên La Hoàn Thâm Cảnh thất bại, UID hiện tại đã bị CSDL cấm</value> 
   </data>
   <data name="ServerRecordComputingStatistics" xml:space="preserve">
-    <value>上传深渊记录失败，正在计算统计数据</value>
+    <value>Tải lên dữ liệu La Hoàn Thâm Cảnh thất bại, đang tính toán số liệu thống kê</value> 
   </data>
   <data name="ServerRecordComputingStatistics2" xml:space="preserve">
-    <value>获取数据失败，正在计算统计数据</value>
+    <value>Lấy dữ liệu thất bại, đang tính toán số liệu thống kê</value> 
   </data>
   <data name="ServerRecordInternalException" xml:space="preserve">
-    <value>上传深渊记录失败，服务器异常，请尽快联系开发者解决</value>
+    <value>Tải lên dữ liệu La Hoàn Thâm Cảnh thất bại, máy chủ bất thường, vui lòng liên hệ nhà phát triển để giải quyết</value> 
   </data>
   <data name="ServerRecordInvalidData" xml:space="preserve">
-    <value>上传深渊记录失败，存在无效的数据</value>
+    <value>Tải lên dữ liệu La Hoàn Thâm Cảnh thất bại, tồn tại dữ liệu không hợp lệ</value> 
   </data>
   <data name="ServerRecordInvalidUid" xml:space="preserve">
-    <value>无效的 UID</value>
+    <value>UID không hợp lệ</value> 
   </data>
   <data name="ServerRecordNotCurrentSchedule" xml:space="preserve">
-    <value>上传深渊记录失败，不是本期数据</value>
+    <value>Tải lên dữ liệu La Hoàn Thâm Cảnh thất bại, không phải dữ liệu của kỳ hiện tại</value> 
   </data>
   <data name="ServerRecordPreviousRequestNotCompleted" xml:space="preserve">
-    <value>上传深渊记录失败，当前 UID 的记录仍在处理中，请勿重复操作</value>
+    <value>Tải lên dữ liệu La Hoàn Thâm Cảnh thất bại, dữ liệu UID này vẫn đang được xử lý, vui lòng không lặp lại thao tác</value> 
   </data>
   <data name="ServerRecordUploadSuccessAndGachaLogServiceTimeExtended" xml:space="preserve">
-    <value>上传深渊记录成功，获赠祈愿记录上传服务时长</value>
+    <value>Tải lên La Hoàn Thâm Cảnh thành công, được tặng thời gian dịch vụ tải lên lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ServerRecordUploadSuccessButNoPassport" xml:space="preserve">
-    <value>上传深渊记录成功，但未登录通行证，无法获赠祈愿记录上传服务时长</value>
+    <value>Tải lên La Hoàn Thâm Cảnh thành công, nhưng chưa đăng nhập Passport, không thể nhận thời gian dịch vụ tặng kèm</value> 
   </data>
   <data name="ServerRecordUploadSuccessButNoSuchUser" xml:space="preserve">
-    <value>上传深渊记录成功，但无法找到用户，无法获赠祈愿记录上传服务时长</value>
+    <value>Tải lên La Hoàn Thâm Cảnh thành công, nhưng không tìm thấy người dùng, không thể nhận thời gian dịch vụ tặng kèm</value> 
   </data>
   <data name="ServerRecordUploadSuccessButNotFirstTimeAtCurrentSchedule" xml:space="preserve">
-    <value>上传深渊记录成功，但不是本期首次提交，无法获赠祈愿记录上传服务时长</value>
+    <value>Tải lên La Hoàn Thâm Cảnh thành công, nhưng không phải lần tải lên đầu tiên của kỳ này, không thể nhận thời gian dịch vụ tặng kèm</value> 
   </data>
   <data name="ServiceAchievementImportResult" xml:space="preserve">
-    <value>新增：{0} 个成就 | 更新：{1} 个成就 | 删除：{2} 个成就</value>
+    <value>Thêm mới: {0} thành tựu | Cập nhật: {1} thành tựu | Xóa: {2} thành tựu</value> 
   </data>
   <data name="ServiceAchievementUIAFImportPickerFilterText" xml:space="preserve">
-    <value>UIAF JSON 文件</value>
+    <value>Tệp JSON UIAF</value> 
   </data>
   <data name="ServiceAchievementUIAFImportPickerTitile" xml:space="preserve">
-    <value>打开 UIAF JSON 文件</value>
+    <value>Mở tệp JSON UIAF</value> 
   </data>
   <data name="ServiceAchievementUserdataCorruptedAchievementIdNotUnique" xml:space="preserve">
-    <value>单个成就存档内发现多个相同的成就 Id</value>
+    <value>Phát hiện nhiều ID thành tựu trùng lặp trong cùng một bản lưu</value> 
   </data>
   <data name="ServiceAppOptionsCalendarServerTimeZoneAmerica" xml:space="preserve">
-    <value>美服 UTC-05</value>
+    <value>Server Mỹ UTC-05</value> 
   </data>
   <data name="ServiceAppOptionsCalendarServerTimeZoneCommon" xml:space="preserve">
-    <value>其他 UTC+08</value>
+    <value>Khác UTC+08</value> 
   </data>
   <data name="ServiceAppOptionsCalendarServerTimeZoneEurope" xml:space="preserve">
-    <value>欧服 UTC+01</value>
+    <value>Server Châu Âu UTC+01</value> 
   </data>
   <data name="ServiceAvatarInfoPropertyAtk" xml:space="preserve">
-    <value>攻击力</value>
+    <value>Tấn Công</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyBaseAtk" xml:space="preserve">
-    <value>基础攻击力</value>
+    <value>Tấn Công Cơ Bản</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyBaseDef" xml:space="preserve">
-    <value>基础防御力</value>
+    <value>Phòng Ngự Cơ Bản</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyBaseHp" xml:space="preserve">
-    <value>基础生命值</value>
+    <value>Giới Hạn HP Cơ Bản</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyCDmg" xml:space="preserve">
-    <value>暴击伤害</value>
+    <value>Sát Thương Bạo Kích</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyCE" xml:space="preserve">
-    <value>元素充能效率</value>
+    <value>Hiệu Quả Nạp Nguyên Tố</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyCR" xml:space="preserve">
-    <value>暴击率</value>
+    <value>Tỷ Lệ Bạo Kích</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBElec" xml:space="preserve">
-    <value>雷元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Lôi</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBFire" xml:space="preserve">
-    <value>火元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Hỏa</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBGrass" xml:space="preserve">
-    <value>草元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Thảo</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBIce" xml:space="preserve">
-    <value>冰元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Băng</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBPhyiscal" xml:space="preserve">
-    <value>物理伤害加成</value>
+    <value>Tăng Sát Thương Vật Lý</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBRock" xml:space="preserve">
-    <value>岩元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Nham</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBWater" xml:space="preserve">
-    <value>水元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Thủy</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDBWind" xml:space="preserve">
-    <value>风元素伤害加成</value>
+    <value>Tăng Sát Thương Nguyên Tố Phong</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyDef" xml:space="preserve">
-    <value>防御力</value>
+    <value>Phòng Ngự</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyEM" xml:space="preserve">
-    <value>元素精通</value>
+    <value>Tinh Thông Nguyên Tố</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyHB" xml:space="preserve">
-    <value>治疗加成</value>
+    <value>Tăng Trị Liệu</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyHDB" xml:space="preserve">
-    <value>受治疗加成</value>
+    <value>Tăng Nhận Trị Liệu</value> 
   </data>
   <data name="ServiceAvatarInfoPropertyHp" xml:space="preserve">
-    <value>生命值</value>
+    <value>Giới Hạn HP</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESElec" xml:space="preserve">
-    <value>雷元素抗性</value>
+    <value>Kháng Nguyên Tố Lôi</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESFire" xml:space="preserve">
-    <value>火元素抗性</value>
+    <value>Kháng Nguyên Tố Hỏa</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESGrass" xml:space="preserve">
-    <value>草元素抗性</value>
+    <value>Kháng Nguyên Tố Thảo</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESIce" xml:space="preserve">
-    <value>冰元素抗性</value>
+    <value>Kháng Nguyên Tố Băng</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESPhysical" xml:space="preserve">
-    <value>物理抗性</value>
+    <value>Kháng Vật Lý</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESRock" xml:space="preserve">
-    <value>岩元素抗性</value>
+    <value>Kháng Nguyên Tố Nham</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESWater" xml:space="preserve">
-    <value>水元素抗性</value>
+    <value>Kháng Nguyên Tố Thủy</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertyRESWind" xml:space="preserve">
-    <value>风元素抗性</value>
+    <value>Kháng Nguyên Tố Phong</value>
     <comment>Need EXACT same string in game</comment>
   </data>
   <data name="ServiceAvatarInfoPropertySkillCDReduce" xml:space="preserve">
-    <value>冷却缩减</value>
+    <value>Giảm Thời Gian CD</value> 
   </data>
   <data name="ServiceBackgroundActivityDefaultDescription" xml:space="preserve">
-    <value>准备中...</value>
+    <value>Đang chuẩn bị...</value> 
   </data>
   <data name="ServiceBackgroundActivityFullTrustInitialization" xml:space="preserve">
-    <value>插件组件初始化</value>
+    <value>Khởi tạo thành phần plugin</value> 
   </data>
   <data name="ServiceBackgroundActivityFullTrustInitializationDescription" xml:space="preserve">
-    <value>仅在必要时执行</value>
+    <value>Chỉ thực thi khi cần thiết</value> 
   </data>
   <data name="ServiceBackgroundActivityMetadataInitialization" xml:space="preserve">
-    <value>游戏元数据</value>
+    <value>Metadata game</value> 
   </data>
   <data name="ServiceBackgroundActivityMetadataInitializationDescription" xml:space="preserve">
-    <value>加载中</value>
+    <value>Đang tải</value> 
   </data>
   <data name="ServiceBackgroundImageTypeLauncher" xml:space="preserve">
-    <value>官方启动器壁纸</value>
+    <value>Hình nền Launcher chính thức</value> 
   </data>
-<data name="ServiceBackgroundImageTypeCustom" xml:space="preserve">
-    <value>自定义图片或视频</value>
+  <data name="ServiceBackgroundImageTypeCustom" xml:space="preserve">
+    <value>Hình ảnh hoặc video tùy chỉnh</value> 
   </data>
   <data name="ServiceBackgroundImageTypeNone" xml:space="preserve">
-    <value>无背景图片</value>
+    <value>Không có hình nền</value> 
   </data>
   <data name="ServiceCloseButtonBehaviorTypeExit" xml:space="preserve">
-    <value>退出</value>
+    <value>Thoát</value> 
   </data>
   <data name="ServiceCloseButtonBehaviorTypeMinimize" xml:space="preserve">
-    <value>最小化到通知区域图标</value>
+    <value>Thu nhỏ xuống khay hệ thống</value> 
   </data>
   <data name="ServiceDailyNoteNotificationSendExceptionTitle" xml:space="preserve">
-    <value>应用通知发送失败</value>
+    <value>Gửi thông báo ứng dụng thất bại</value> 
   </data>
   <data name="ServiceDailyNoteNotifierActionLaunchGameButton" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value> 
   </data>
   <data name="ServiceDailyNoteNotifierActionLaunchGameDismiss" xml:space="preserve">
-    <value>我知道了</value>
+    <value>Đã hiểu</value> 
   </data>
   <data name="ServiceDailyNoteNotifierDailyTask" xml:space="preserve">
-    <value>每日委托</value>
+    <value>Nhiệm Vụ Hằng Ngày</value> 
   </data>
   <data name="ServiceDailyNoteNotifierDailyTaskHint" xml:space="preserve">
-    <value>奖励未领取</value>
+    <value>Phần thưởng chưa nhận</value> 
   </data>
   <data name="ServiceDailyNoteNotifierExpedition" xml:space="preserve">
-    <value>探索派遣</value>
+    <value>Phái Đi Thám Hiểm</value> 
   </data>
   <data name="ServiceDailyNoteNotifierExpeditionAdaptiveHint" xml:space="preserve">
-    <value>已完成</value>
+    <value>Đã hoàn thành</value> 
   </data>
   <data name="ServiceDailyNoteNotifierExpeditionHint" xml:space="preserve">
-    <value>探索派遣已完成</value>
+    <value>Phái Đi Thám Hiểm đã hoàn thành</value> 
   </data>
   <data name="ServiceDailyNoteNotifierHomeCoin" xml:space="preserve">
-    <value>洞天宝钱</value>
+    <value>Tiền Động Tiên</value> 
   </data>
   <data name="ServiceDailyNoteNotifierHomeCoinCurrent" xml:space="preserve">
-    <value>当前洞天宝钱：{0}</value>
+    <value>Tiền Động Tiên hiện tại: {0}</value> 
   </data>
   <data name="ServiceDailyNoteNotifierMultiValueReached" xml:space="preserve">
-    <value>多个提醒项达到设定值</value>
+    <value>Nhiều mục nhắc nhở đạt giá trị thiết lập</value> 
   </data>
   <data name="ServiceDailyNoteNotifierResin" xml:space="preserve">
-    <value>原粹树脂</value>
+    <value>Nhựa Nguyên Chất</value> 
   </data>
   <data name="ServiceDailyNoteNotifierResinCurrent" xml:space="preserve">
-    <value>当前原粹树脂：{0}</value>
+    <value>Nhựa Nguyên Chất hiện tại: {0}</value> 
   </data>
   <data name="ServiceDailyNoteNotifierTitle" xml:space="preserve">
-    <value>实时便笺提醒</value>
+    <value>Nhắc nhở Ghi chú thời gian thực</value> 
   </data>
   <data name="ServiceDailyNoteNotifierTransformer" xml:space="preserve">
-    <value>参量质变仪</value>
+    <value>Máy Biến Đổi Tham Số</value> 
   </data>
   <data name="ServiceDailyNoteNotifierTransformerAdaptiveHint" xml:space="preserve">
-    <value>准备完成</value>
+    <value>Chuẩn bị hoàn tất</value> 
   </data>
   <data name="ServiceDailyNoteNotifierTransformerHint" xml:space="preserve">
-    <value>参量质变仪已准备完成</value>
+    <value>Máy Biến Đổi Tham Số đã sẵn sàng</value> 
   </data>
   <data name="ServiceDailyNoteNotifierWeekActiveProgress" xml:space="preserve">
-    <value>砺行修远</value>
+    <value>Rèn Luyện Tiến Bước</value> 
   </data>
   <data name="ServiceDailyNoteNotifierWeekActiveProgressHint" xml:space="preserve">
-    <value>本周砺行修远已完成</value>
+    <value>Rèn Luyện Tiến Bước tuần này đã hoàn thành</value> 
   </data>
   <data name="ServiceGachaLogFactoryAvatarWishName" xml:space="preserve">
-    <value>角色活动</value>
+    <value>Sự kiện nhân vật</value> 
   </data>
   <data name="ServiceGachaLogFactoryChronicledWishName" xml:space="preserve">
-    <value>集录祈愿</value>
+    <value>Cầu Nguyện Tân Thủ</value> 
   </data>
   <data name="ServiceGachaLogFactoryPermanentWishName" xml:space="preserve">
-    <value>奔行世间</value>
+    <value>Du Hành Thế Gian</value> 
   </data>
   <data name="ServiceGachaLogFactoryWeaponWishName" xml:space="preserve">
-    <value>神铸赋形</value>
+    <value>Thân Hình Thần Đúc</value> 
   </data>
   <data name="ServiceGachaLogLauncherCloudEndIdFetchFailed" xml:space="preserve">
-    <value>获取云端祈愿记录失败</value>
+    <value>Lấy lịch sử Cầu Nguyện từ Cloud thất bại</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderAuthkeyRequestFailed" xml:space="preserve">
-    <value>请求验证密钥失败</value>
+    <value>Yêu cầu khóa xác thực (authkey) thất bại</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderCachePathInvalid" xml:space="preserve">
-    <value>未正确提供原神路径，或当前设置的路径不正确</value>
+    <value>Đường dẫn Genshin Impact không được cung cấp đúng cách, hoặc đường dẫn thiết lập hiện tại không chính xác</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderCachePathNotFound" xml:space="preserve">
-    <value>找不到原神内置浏览器缓存路径：
-{0}</value>
+    <value>Không tìm thấy đường dẫn cache trình duyệt tích hợp của Genshin Impact:{0}
+    </value> 
   </data>
   <data name="ServiceGachaLogUrlProviderCacheUrlNotFound" xml:space="preserve">
-    <value>未找到可用的 URL</value>
+    <value>Không tìm thấy URL khả dụng</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderLogFileUrlNotFound" xml:space="preserve">
-    <value>无法从游戏日志中自动获取祈愿链接，请确保已在游戏内打开过祈愿历史记录</value>
+    <value>Không thể tự động lấy liên kết Cầu Nguyện từ nhật ký game. Hãy đảm bảo bạn đã mở lịch sử Cầu Nguyện trong game</value> 
   </data>
-<data name="ServiceGachaLogUrlProviderLogFileUrlCopied" xml:space="preserve">
-    <value>祈愿链接已复制到剪贴板（{0}）</value>
+  <data name="ServiceGachaLogUrlProviderLogFileUrlCopied" xml:space="preserve">
+    <value>Liên kết Cầu Nguyện đã được sao chép vào bộ nhớ tạm ({0})</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderLogFileServerCN" xml:space="preserve">
-    <value>国服</value>
+    <value>Server CN</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderLogFileServerOversea" xml:space="preserve">
-    <value>国际服</value>
+    <value>Server Quốc Tế</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderCopyWebCacheUnauthorizedAccess" xml:space="preserve">
-    <value>复制网页缓存到临时文件夹时发生问题，权限不足</value>
+    <value>Xảy ra lỗi khi sao chép cache trang web vào thư mục tạm thời do không đủ quyền</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderManualInputInvalid" xml:space="preserve">
-    <value>提供的 URL 无效</value>
+    <value>URL cung cấp không hợp lệ</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderStokenUnsupported" xml:space="preserve">
-    <value>HoYoLab 账号不支持使用 SToken 刷新祈愿记录</value>
+    <value>Tài khoản HoYoLAB không hỗ trợ sử dụng SToken để làm mới lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ServiceGachaLogUrlProviderUrlLanguageNotMatchCurrentLocale" xml:space="preserve">
-    <value>URL 中的语言：{0} 与的语言：{1} 不匹配，请切换到对应语言重试</value>
+    <value>Ngôn ngữ trong URL: {0} không khớp với ngôn ngữ ứng dụng: {1}, vui lòng chuyển đổi ngôn ngữ tương ứng rồi thử lại</value> 
   </data>
   <data name="ServiceGachaStatisticsFactoryItemIdInvalid" xml:space="preserve">
-    <value>不支持的 Item Id：{0}</value>
+    <value>Item Id không được hỗ trợ: {0}</value> 
   </data>
   <data name="ServiceGameAccountBilibiliNotSupported" xml:space="preserve">
-    <value>Bilibili 渠道服不支持账号功能</value>
+    <value>Server Kênh Bilibili không hỗ trợ chức năng tài khoản</value> 
   </data>
   <data name="ServiceGameAccountDetectInputNameAlreadyExists" xml:space="preserve">
-    <value>名称为 {0} 的账号已存在</value>
+    <value>Tài khoản có tên {0} đã tồn tại</value> 
   </data>
   <data name="ServiceGameAccountRegistryMultipleAccountDetected" xml:space="preserve">
-    <value>检测到多个账号的登录信息，请在游戏登录界面删除多余的账号并进入游戏后重试</value>
+    <value>Phát hiện thông tin đăng nhập của nhiều tài khoản, vui lòng xóa các tài khoản thừa tại giao diện đăng nhập game và vào game rồi thử lại</value> 
   </data>
   <data name="ServiceGameAccountRegistryNoAccountDetected" xml:space="preserve">
-    <value>未检测到登录信息，请进入游戏后重试</value>
+    <value>Không phát hiện thông tin đăng nhập, vui lòng vào game rồi thử lại</value> 
   </data>
   <data name="ServiceGameAccountRegistryTryGetFailed" xml:space="preserve">
-    <value>此设备的 MAC 地址发生变化，请重新登录游戏后再尝试</value>
+    <value>Địa chỉ MAC của thiết bị này đã thay đổi, vui lòng đăng nhập lại game rồi thử lại</value> 
   </data>
   <data name="ServiceGameDetectGameAccountMultiMatched" xml:space="preserve">
-    <value>存在多个匹配账号，请删除重复的账号</value>
+    <value>Có nhiều tài khoản khớp, vui lòng xóa tài khoản trùng lặp</value> 
   </data>
   <data name="ServiceGameEnsureGameResourceInsufficientDirectoryPermissions" xml:space="preserve">
-    <value>文件系统权限不足，无法转换服务器</value>
+    <value>Quyền hệ thống tệp không đủ, không thể chuyển đổi máy chủ</value> 
   </data>
   <data name="ServiceGameEnsureGameResourceQueryResourceInformation" xml:space="preserve">
-    <value>下载游戏资源索引</value>
+    <value>Tải xuống chỉ mục tài nguyên game</value> 
   </data>
   <data name="ServiceGameIslandFileSystemGetGameVersionFailed" xml:space="preserve">
-    <value>获取本地游戏版本失败，无法获取插件配置信息</value>
+    <value>Lấy phiên bản game cục bộ thất bại, không thể lấy thông tin cấu hình plugin</value> 
   </data>
   <data name="ServiceGameIslandTargetVersionFileNotExists" xml:space="preserve">
-    <value>尚未支持当前游戏版本</value>
+    <value>Phiên bản game hiện tại chưa được hỗ trợ</value> 
   </data>
   <data name="ServiceGameLaunchExecutionCurrentSchemeNull" xml:space="preserve">
-    <value>本地游戏配置文件损坏，请修复后重试</value>
+    <value>Tệp cấu hình game cục bộ bị hỏng, vui lòng sửa chữa rồi thử lại</value> 
   </data>
   <data name="ServiceGameLaunchExecutionGameIsRunning" xml:space="preserve">
-    <value>游戏进程运行中</value>
+    <value>Tiến trình game đang chạy</value> 
   </data>
   <data name="ServiceGameLaunchExecutionGameResourceQueryIndexFailed" xml:space="preserve">
-    <value>下载游戏资源索引失败: {0}</value>
+    <value>Tải xuống chỉ mục tài nguyên game thất bại: {0}</value> 
   </data>
   <data name="ServiceGameLaunchExecutionGameRunningKillFailed" xml:space="preserve">
-    <value>结束进程失败</value>
+    <value>Kết thúc tiến trình thất bại</value> 
   </data>
   <data name="ServiceGameLaunchPhaseProcessExited" xml:space="preserve">
-    <value>游戏进程已退出</value>
+    <value>Tiến trình game đã thoát</value> 
   </data>
   <data name="ServiceGameLaunchPhaseProcessStarted" xml:space="preserve">
-    <value>游戏进程已启动</value>
+    <value>Tiến trình game đã khởi động</value> 
   </data>
   <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
-    <value>等待游戏进程退出</value>
+    <value>Đang chờ tiến trình game thoát</value> 
   </data>
   <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
-    <value>目标服务器与当前游戏资源匹配，无需转换</value>
+    <value>Máy chủ mục tiêu khớp với tài nguyên game hiện tại, không cần chuyển đổi</value> 
   </data>
   <data name="ServiceGameLaunchingHandlerEmbeddedYaeClientNotElevated" xml:space="preserve">
-    <value>使用 Embedded Yae 前，需要以管理员权限运行</value>
+    <value>Cần chạy với quyền quản trị viên trước khi sử dụng Embedded Yae</value> 
   </data>
   <data name="ServiceGameLaunchingHandlerEmbeddedYaeErrorSystemIntegrityPolicyViolation" xml:space="preserve">
-    <value>插件加载失败，可能是由于 Windows Defender 应用和浏览器控制 &gt; 智能应用控制策略阻止了操作，请尝试关闭。</value>
+    <value>Tải plugin thất bại, có thể do chính sách kiểm soát ứng dụng và trình duyệt của Windows Defender &gt; tính năng Smart App Control đã chặn thao tác, vui lòng thử tắt nó.</value> 
   </data>
   <data name="ServiceGameLaunchingHandlerEmbeddedYaeIslandNotEnabled" xml:space="preserve">
-    <value>使用 Embedded Yae 前，需要您了解相关风险并在「启动游戏」页面开启插件功能</value>
+    <value>Trước khi sử dụng Embedded Yae, bạn cần hiểu rõ các rủi ro liên quan và bật chức năng plugin trên trang "Khởi động game"</value> 
   </data>
   <data name="ServiceGameLaunchingHandlerGameProcessStartRepositorySyncFailed" xml:space="preserve">
-    <value>在获取必要的启动游戏组件时发生错误</value>
+    <value>Đã xảy ra lỗi khi lấy các thành phần khởi động game cần thiết</value> 
   </data>
   <data name="ServiceGameLocatorFileOpenPickerCommitText" xml:space="preserve">
-    <value>选择游戏本体</value>
+    <value>Chọn bản cài game</value> 
   </data>
   <data name="ServiceGameLocatorPickerFilterText" xml:space="preserve">
-    <value>游戏本体</value>
+    <value>Bản cài game</value> 
   </data>
   <data name="ServiceGameLocatorUnityLogCannotOpenRead" xml:space="preserve">
-    <value>游戏运行中，无法读取 Unity 日志文件</value>
+    <value>Game đang chạy, không thể đọc tệp nhật ký Unity</value> 
   </data>
   <data name="ServiceGameLocatorUnityLogFileNotFound" xml:space="preserve">
-    <value>找不到 Unity 日志文件</value>
+    <value>Không tìm thấy tệp nhật ký Unity</value> 
   </data>
   <data name="ServiceGameLocatorUnityLogGamePathNotFound" xml:space="preserve">
-    <value>在 Unity 日志文件中找不到游戏路径</value>
+    <value>Không tìm thấy đường dẫn game trong tệp nhật ký Unity</value> 
   </data>
   <data name="ServiceGamePackageAdvancedAssetOperationDiskCorrupted" xml:space="preserve">
-    <value>检测到硬盘错误，请运行 chkdsk 修复</value>
+    <value>Phát hiện lỗi ổ cứng, vui lòng chạy chkdsk để sửa lỗi</value> 
   </data>
   <data name="ServiceGamePackageAdvancedAssetOperationNoSuchDevice" xml:space="preserve">
-    <value>检测到硬盘丢失，请检查硬件连接情况</value>
+    <value>Phát hiện mất kết nối ổ cứng, vui lòng kiểm tra kết nối phần cứng</value> 
   </data>
   <data name="ServiceGamePackageAdvancedConfirmMessage" xml:space="preserve">
-    <value>资源包体大小: {0}
-所需空间: {1}
-可用空间: {2}</value>
+    <value>Kích thước gói tài nguyên: {0}
+    Không gian cần thiết: {1}
+    Không gian trống: {2}</value> 
   </data>
   <data name="ServiceGamePackageAdvancedConfirmStartInstallTitle" xml:space="preserve">
-    <value>确认开始安装游戏</value>
+    <value>Xác nhận bắt đầu cài đặt game</value> 
   </data>
   <data name="ServiceGamePackageAdvancedConfirmStartPredownloadTitle" xml:space="preserve">
-    <value>确认开始预下载</value>
+    <value>Xác nhận bắt đầu tải trước</value> 
   </data>
   <data name="ServiceGamePackageAdvancedConfirmStartUpdateTitle" xml:space="preserve">
-    <value>确认开始更新游戏</value>
+    <value>Xác nhận bắt đầu cập nhật game</value> 
   </data>
   <data name="ServiceGamePackageAdvancedDecodeManifestFailed" xml:space="preserve">
-    <value>清单数据解析失败</value>
+    <value>Phân tích dữ liệu Manifest thất bại</value> 
   </data>
   <data name="ServiceGamePackageAdvancedDriverNoAvailableFreeSpace" xml:space="preserve">
-    <value>磁盘空间不足</value>
+    <value>Không gian ổ đĩa không đủ</value> 
   </data>
   <data name="ServiceGamePackageAdvancedInstalling" xml:space="preserve">
-    <value>正在安装游戏</value>
+    <value>Đang cài đặt game</value> 
   </data>
   <data name="ServiceGamePackageAdvancedPredownloading" xml:space="preserve">
-    <value>正在预下载资源</value>
+    <value>Đang tải trước tài nguyên</value> 
   </data>
   <data name="ServiceGamePackageAdvancedRepairing" xml:space="preserve">
-    <value>正在修复游戏</value>
+    <value>Đang sửa chữa game</value> 
   </data>
   <data name="ServiceGamePackageAdvancedUpdating" xml:space="preserve">
-    <value>正在更新游戏</value>
+    <value>Đang cập nhật game</value> 
   </data>
   <data name="ServiceGamePackageAdvancedVerifyingIntegrity" xml:space="preserve">
-    <value>正在验证游戏完整性</value>
+    <value>Đang xác minh tính toàn vẹn của game</value> 
   </data>
   <data name="ServiceGamePackageConvertMoveFileBackup" xml:space="preserve">
-    <value>备份：{0}</value>
+    <value>Sao lưu: {0}</value> 
   </data>
   <data name="ServiceGamePackageConvertMoveFileRename" xml:space="preserve">
-    <value>重命名：{0} 到：{1}</value>
+    <value>Đổi tên: {0} thành: {1}</value> 
   </data>
   <data name="ServiceGamePackageConvertMoveFileRestore" xml:space="preserve">
-    <value>替换：{0}</value>
+    <value>Thay thế: {0}</value> 
   </data>
   <data name="ServiceGamePackageRenameDataFolderFailed" xml:space="preserve">
-    <value>重命名数据文件夹名称失败</value>
+    <value>Đổi tên thư mục dữ liệu thất bại</value> 
   </data>
   <data name="ServiceGamePathLocateFailed" xml:space="preserve">
-    <value>无法找到游戏路径，请前往设置修改</value>
+    <value>Không thể tìm thấy đường dẫn game, vui lòng vào cài đặt để sửa đổi</value> 
   </data>
   <data name="ServiceGameSetMultiChannelConfigFileNotFound" xml:space="preserve">
-    <value>无法读取游戏配置文件 {0}，可能是文件不存在</value>
+    <value>Không thể đọc tệp cấu hình game {0}, có thể tệp không tồn tại</value> 
   </data>
   <data name="ServiceGameSetMultiChannelUnauthorizedAccess" xml:space="preserve">
-    <value>无法读取或保存配置文件，请以管理员模式重试</value>
+    <value>Không thể đọc hoặc lưu tệp cấu hình, vui lòng thử lại bằng chế độ quản trị viên</value> 
   </data>
   <data name="ServiceGitRepositoryOperationCompleted" xml:space="preserve">
-    <value>操作完成</value>
+    <value>Thao tác hoàn tất</value> 
   </data>
   <data name="ServiceGitRepositoryOperationFailed" xml:space="preserve">
-    <value>操作失败</value>
+    <value>Thao tác thất bại</value> 
   </data>
   <data name="ServiceLauncherUserGachaLogExpiredAt" xml:space="preserve">
-    <value>祈愿记录上传服务有效期至</value>
+    <value>Dịch vụ tải lên lịch sử Cầu Nguyện có hiệu lực đến</value> 
   </data>
   <data name="ServiceInventoryRefreshByEmbeddedYaeErrorMessage" xml:space="preserve">
-    <value>请使用其他方法同步背包物品</value>
+    <value>Vui lòng sử dụng các phương pháp khác để đồng bộ vật phẩm trong ba lô</value> 
   </data>
   <data name="ServiceMetadataDownloadSourceFilesFailed" xml:space="preserve">
-    <value>一个或多个元数据文件下载失败：{0}</value>
+    <value>Một hoặc nhiều tệp siêu dữ liệu (metadata) tải xuống thất bại: {0}</value> 
   </data>
   <data name="ServiceMetadataFileNotFound" xml:space="preserve">
-    <value>无法找到缓存的元数据文件</value>
+    <value>Không thể tìm thấy tệp siêu dữ liệu (metadata) được cache</value> 
   </data>
   <data name="ServiceMetadataNotInitialized" xml:space="preserve">
-    <value>元数据服务尚未初始化，或初始化失败</value>
+    <value>Dịch vụ siêu dữ liệu (metadata) chưa được khởi tạo hoặc khởi tạo thất bại</value> 
   </data>
   <data name="ServiceMetadataParseFailed" xml:space="preserve">
-    <value>元数据校验文件解析失败</value>
+    <value>Phân tích tệp xác minh siêu dữ liệu thất bại</value> 
   </data>
   <data name="ServiceMetadataVersionNotSupported" xml:space="preserve">
-    <value>你的版本过低，请尽快升级</value>
+    <value>Phiên bản của bạn quá cũ, vui lòng cập nhật sớm nhất có thể</value> 
   </data>
   <data name="ServicePackageAdvancedExecuteOperationCanceledTitle" xml:space="preserve">
-    <value>游戏资源操作已取消</value>
+    <value>Thao tác tài nguyên game đã bị hủy</value> 
   </data>
   <data name="ServicePackageAdvancedExecuteOperationFailedTitle" xml:space="preserve">
-    <value>游戏资源操作失败</value>
+    <value>Thao tác tài nguyên game thất bại</value> 
   </data>
   <data name="ServiceReSignInClaimRewardFailed" xml:space="preserve">
-    <value>补签失败，{0}</value>
+    <value>Điểm danh bù thất bại, {0}</value> 
   </data>
   <data name="ServiceReSignInSuccessReward" xml:space="preserve">
-    <value>补签成功，{0}×{1}</value>
+    <value>Điểm danh bù thành công, {0}×{1}</value> 
   </data>
   <data name="ServiceSignInClaimRewardFailed" xml:space="preserve">
-    <value>签到失败，{0}</value>
+    <value>Điểm danh thất bại, {0}</value> 
   </data>
   <data name="ServiceSignInInfoRequestFailed" xml:space="preserve">
-    <value>获取签到次数失败</value>
+    <value>Lấy số lần điểm danh thất bại</value> 
   </data>
   <data name="ServiceSignInRewardListRequestFailed" xml:space="preserve">
-    <value>获取奖励列表失败</value>
+    <value>Lấy danh sách phần thưởng thất bại</value> 
   </data>
   <data name="ServiceSignInRiskVerificationFailed" xml:space="preserve">
-    <value>验证失败，请前往米游社原神签到页面自行领取奖励</value>
+    <value>Xác minh thất bại, vui lòng đến trang điểm danh Genshin Impact của HoyoLAB để tự nhận phần thưởng</value> 
   </data>
   <data name="ServiceSignInSuccessReward" xml:space="preserve">
-    <value>签到成功，{0}×{1}</value>
+    <value>Điểm danh thành công, {0}×{1}</value> 
   </data>
   <data name="ServiceUIGFImportInvalidItem" xml:space="preserve">
-    <value>不支持的物品, Id: {0}</value>
+    <value>Vật phẩm không được hỗ trợ, Id: {0}</value> 
   </data>
   <data name="ServiceUserProcessCookieNoMid" xml:space="preserve">
-    <value>输入的 Cookie 必须包含 Mid</value>
+    <value>Cookie nhập vào phải chứa Mid</value> 
   </data>
   <data name="ServiceUserProcessCookieNoSToken" xml:space="preserve">
-    <value>输入的 Cookie 必须包含 SToken</value>
+    <value>Cookie nhập vào phải chứa SToken</value> 
   </data>
   <data name="ServiceUserProcessCookieRequestUserInfoFailed" xml:space="preserve">
-    <value>输入的 Cookie 无法获取用户信息</value>
+    <value>Cookie nhập vào không thể lấy thông tin người dùng</value> 
   </data>
   <data name="ServiceUserProcessInputCookieDialogTitle" xml:space="preserve">
-    <value>获取用户信息中，请稍候...</value>
+    <value>Đang lấy thông tin người dùng, vui lòng đợi...</value> 
   </data>
   <data name="ServiceUserUserInfoContainsNoGameRole" xml:space="preserve">
-    <value>此账号尚未绑定原神游戏角色</value>
+    <value>Tài khoản này chưa liên kết với nhân vật Genshin Impact</value> 
   </data>
   <data name="ServiceYaeEmbeddedYaeErrorTitle" xml:space="preserve">
-    <value>Embedded Yae 错误</value>
+    <value>Lỗi Embedded Yae</value> 
   </data>
   <data name="ServiceYaeGetGameVersionFailed" xml:space="preserve">
-    <value>获取游戏版本失败</value>
+    <value>Lấy phiên bản game thất bại</value> 
   </data>
   <data name="ServiceYaeWaitForGameResponseMessage" xml:space="preserve">
-    <value>正在等待游戏数据</value>
+    <value>Đang đợi dữ liệu game</value> 
   </data>
   <data name="ServiceThirdPartyToolNoExecutableFound" xml:space="preserve">
-    <value>未找到可执行文件</value>
+    <value>Không tìm thấy tệp thực thi</value> 
   </data>
   <data name="ServiceThirdPartyToolFileNotFound" xml:space="preserve">
-    <value>文件不存在：{0}</value>
+    <value>Tệp không tồn tại: {0}</value> 
   </data>
   <data name="UIViewMainTitleBarRestartToUpdateAction" xml:space="preserve">
-    <value>重启以更新</value>
+    <value>Khởi động lại để cập nhật</value> 
   </data>
   <data name="UIViewMainTitleBarBackgroundActivityAction" xml:space="preserve">
-    <value>后台任务</value>
+    <value>Nhiệm vụ nền</value> 
   </data>
   <data name="UIViewMainTitleBarRedeemCodeAction" xml:space="preserve">
-    <value>奖励兑换码</value>
+    <value>Mã Đổi Thưởng</value> 
   </data>
   <data name="UIViewMainRedeemCodeCNHeader" xml:space="preserve">
-    <value>CN:</value>
+    <value>CN:</value> 
   </data>
   <data name="UIViewMainRedeemCodeOSHeader" xml:space="preserve">
-    <value>OS:</value>
+    <value>OS:</value> 
   </data>
   <data name="UIViewMainRedeemCodeCopy" xml:space="preserve">
-    <value>复制</value>
+    <value>Sao chép</value> 
   </data>
   <data name="UIViewMainRedeemCodeValidUntil" xml:space="preserve">
-    <value>有效期至 {0}</value>
+    <value>Có hiệu lực đến {0}</value> 
   </data>
   <data name="UIViewMainRedeemCodeCopySucceed" xml:space="preserve">
-    <value>已复制兑换码: {0}</value>
+    <value>Đã sao chép mã đổi thưởng: {0}</value> 
   </data>
   <data name="UIViewPageAvatarPropertyRecommendedAppendProperties" xml:space="preserve">
-    <value>追加属性推荐</value>
+    <value>Thuộc Tính Bổ Sung Đề Xuất</value> 
   </data>
   <data name="UIViewPageAvatarPropertyRecommendedCircletProperties" xml:space="preserve">
-    <value>理之冠主属性推荐</value>
+    <value>Thuộc Tính Chính Đề Xuất Nón Lý Trí</value> 
   </data>
   <data name="UIViewPageAvatarPropertyRecommendedGobletProperties" xml:space="preserve">
-    <value>空之杯主属性推荐</value>
+    <value>Thuộc Tính Chính Đề Xuất Ly Không Gian</value> 
   </data>
   <data name="UIViewPageAvatarPropertyRecommendedSandProperties" xml:space="preserve">
-    <value>时之沙主属性推荐</value>
+    <value>Thuộc Tính Chính Đề Xuất Đồng Hồ Cát</value> 
   </data>
   <data name="UIXamlControlCachedImageCopyImage" xml:space="preserve">
-    <value>复制图像</value>
+    <value>Sao chép hình ảnh</value> 
   </data>
   <data name="UIXamlViewSpecializedSophonProgressDefault" xml:space="preserve">
-    <value>正在获取清单数据</value>
+    <value>Đang lấy dữ liệu Manifest</value> 
   </data>
   <data name="UIXamlViewWindowWebView2GeetestHeader" xml:space="preserve">
-    <value>请完成验证</value>
+    <value>Vui lòng hoàn thành xác minh</value> 
   </data>
   <data name="ViewAchievementHeader" xml:space="preserve">
-    <value>成就管理</value>
+    <value>Quản lý Thành Tựu</value> 
   </data>
   <data name="ViewAnnouncementHeader" xml:space="preserve">
-    <value>主页</value>
+    <value>Trang chủ</value> 
   </data>
   <data name="ViewAvatarPropertyHeader" xml:space="preserve">
-    <value>我的角色</value>
+    <value>Nhân vật của tôi</value> 
   </data>
   <data name="ViewAvatarPropertySyncDataButtonLabel" xml:space="preserve">
-    <value>同步角色信息</value>
+    <value>Đồng bộ thông tin nhân vật</value> 
   </data>
   <data name="ViewCardAchievementStatisticsTitle" xml:space="preserve">
-    <value>成就统计</value>
+    <value>Thống kê Thành Tựu</value> 
   </data>
   <data name="ViewCardCalendarAllMaterialsHint" xml:space="preserve">
-    <value>全部材料副本均可挑战</value>
+    <value>Tất cả Bí Cảnh nguyên liệu đều có thể khiêu chiến</value> 
   </data>
   <data name="ViewCardCalendarNoBirthdayAvatarHint" xml:space="preserve">
-    <value>当天没有角色过生日</value>
+    <value>Hôm nay không có nhân vật nào sinh nhật</value> 
   </data>
   <data name="ViewCardGachaStatisticsTitle" xml:space="preserve">
-    <value>保底计数</value>
+    <value>Đếm số lần bảo hiểm</value> 
   </data>
   <data name="ViewCardLaunchGameSelectAccountPlaceholder" xml:space="preserve">
-    <value>选择账号或直接启动</value>
+    <value>Chọn tài khoản hoặc khởi động trực tiếp</value> 
   </data>
   <data name="ViewCardSignInClaimReSignInAction" xml:space="preserve">
-    <value>补签</value>
+    <value>Điểm danh bù</value> 
   </data>
   <data name="ViewCardSignInClaimSignInAction" xml:space="preserve">
-    <value>签到</value>
+    <value>Điểm danh</value> 
   </data>
   <data name="ViewControlBaseValueSliderLevel" xml:space="preserve">
-    <value>等级</value>
+    <value>Cấp độ</value> 
   </data>
   <data name="ViewControlBaseValueSliderPromoted" xml:space="preserve">
-    <value>突破后</value>
+    <value>Sau Đột Phá</value> 
   </data>
   <data name="ViewControlElevationText" xml:space="preserve">
-    <value>需要管理员权限</value>
+    <value>Cần quyền quản trị viên</value> 
   </data>
   <data name="ViewControlLoadingText" xml:space="preserve">
-    <value>加载中，请稍候</value>
+    <value>Đang tải, vui lòng đợi</value> 
   </data>
   <data name="ViewControlStatisticsCardBlueText" xml:space="preserve">
-    <value>三星</value>
+    <value>3 Sao</value> 
   </data>
   <data name="ViewControlStatisticsCardGuaranteeText" xml:space="preserve">
-    <value>保底</value>
+    <value>Bảo hiểm</value> 
   </data>
   <data name="ViewControlStatisticsCardOrangeAveragePullText" xml:space="preserve">
-    <value>五星平均抽数</value>
+    <value>Lần rút trung bình 5 Sao</value> 
   </data>
   <data name="ViewControlStatisticsCardOrangeText" xml:space="preserve">
-    <value>五星</value>
+    <value>5 Sao</value> 
   </data>
   <data name="ViewControlStatisticsCardPullText" xml:space="preserve">
-    <value>抽</value>
+    <value>Lần rút</value> 
   </data>
   <data name="ViewControlStatisticsCardPurpleText" xml:space="preserve">
-    <value>四星</value>
+    <value>4 Sao</value> 
   </data>
   <data name="ViewControlStatisticsCardToLastOrangeText" xml:space="preserve">
-    <value>距上个五星</value>
+    <value>Cách 5 Sao trước</value> 
   </data>
   <data name="ViewControlStatisticsCardToLastPurpleText" xml:space="preserve">
-    <value>距上个四星</value>
+    <value>Cách 4 Sao trước</value> 
   </data>
   <data name="ViewControlStatisticsCardUpAveragePullText" xml:space="preserve">
-    <value>UP 平均抽数</value>
+    <value>Lần rút trung bình UP</value> 
   </data>
   <data name="ViewControlStatisticsCardUpText" xml:space="preserve">
-    <value>UP</value>
+    <value>UP</value> 
   </data>
   <data name="ViewControlStatisticsCardNotUpText" xml:space="preserve">
-    <value>歪</value>
+    <value>Lệch</value> 
   </data>
   <data name="ViewControlStatisticsSegmentedItemContentPrediction" xml:space="preserve">
-    <value>预测</value>
+    <value>Dự đoán</value> 
   </data>
   <data name="ViewControlStatisticsSegmentedItemContentProportion" xml:space="preserve">
-    <value>比例</value>
+    <value>Tỷ lệ</value> 
   </data>
   <data name="ViewControlStatisticsSegmentedItemContentStatistics" xml:space="preserve">
-    <value>统计</value>
+    <value>Thống kê</value> 
   </data>
   <data name="ViewControlWebViewerCoreWebView2ProfileQueryInterfaceFailed" xml:space="preserve">
-    <value>当前 WebView2 版本不支持管理配置，继续使用可能会导致异常，请尽快升级</value>
+    <value>Phiên bản WebView2 hiện tại không hỗ trợ quản lý cấu hình, tiếp tục sử dụng có thể dẫn đến lỗi, vui lòng cập nhật sớm nhất có thể</value> 
   </data>
   <data name="ViewCultivationHeader" xml:space="preserve">
-    <value>养成计划</value>
+    <value>Kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewDailyNoteHeader" xml:space="preserve">
-    <value>实时便笺</value>
+    <value>Ghi chú thời gian thực</value> 
   </data>
   <data name="ViewDataHeader" xml:space="preserve">
-    <value>数据</value>
+    <value>Dữ liệu</value> 
   </data>
   <data name="ViewDialogAchievementArchiveCreateInputPlaceholder" xml:space="preserve">
-    <value>在此处输入</value>
+    <value>Nhập vào đây</value> 
   </data>
   <data name="ViewDialogAchievementArchiveCreateTitle" xml:space="preserve">
-    <value>设置成就存档的名称</value>
+    <value>Đặt tên cho bản lưu Thành Tựu</value> 
   </data>
   <data name="ViewDialogAchievementArchiveImportStrategy" xml:space="preserve">
-    <value>导入模式</value>
+    <value>Chế độ nhập</value> 
   </data>
   <data name="ViewDialogAchievementArchiveImportStrategyAggressive" xml:space="preserve">
-    <value>添加新数据，更新已完成项</value>
+    <value>Thêm dữ liệu mới, cập nhật mục đã hoàn thành</value> 
   </data>
   <data name="ViewDialogAchievementArchiveImportStrategyLazy" xml:space="preserve">
-    <value>添加新数据，跳过已完成项</value>
+    <value>Thêm dữ liệu mới, bỏ qua mục đã hoàn thành</value> 
   </data>
   <data name="ViewDialogAchievementArchiveImportStrategyOverwrite" xml:space="preserve">
-    <value>删除老数据，添加新的数据</value>
+    <value>Xóa dữ liệu cũ, thêm dữ liệu mới</value> 
   </data>
   <data name="ViewDialogAchievementArchiveImportTitle" xml:space="preserve">
-    <value>为当前存档导入成就</value>
+    <value>Nhập thành tựu vào bản lưu hiện tại</value> 
   </data>
   <data name="ViewDialogAvatarPropertyMultiAvatarCultivateSelectTitle" xml:space="preserve">
-    <value>选择要添加到当前培养计划的角色</value>
+    <value>Chọn nhân vật để thêm vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewDialogCultivateWeaponSelectTitle" xml:space="preserve">
-    <value>选择要添加到当前培养计划的武器</value>
+    <value>Chọn vũ khí để thêm vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewDialogCultivateWeaponLevelTitle" xml:space="preserve">
-    <value>设置武器等级</value>
+    <value>Cấp vũ khí</value> 
   </data>
   <data name="ViewDialogCultivateBatchAvatarLevelTarget" xml:space="preserve">
-    <value>角色目标等级</value>
+    <value>Cấp nhân vật</value> 
   </data>
   <data name="ViewDialogCultivateBatchSkillATarget" xml:space="preserve">
-    <value>普通攻击目标等级</value>
+    <value>Cấp Tấn Công Thường</value> 
   </data>
   <data name="ViewDialogCultivateBatchSkillETarget" xml:space="preserve">
-    <value>元素战技目标等级</value>
+    <value>Cấp Kỹ Năng Nguyên Tố</value> 
   </data>
   <data name="ViewDialogCultivateBatchSkillQTarget" xml:space="preserve">
-    <value>元素爆发目标等级</value>
+    <value>Cấp Kỹ Năng Nộ</value> 
   </data>
   <data name="ViewDialogCultivateBatchWeaponLevelTarget" xml:space="preserve">
-    <value>武器目标等级</value>
+    <value>Cấp vũ khí</value> 
   </data>
   <data name="ViewDialogCultivateProjectInputPlaceholder" xml:space="preserve">
-    <value>在此处输入计划名称</value>
+    <value>Nhập tên kế hoạch vào đây</value> 
   </data>
   <data name="ViewDialogCultivateLevelTitle" xml:space="preserve">
-    <value>添加或更新到当前养成计划</value>
+    <value>Thêm hoặc cập nhật vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewDialogCultivateLevelAvatarLevel" xml:space="preserve">
-    <value>角色等级</value>
+    <value>Cấp độ nhân vật</value> 
   </data>
   <data name="ViewDialogCultivateLevelFrom" xml:space="preserve">
-    <value>当前</value>
+    <value>Hiện tại</value> 
   </data>
   <data name="ViewDialogCultivateLevelTo" xml:space="preserve">
-    <value>目标</value>
+    <value>Mục tiêu</value> 
   </data>
   <data name="ViewDialogCultivateLevelSkillA" xml:space="preserve">
-    <value>普通攻击</value>
+    <value>Tấn Công Thường</value> 
   </data>
   <data name="ViewDialogCultivateLevelSkillE" xml:space="preserve">
-    <value>元素战技</value>
+    <value>Kỹ Năng Nguyên Tố</value> 
   </data>
   <data name="ViewDialogCultivateLevelSkillQ" xml:space="preserve">
-    <value>元素爆发</value>
+    <value>Kỹ Năng Nộ</value> 
   </data>
   <data name="ViewDialogCultivateProjectTitle" xml:space="preserve">
-    <value>创建新的养成计划</value>
+    <value>Tạo kế hoạch bồi dưỡng mới</value> 
   </data>
   <data name="ViewDialogCultivatePromotionDeltaBatchTitle" xml:space="preserve">
-    <value>批量添加或更新到当前养成计划</value>
+    <value>Thêm hàng loạt hoặc cập nhật vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewDialogCultivatePromotionDeltaPromoted" xml:space="preserve">
-    <value>已突破</value>
+    <value>Đã Đột Phá</value> 
   </data>
   <data name="ViewDialogCultivatePromotionDeltaTitle" xml:space="preserve">
-    <value>添加或更新到当前养成计划</value>
+    <value>Thêm hoặc cập nhật vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewDialogCultivationConsumptionSaveStrategyCreateNewEntry" xml:space="preserve">
-    <value>总是创建新的养成目标物品</value>
+    <value>Luôn tạo vật phẩm mục tiêu bồi dưỡng mới</value> 
   </data>
   <data name="ViewDialogCultivationConsumptionSaveStrategyHeader" xml:space="preserve">
-    <value>保存方式</value>
+    <value>Cách lưu</value> 
   </data>
   <data name="ViewDialogCultivationConsumptionSaveStrategyOverwriteExisting" xml:space="preserve">
-    <value>覆盖存在的养成目标物品</value>
+    <value>Ghi đè vật phẩm mục tiêu bồi dưỡng hiện có</value> 
   </data>
   <data name="ViewDialogCultivationConsumptionSaveStrategyPreserveExisting" xml:space="preserve">
-    <value>保留存在的养成目标物品</value>
+    <value>Giữ lại vật phẩm mục tiêu bồi dưỡng hiện có</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationDailyTaskNotify" xml:space="preserve">
-    <value>每日委托上线提醒</value>
+    <value>Nhắc nhở Nhiệm Vụ Hằng Ngày trực tuyến</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationExpeditionNotify" xml:space="preserve">
-    <value>探索派遣完成提醒</value>
+    <value>Nhắc nhở hoàn thành Phái Đi Thám Hiểm</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationHomeCoinNotifyThreshold" xml:space="preserve">
-    <value>洞天宝钱提醒阈值</value>
+    <value>Ngưỡng nhắc nhở Tiền Động Tiên</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationResinNotifyThreshold" xml:space="preserve">
-    <value>原粹树脂提醒阈值</value>
+    <value>Ngưỡng nhắc nhở Nhựa Nguyên Chất</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationTitle" xml:space="preserve">
-    <value>实时便笺通知设置</value>
+    <value>Cài đặt thông báo Ghi chú thời gian thực</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationTransformerNotify" xml:space="preserve">
-    <value>参量质变仪提醒</value>
+    <value>Nhắc nhở Máy Biến Đổi Tham Số</value> 
   </data>
   <data name="ViewDialogDailyNoteNotificationWeekActiveProgressNotify" xml:space="preserve">
-    <value>砺行修远完成提醒</value>
+    <value>Nhắc nhở hoàn thành Đi Khắp Non Sông</value> 
   </data>
   <data name="ViewDialogDailyNoteWebhookUrlInputPlaceholder" xml:space="preserve">
-    <value>请输入 URL</value>
+    <value>Vui lòng nhập URL</value> 
   </data>
   <data name="ViewDialogDailyNoteWebhookUrlTitle" xml:space="preserve">
-    <value>实时便笺 Webhook URL</value>
+    <value>Webhook URL Ghi chú thời gian thực</value> 
   </data>
   <data name="ViewDialogExportUIGFSubtitle" xml:space="preserve">
-    <value>选择要导出记录的 UID</value>
+    <value>Chọn UID để xuất bản ghi</value> 
   </data>
   <data name="ViewDialogExportUIGFTitle" xml:space="preserve">
-    <value>导出 UIGF 文件</value>
+    <value>Xuất tệp UIGF</value> 
   </data>
   <data name="ViewDialogFeedbackEnableLoopbackContent" xml:space="preserve">
-    <value>解除限制后需要使用其他工具恢复限制</value>
+    <value>Sau khi gỡ bỏ giới hạn, cần dùng công cụ khác để khôi phục giới hạn</value> 
   </data>
   <data name="ViewDialogFeedbackEnableLoopbackTitle" xml:space="preserve">
-    <value>是否解除 Loopback 限制</value>
+    <value>Có gỡ bỏ giới hạn Loopback không</value> 
   </data>
   <data name="ViewDialogGachaLogRefreshProgressAuthkeyTimeout" xml:space="preserve">
-    <value>祈愿记录 URL 已失效，请重新获取</value>
+    <value>URL Cầu Nguyện đã hết hiệu lực, vui lòng lấy lại</value> 
   </data>
   <data name="ViewDialogGachaLogRefreshProgressDescription" xml:space="preserve">
-    <value>正在获取 {0}</value>
+    <value>Đang lấy {0}</value> 
   </data>
   <data name="ViewDialogGachaLogRefreshProgressTitle" xml:space="preserve">
-    <value>获取祈愿物品中</value>
+    <value>Đang lấy vật phẩm Cầu Nguyện</value> 
   </data>
   <data name="ViewDialogGachaLogUrlInputPlaceholder" xml:space="preserve">
-    <value>请输入 URL</value>
+    <value>Vui lòng nhập URL</value> 
   </data>
   <data name="ViewDialogGachaLogUrlTitle" xml:space="preserve">
-    <value>手动输入祈愿记录 URL</value>
+    <value>Nhập URL lịch sử Cầu Nguyện thủ công</value> 
   </data>
   <data name="ViewDialogGameInstallLaunchScheme" xml:space="preserve">
-    <value>游戏服务器</value>
+    <value>Máy chủ game</value> 
   </data>
   <data name="ViewDialogGameInstallPathHddHint" xml:space="preserve">
-    <value>当前选择目录为HDD，建议使用SSD</value>
+    <value>Thư mục đang chọn là HDD, khuyên dùng SSD</value> 
   </data>
   <data name="ViewDialogGameInstallPickGameDirectory" xml:space="preserve">
-    <value>设置游戏安装目录</value>
+    <value>Cài đặt thư mục cài game</value> 
   </data>
   <data name="ViewDialogGameInstallTitle" xml:space="preserve">
-    <value>安装游戏</value>
+    <value>Cài đặt game</value> 
   </data>
   <data name="ViewDialogGameInstallVoiceChinese" xml:space="preserve">
-    <value>汉语</value>
+    <value>Tiếng Trung (Hán)</value> 
   </data>
   <data name="ViewDialogGameInstallVoiceEnglish" xml:space="preserve">
-    <value>英语</value>
+    <value>Tiếng Anh</value> 
   </data>
   <data name="ViewDialogGameInstallVoiceJapanese" xml:space="preserve">
-    <value>日语</value>
+    <value>Tiếng Nhật</value> 
   </data>
   <data name="ViewDialogGameInstallVoiceKorean" xml:space="preserve">
-    <value>韩语</value>
+    <value>Tiếng Hàn</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlCompositInputHint" xml:space="preserve">
-    <value>请输入请求接口的 URL 复合模板</value>
+    <value>Vui lòng nhập mẫu URL hỗn hợp của giao diện yêu cầu</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlReturnDataDescription1" xml:space="preserve">
-    <value>接口需要返回形如上方所示的 JSON 数据，多余的数据会被忽略</value>
+    <value>Giao diện cần trả về dữ liệu JSON có dạng như phía trên, dữ liệu dư thừa sẽ bị bỏ qua</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlReturnDataDescription2" xml:space="preserve">
-    <value>"code" 为 0 时，指示验证成功，其他的值均视为验证失败</value>
+    <value>Khi "code" là 0, chỉ báo xác minh thành công, các giá trị khác được coi là xác minh thất bại</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlReturnDataHeader" xml:space="preserve">
-    <value>返回数据</value>
+    <value>Dữ liệu trả về</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlSampleDescription1" xml:space="preserve">
-    <value>{0} 将在实际请求时替换为 gt</value>
+    <value>{0} sẽ được thay thế bằng gt khi yêu cầu thực tế</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlSampleDescription2" xml:space="preserve">
-    <value>{1} 将在实际请求时替换为 challenge</value>
+    <value>{1} sẽ được thay thế bằng challenge khi yêu cầu thực tế</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlSampleDescription3" xml:space="preserve">
-    <value>将会通过 GET 方式对接口发送请求</value>
+    <value>Sẽ gửi yêu cầu tới giao diện thông qua phương thức GET</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlSampleHeader" xml:space="preserve">
-    <value>示例</value>
+    <value>Ví dụ</value> 
   </data>
   <data name="ViewDialogGeetestCustomUrlTitle" xml:space="preserve">
-    <value>配置无感验证接口</value>
+    <value>Cấu hình giao diện xác minh ẩn</value> 
   </data>
   <data name="ViewDialogLauncherPassportLoginTitle" xml:space="preserve">
-    <value>登录通行证</value>
+    <value>Đăng nhập Passport</value> 
   </data>
   <data name="ViewDialogLauncherPassportRegisterTitle" xml:space="preserve">
-    <value>注册通行证</value>
+    <value>Đăng ký Passport</value> 
   </data>
   <data name="ViewDialogLauncherPassportResetPasswordTitle" xml:space="preserve">
-    <value>重置通行证密码</value>
+    <value>Đặt lại mật khẩu Passport</value> 
   </data>
   <data name="ViewDialogLauncherPassportResetUserNameTitle" xml:space="preserve">
-    <value>重置通行证邮箱</value>
+    <value>Đặt lại email Passport</value> 
   </data>
   <data name="ViewDialogLauncherPassportUnregisterTitle" xml:space="preserve">
-    <value>注销通行证账号</value>
+    <value>Hủy tài khoản Passport</value> 
   </data>
   <data name="ViewDialogLauncherPassportUseRedeemCodeTitle" xml:space="preserve">
-    <value>使用云兑换码</value>
+    <value>Sử dụng Mã Đổi Thưởng Cloud</value> 
   </data>
   <data name="ViewDialogImportExportApp" xml:space="preserve">
-    <value>导出 App</value>
+    <value>Ứng dụng xuất</value> 
   </data>
   <data name="ViewDialogImportExportAppVersion" xml:space="preserve">
-    <value>导出 App 版本</value>
+    <value>Phiên bản ứng dụng xuất</value> 
   </data>
   <data name="ViewDialogImportExportTime" xml:space="preserve">
-    <value>导出时间</value>
+    <value>Thời gian xuất</value> 
   </data>
   <data name="ViewDialogImportUIAFExportListCount" xml:space="preserve">
-    <value>成就个数</value>
+    <value>Số lượng thành tựu</value> 
   </data>
   <data name="ViewDialogImportUIAFExportUIAFVersion" xml:space="preserve">
-    <value>UIAF 版本</value>
+    <value>Phiên bản UIAF</value> 
   </data>
   <data name="ViewDialogImportUIGFExportUIGFVersion" xml:space="preserve">
-    <value>UIGF 版本</value>
+    <value>Phiên bản UIGF</value> 
   </data>
   <data name="ViewDialogImportUIGFSubtitle" xml:space="preserve">
-    <value>选择要导入记录的 UID</value>
+    <value>Chọn UID để nhập bản ghi</value> 
   </data>
   <data name="ViewDialogImportUIGFTitle" xml:space="preserve">
-    <value>导入 UIGF 文件</value>
+    <value>Nhập tệp UIGF</value> 
   </data>
   <data name="ViewDialogLaunchGameAccountInputPlaceholder" xml:space="preserve">
-    <value>在此处输入名称</value>
+    <value>Nhập tên vào đây</value> 
   </data>
   <data name="ViewDialogLaunchGameAccountTitle" xml:space="preserve">
-    <value>为账号命名</value>
+    <value>Đặt tên cho tài khoản</value> 
   </data>
   <data name="ViewDialogLaunchGameConfigurationFixDialogHint" xml:space="preserve">
-    <value>请选择当前游戏路径对应的游戏服务器</value>
+    <value>Vui lòng chọn máy chủ game tương ứng với đường dẫn game hiện tại</value> 
   </data>
   <data name="ViewDialogLaunchGameConfigurationFixDialogTitle" xml:space="preserve">
-    <value>修复配置文件</value>
+    <value>Sửa tệp cấu hình</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameDirectoryCreationFailed" xml:space="preserve">
-    <value>选择的安装路径不存在且无法创建</value>
+    <value>Đường dẫn cài đặt đã chọn không tồn tại và không thể tạo</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameDirectoryExistsFileSystemEntry" xml:space="preserve">
-    <value>选择的安装路径存在文件或文件夹</value>
+    <value>Đường dẫn cài đặt đã chọn có chứa tệp hoặc thư mục</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameDirectoryInvalid" xml:space="preserve">
-    <value>选择的安装路径无效</value>
+    <value>Đường dẫn cài đặt đã chọn không hợp lệ</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameDirectoryIsSSDCheckFailed" xml:space="preserve">
-    <value>在检测路径所在驱动器的类型时发生了未知的错误，数据下载与写入将会受到限制。如果你确定此设备为固态硬盘，请与我们联系。</value>
+    <value>Xảy ra lỗi không xác định khi phát hiện loại ổ đĩa chứa đường dẫn, tải xuống và ghi dữ liệu sẽ bị hạn chế. Nếu bạn chắc chắn thiết bị này là ổ cứng SSD, vui lòng liên hệ với chúng tôi.</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameNoAudioPackageSelected" xml:space="preserve">
-    <value>未选择语音包</value>
+    <value>Chưa chọn gói giọng nói</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGameNoSchemeSelected" xml:space="preserve">
-    <value>未选择游戏区服</value>
+    <value>Chưa chọn khu vực/máy chủ game</value> 
   </data>
   <data name="ViewDialogLaunchGameInstallGamePickDirectoryTitle" xml:space="preserve">
-    <value>选择安装路径</value>
+    <value>Chọn đường dẫn cài đặt</value> 
   </data>
   <data name="ViewDialogLaunchGamePackageConvertHint" xml:space="preserve">
-    <value>转换可能需要花费一段时间，请勿关闭</value>
+    <value>Chuyển đổi có thể mất một khoảng thời gian, vui lòng không đóng</value> 
   </data>
   <data name="ViewDialogLaunchGamePackageConvertTitle" xml:space="preserve">
-    <value>正在转换客户端</value>
+    <value>Đang chuyển đổi client</value> 
   </data>
   <data name="ViewDialogThirdPartyToolDescription" xml:space="preserve">
-    <value>工具描述：</value>
+    <value>Mô tả công cụ:</value> 
   </data>
   <data name="ViewDialogThirdPartyToolLaunch" xml:space="preserve">
-    <value>启动</value>
+    <value>Khởi động</value> 
   </data>
   <data name="ViewDialogQRCodeTitle" xml:space="preserve">
-    <value>使用米游社扫描二维码</value>
+    <value>Dùng HoyoLAB quét mã QR</value> 
   </data>
   <data name="ViewDialogReconfirmHint" xml:space="preserve">
-    <value>为了确保功能的启用者有独立的判断能力，我们将不定期更新这些功能的启用条件，如果您是一位内容创造者，在创作相关的内容时请不要向你的受众介绍具体的启用方法。</value>
+    <value>Để đảm bảo người bật chức năng có khả năng đánh giá độc lập, chúng tôi sẽ cập nhật không định kỳ điều kiện bật các chức năng này. Nếu bạn là người sáng tạo nội dung, xin đừng hướng dẫn cách bật cụ thể cho khán giả khi sáng tạo nội dung liên quan.</value> 
   </data>
   <data name="ViewDialogReconfirmTextHeader" xml:space="preserve">
-    <value>为防止你在无意间启用，请输入正在启用的功能开关的&lt;b&gt;标题名称&lt;/b&gt;</value>
+    <value>Để ngăn bạn vô tình bật, vui lòng nhập &lt;b&gt;tên tiêu đề&lt;/b&gt; của công tắc chức năng đang bật</value> 
   </data>
   <data name="ViewDialogReconfirmTitle" xml:space="preserve">
-    <value>你正在启用一个危险功能</value>
+    <value>Bạn đang bật một chức năng nguy hiểm</value> 
   </data>
   <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginHint" xml:space="preserve">
-    <value>当前未登录账号，上传深渊数据无法获赠云时长</value>
+    <value>Chưa đăng nhập tài khoản hiện tại, tải lên dữ liệu La Hoàn sẽ không nhận được thời gian Cloud tặng kèm</value> 
   </data>
   <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginPrimaryButtonText" xml:space="preserve">
-    <value>前往登录</value>
+    <value>Đi đăng nhập</value> 
   </data>
   <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginSecondaryButtonText" xml:space="preserve">
-    <value>继续上传</value>
+    <value>Tiếp tục tải lên</value> 
   </data>
   <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginTitle" xml:space="preserve">
-    <value>上传深渊数据</value>
+    <value>Tải lên dữ liệu La Hoàn</value> 
   </data>
   <data name="ViewDialogUserAccountPasswordAccountHint" xml:space="preserve">
-    <value>请输入账号</value>
+    <value>Vui lòng nhập tài khoản</value> 
   </data>
   <data name="ViewDialogUserAccountPasswordPasswordHint" xml:space="preserve">
-    <value>请输入密码</value>
+    <value>Vui lòng nhập mật khẩu</value> 
   </data>
   <data name="ViewDialogUserAccountPasswordTitle" xml:space="preserve">
-    <value>账号密码登录</value>
+    <value>Đăng nhập bằng tài khoản mật khẩu</value> 
   </data>
   <data name="ViewDialogUserAccountVerificationCaptchaPlaceholder" xml:space="preserve">
-    <value>验证码</value>
+    <value>Mã xác minh</value> 
   </data>
   <data name="ViewDialogUserAccountVerificationEmailCaptchaSent" xml:space="preserve">
-    <value>验证码已发送</value>
+    <value>Mã xác minh đã gửi</value> 
   </data>
   <data name="ViewDialogUserAccountVerificationTitle" xml:space="preserve">
-    <value>请输入邮箱验证码</value>
+    <value>Vui lòng nhập mã xác minh email</value> 
   </data>
   <data name="ViewDialogUserDocumentAction" xml:space="preserve">
-    <value>立即前往</value>
+    <value>Đi tới ngay</value> 
   </data>
   <data name="ViewDialogUserDocumentDescription" xml:space="preserve">
-    <value>进入文档页面并按指示操作</value>
+    <value>Vào trang tài liệu và làm theo hướng dẫn</value> 
   </data>
   <data name="ViewDialogUserDocumentHeader" xml:space="preserve">
-    <value>操作文档</value>
+    <value>Tài liệu hướng dẫn thao tác</value> 
   </data>
   <data name="ViewDialogUserInputPlaceholder" xml:space="preserve">
-    <value>在此处输入包含 SToken 的 Cookie</value>
+    <value>Nhập Cookie chứa SToken vào đây</value> 
   </data>
   <data name="ViewDialogUserMobileCaptchaCaptchaHint" xml:space="preserve">
-    <value>请输入收到的验证码</value>
+    <value>Vui lòng nhập mã xác minh đã nhận</value> 
   </data>
   <data name="ViewDialogUserMobileCaptchaMobileHint" xml:space="preserve">
-    <value>请输入手机号码</value>
+    <value>Vui lòng nhập số điện thoại</value> 
   </data>
   <data name="ViewDialogUserMobileCaptchaSendCaptchaAction" xml:space="preserve">
-    <value>发送</value>
+    <value>Gửi</value> 
   </data>
   <data name="ViewDialogUserMobileCaptchaTitle" xml:space="preserve">
-    <value>手机验证码登录</value>
+    <value>Đăng nhập bằng mã xác minh điện thoại</value> 
   </data>
   <data name="ViewDialogUserTitle" xml:space="preserve">
-    <value>设置 Cookie</value>
+    <value>Thiết lập Cookie</value> 
   </data>
   <data name="ViewExceptionWindowCommentDescription" xml:space="preserve">
-    <value>步骤明确，条理清晰的描述将有助于我们更快的定位问题</value>
+    <value>Mô tả các bước rõ ràng và mạch lạc sẽ giúp chúng tôi định vị vấn đề nhanh hơn</value> 
   </data>
   <data name="ViewExceptionWindowCommentHeader" xml:space="preserve">
-    <value>崩溃发生前您执行了哪些操作？</value>
+    <value>Bạn đã thực hiện những thao tác nào trước khi xảy ra sự cố?</value> 
   </data>
   <data name="ViewExceptionWindowStacktraceHeader" xml:space="preserve">
-    <value>调用堆栈</value>
+    <value>Ngăn xếp lệnh gọi (Stacktrace)</value> 
   </data>
   <data name="ViewFeedbackHeader" xml:space="preserve">
-    <value>反馈中心</value>
+    <value>Trung tâm phản hồi</value> 
   </data>
   <data name="ViewGachaLogHeader" xml:space="preserve">
-    <value>祈愿记录</value>
+    <value>Lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ViewWishCountdownHeader" xml:space="preserve">
-    <value>UP 计时</value>
+    <value>Đếm ngược UP</value> 
   </data>
   <data name="ViewGuideStepAgreementIHaveReadText" xml:space="preserve">
-    <value>我已阅读并同意</value>
+    <value>Tôi đã đọc và đồng ý</value> 
   </data>
   <data name="ViewGuideStepAgreementPrivacyPolicy" xml:space="preserve">
-    <value>用户数据与隐私权益</value>
+    <value>Quyền lợi người dùng và chính sách quyền riêng tư</value> 
   </data>
   <data name="ViewGuideStepAgreementTermOfService" xml:space="preserve">
-    <value>用户使用协议与法律声明</value>
+    <value>Thỏa thuận sử dụng và Tuyên bố pháp lý</value> 
   </data>
   <data name="ViewGuideStepCommonSettingHint" xml:space="preserve">
-    <value>稍后可以在设置中修改</value>
+    <value>Có thể sửa lại trong cài đặt sau</value> 
   </data>
   <data name="ViewGuideStepDataFolderHeader" xml:space="preserve">
-    <value>数据文件夹用于存储所有由用户操作产生的数据、自定义壁纸、元数据、切换服务器缓存、更新缓存等文件</value>
+    <value>Thư mục Dữ liệu dùng để lưu trữ mọi dữ liệu do người dùng thao tác, hình nền tùy chỉnh, siêu dữ liệu, bộ nhớ tạm khi chuyển đổi máy chủ, tệp tạm thời cập nhật...</value> 
   </data>
   <data name="ViewGuideStepDataFolderHint" xml:space="preserve">
-    <value>* 默认的文件夹会在卸载时一同删除，稍后可以在设置中修改</value>
+    <value>* Thư mục mặc định sẽ bị xóa khi gỡ cài đặt, bạn có thể thay đổi trong phần Cài đặt sau</value> 
   </data>
   <data name="ViewGuideStepCacheFolderHeader" xml:space="preserve">
-    <value>缓存文件夹用于存储图片缓存、背景缓存、静态资源等临时文件</value>
+    <value>Thư mục Cache dùng để lưu trữ bộ nhớ đệm hình ảnh, bộ nhớ đệm nền, tài nguyên tĩnh và các tệp tạm thời khác</value> 
   </data>
   <data name="ViewPageSettingSetCacheFolderHeader" xml:space="preserve">
-    <value>更改缓存目录</value>
+    <value>Đổi thư mục Cache</value> 
   </data>
   <data name="ViewGuideStepEnvironmentAfterInstallDescription" xml:space="preserve">
-    <value>安装完成后重启以查看是否正常生效</value>
+    <value>Khởi động lại sau khi cài đặt xong để kiểm tra xem có hoạt động bình thường không</value> 
   </data>
   <data name="ViewGuideStepEnvironmentFontDescription1" xml:space="preserve">
-    <value>如果上方的图标中存在乱码或方块字，请前往</value>
+    <value>Nếu các biểu tượng bên trên bị lỗi font hoặc biến thành hình vuông, vui lòng truy cập</value> 
   </data>
   <data name="ViewGuideStepEnvironmentFontDescription2" xml:space="preserve">
-    <value>下载并自行安装图标字体</value>
+    <value>Tải về và tự cài đặt font biểu tượng</value> 
   </data>
   <data name="ViewGuideStepEnvironmentWebView2Description1" xml:space="preserve">
-    <value>若未检测到 WebView2 运行时信息，可以前往</value>
+    <value>Nếu không phát hiện thấy thông tin Runtime WebView2, bạn có thể truy cập</value> 
   </data>
   <data name="ViewGuideStepEnvironmentWebView2Description2" xml:space="preserve">
-    <value>下载并自行安装运行时</value>
+    <value>Tải về và tự cài đặt Runtime</value> 
   </data>
   <data name="ViewHardChallengeHeader" xml:space="preserve">
-    <value>幽境危战</value>
+    <value>Ảo Cảnh Hiểm Ác</value> 
   </data>
   <data name="ViewLauncherPassportHeader" xml:space="preserve">
-    <value>通行证</value>
+    <value>Passport</value> 
   </data>
   <data name="ViewInfoBarPanelClearAllContent" xml:space="preserve">
-    <value>清除所有通知</value>
+    <value>Xóa tất cả thông báo</value> 
   </data>
   <data name="ViewInfoBarPanelContractContent" xml:space="preserve">
-    <value>收起</value>
+    <value>Thu gọn</value> 
   </data>
   <data name="ViewInfoBarPanelTitle" xml:space="preserve">
-    <value>所有通知</value>
+    <value>Tất cả thông báo</value> 
   </data>
   <data name="ViewInfoBarToggleTitle" xml:space="preserve">
-    <value>有新的通知</value>
+    <value>Có thông báo mới</value> 
   </data>
   <data name="ViewLaunchGameHeader" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value> 
   </data>
   <data name="ViewListViewDragElevatedHint" xml:space="preserve">
-    <value>管理员模式下无法拖动排序</value>
+    <value>Không thể kéo thả để sắp xếp trong chế độ quản trị viên</value> 
   </data>
   <data name="ViewModelAchievementArchiveAdded" xml:space="preserve">
-    <value>存档 [{0}] 添加成功</value>
+    <value>Bản lưu [{0}] đã thêm thành công</value> 
   </data>
   <data name="ViewModelAchievementArchiveAlreadyExists" xml:space="preserve">
-    <value>不能添加名称重复的存档 [{0}]</value>
+    <value>Không thể thêm bản lưu bị trùng tên [{0}]</value> 
   </data>
   <data name="ViewModelAchievementArchiveInvalidName" xml:space="preserve">
-    <value>不能添加名称无效的存档</value>
+    <value>Không thể thêm bản lưu có tên không hợp lệ</value> 
   </data>
   <data name="ViewModelAchievementCopyAchievementIdSuccess" xml:space="preserve">
-    <value>复制成就 ID 成功</value>
+    <value>Sao chép ID Thành Tựu thành công</value> 
   </data>
   <data name="ViewModelAchievementExportFileType" xml:space="preserve">
-    <value>UIAF 文件</value>
+    <value>Tệp UIAF</value> 
   </data>
   <data name="ViewModelAchievementImportProgress" xml:space="preserve">
-    <value>导入成就中</value>
+    <value>Đang nhập Thành Tựu</value> 
   </data>
   <data name="ViewModelAchievementImportWarningMessage" xml:space="preserve">
-    <value>数据的 UIAF 版本过低，无法导入</value>
+    <value>Phiên bản UIAF của dữ liệu quá cũ, không thể nhập</value> 
   </data>
   <data name="ViewModelAchievementRemoveArchiveContent" xml:space="preserve">
-    <value>该操作是不可逆的，该存档和其内的所有成就状态会丢失</value>
+    <value>Thao tác này là không thể đảo ngược, bản lưu này và mọi trạng thái Thành Tựu bên trong sẽ bị mất</value> 
   </data>
   <data name="ViewModelAchievementRemoveArchiveTitle" xml:space="preserve">
-    <value>确定要删除存档 {0} 吗？</value>
+    <value>Chắc chắn muốn xóa bản lưu {0} không?</value> 
   </data>
   <data name="ViewModelAchievementSearchInHoYoLAB" xml:space="preserve">
-    <value>前往HoYoLAB搜索</value>
+    <value>Đến HoYoLAB tìm kiếm</value> 
   </data>
-  <data name="ViewModelAchievementSearchInMiyoushe" xml:space="preserve">
-    <value>前往米游社搜索</value>
+  <data name="ViewModelAchievementSearchInHoyoLAB" xml:space="preserve">
+    <value>Đến HoyoLAB tìm kiếm</value> 
   </data>
   <data name="ViewModelAchievementSearchQuery" xml:space="preserve">
-    <value>{0} 成就</value>
+    <value>Thành Tựu {0}</value> 
   </data>
   <data name="ViewModelAchievementUIAFExportPickerTitle" xml:space="preserve">
-    <value>导出 UIAF JSON 文件到指定路径</value>
+    <value>Xuất tệp JSON UIAF đến đường dẫn chỉ định</value> 
   </data>
   <data name="ViewModelAvatarPropertyBatchCultivateNoSelectedAvatar" xml:space="preserve">
-    <value>未选中任意角色</value>
+    <value>Chưa chọn bất kỳ nhân vật nào</value> 
   </data>
   <data name="ViewModelAvatarPropertyBatchCultivateProgressTitle" xml:space="preserve">
-    <value>获取培养材料中，请稍候...</value>
+    <value>Đang lấy nguyên liệu bồi dưỡng, vui lòng đợi...</value> 
   </data>
   <data name="ViewModelAvatarPropertyCalculateWeaponNull" xml:space="preserve">
-    <value>当前角色无法计算，请同步信息后再试</value>
+    <value>Nhân vật hiện tại không thể tính toán, vui lòng đồng bộ thông tin rồi thử lại</value> 
   </data>
   <data name="ViewModelAvatarPropertyFetch" xml:space="preserve">
-    <value>获取数据中</value>
+    <value>Đang lấy dữ liệu</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindActivatedConstellationCount" xml:space="preserve">
-    <value>命之座解锁层数顺序</value>
+    <value>Xếp theo Cung Mệnh</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindCurAttack" xml:space="preserve">
-    <value>攻击力顺序</value>
+    <value>Xếp theo Tấn Công</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindCurDefense" xml:space="preserve">
-    <value>防御力顺序</value>
+    <value>Xếp theo Phòng Ngự</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindDefault" xml:space="preserve">
-    <value>默认顺序</value>
+    <value>Xếp theo mặc định</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindElementMastery" xml:space="preserve">
-    <value>元素精通顺序</value>
+    <value>Xếp theo Tinh Thông Nguyên Tố</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindFetterLevel" xml:space="preserve">
-    <value>好感度顺序</value>
+    <value>Xếp theo mức Yêu Thích</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindLevelNumber" xml:space="preserve">
-    <value>等级顺序</value>
+    <value>Xếp theo Cấp độ</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindMaxHp" xml:space="preserve">
-    <value>生命值上限顺序</value>
+    <value>Xếp theo Giới Hạn HP</value> 
   </data>
   <data name="ViewModelAvatarPropertySortDescriptionKindQuality" xml:space="preserve">
-    <value>品质顺序</value>
+    <value>Xếp theo Phẩm chất</value> 
   </data>
   <data name="ViewModelAvatarPropertyTotalAvatarCountHint" xml:space="preserve">
-    <value>共 {0} 位角色</value>
+    <value>Tổng cộng {0} nhân vật</value> 
   </data>
   <data name="ViewModelAvatatPropertyExportTextError" xml:space="preserve">
-    <value>复制角色详情失败</value>
+    <value>Sao chép chi tiết nhân vật thất bại</value> 
   </data>
   <data name="ViewModelAvatatPropertyExportTextSuccess" xml:space="preserve">
-    <value>复制角色详情成功</value>
+    <value>Sao chép chi tiết nhân vật thành công</value> 
   </data>
   <data name="ViewModelComplexReliquarySetViewEmptyName" xml:space="preserve">
-    <value>无圣遗物或散件</value>
+    <value>Không có Thánh Di Vật hoặc Đồ Lẻ</value> 
   </data>
   <data name="ViewModelCultivationAddWarning" xml:space="preserve">
-    <value>养成计划添加失败</value>
+    <value>Thêm kế hoạch bồi dưỡng thất bại</value> 
   </data>
   <data name="ViewModelCultivationBatchAddCompleted" xml:space="preserve">
-    <value>操作完成：添加 / 更新：{0} 个，跳过 {1} 个</value>
+    <value>Thao tác hoàn thành: Thêm / Cập nhật: {0} mục, bỏ qua {1} mục</value> 
   </data>
   <data name="ViewModelCultivationBatchAddIncompleted" xml:space="preserve">
-    <value>操作未全部完成：添加 / 更新：{0} 个，跳过 {1} 个</value>
+    <value>Thao tác chưa hoàn thành toàn bộ: Thêm / Cập nhật: {0} mục, bỏ qua {1} mục</value> 
   </data>
   <data name="ViewModelCultivationClearInventoryContent" xml:space="preserve">
-    <value>此操作不可逆，此计划的背包物品将会丢失</value>
+    <value>Thao tác này là không thể đảo ngược, vật phẩm trong ba lô của kế hoạch này sẽ bị mất</value> 
   </data>
   <data name="ViewModelCultivationClearInventoryProgress" xml:space="preserve">
-    <value>正在清空背包物品</value>
+    <value>Đang dọn dẹp vật phẩm ba lô</value> 
   </data>
   <data name="ViewModelCultivationClearInventoryTitle" xml:space="preserve">
-    <value>确认要清空当前计划下的所有背包物品吗？</value>
+    <value>Chắc chắn muốn dọn sạch mọi vật phẩm trong ba lô của kế hoạch hiện tại không?</value> 
   </data>
   <data name="ViewModelCultivationConsumptionSaveNoItemHint" xml:space="preserve">
-    <value>选定的等级不需要养成材料</value>
+    <value>Cấp độ đã chọn không cần nguyên liệu bồi dưỡng</value> 
   </data>
   <data name="ViewModelCultivationConsumptionSaveSkippedHint" xml:space="preserve">
-    <value>已存在该物品的养成项目</value>
+    <value>Mục bồi dưỡng của vật phẩm này đã tồn tại</value> 
   </data>
   <data name="ViewModelCultivationEntryAddNoConsumptionWarning" xml:space="preserve">
-    <value>未消耗任何材料</value>
+    <value>Chưa tiêu hao bất kỳ nguyên liệu nào</value> 
   </data>
   <data name="ViewModelCultivationEntryAddSuccess" xml:space="preserve">
-    <value>已成功添加至当前养成计划</value>
+    <value>Đã thêm thành công vào kế hoạch bồi dưỡng hiện tại</value> 
   </data>
   <data name="ViewModelCultivationEntryAddWarning" xml:space="preserve">
-    <value>请先前往养成计划页面创建计划并选中</value>
+    <value>Vui lòng đến trang Kế hoạch bồi dưỡng tạo kế hoạch và chọn trước</value> 
   </data>
   <data name="ViewModelCultivationEntryViewDescriptionDefault" xml:space="preserve">
-    <value>重新添加物品以查看养成描述</value>
+    <value>Thêm lại vật phẩm để xem mô tả bồi dưỡng</value> 
   </data>
   <data name="ViewModelCultivationEntryViewPromoteOnlyHint" xml:space="preserve">
-    <value>仅突破</value>
+    <value>Chỉ Đột Phá</value> 
   </data>
   <data name="ViewModelCultivationProjectAdded" xml:space="preserve">
-    <value>添加成功</value>
+    <value>Thêm thành công</value> 
   </data>
   <data name="ViewModelCultivationProjectAlreadyExists" xml:space="preserve">
-    <value>不能添加名称重复的计划</value>
+    <value>Không thể thêm kế hoạch trùng tên</value> 
   </data>
   <data name="ViewModelCultivationProjectInvalidName" xml:space="preserve">
-    <value>不能添加名称无效的计划</value>
+    <value>Không thể thêm kế hoạch có tên không hợp lệ</value> 
   </data>
   <data name="ViewModelCultivationRefreshInventoryProgress" xml:space="preserve">
-    <value>正在同步背包物品</value>
+    <value>Đang đồng bộ vật phẩm ba lô</value> 
   </data>
   <data name="ViewModelCultivationRemoveProjectContent" xml:space="preserve">
-    <value>此操作不可逆，此计划的养成物品与背包材料将会丢失</value>
+    <value>Thao tác này là không thể đảo ngược, vật phẩm bồi dưỡng và nguyên liệu ba lô của kế hoạch này sẽ bị mất</value> 
   </data>
   <data name="ViewModelCultivationRemoveProjectTitle" xml:space="preserve">
-    <value>确认要删除当前计划吗？</value>
+    <value>Xác nhận muốn xóa kế hoạch hiện tại không?</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsBlossomOfRevelationTitle" xml:space="preserve">
-    <value>启示之花</value>
+    <value>Hoa Chỉ Thị</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsBlossomOfWealthTitle" xml:space="preserve">
-    <value>藏金之花</value>
+    <value>Hoa Tàng Kim</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsItemRemainDays" xml:space="preserve">
-    <value>还需 {0} 天</value>
+    <value>Còn cần {0} ngày</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsNormalBossTitle" xml:space="preserve">
-    <value>世界 BOSS</value>
+    <value>BOSS Thế giới</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsTalentAscensionTitle" xml:space="preserve">
-    <value>角色天赋素材</value>
+    <value>Nguyên Liệu Thiên Phú Nhân Vật</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsWeaponAscensionTitle" xml:space="preserve">
-    <value>武器突破素材</value>
+    <value>Nguyên Liệu Đột Phá Vũ Khí</value> 
   </data>
   <data name="ViewModelCultivationResinStatisticsWeeklyBossTitle" xml:space="preserve">
-    <value>周常 BOSS</value>
+    <value>BOSS Tuần</value> 
   </data>
   <data name="ViewModelDailyNoteConfigWebhookUrlComplete" xml:space="preserve">
-    <value>实时便笺 Webhook URL 配置成功</value>
+    <value>Cấu hình Webhook URL Ghi chú thời gian thực thành công</value> 
   </data>
   <data name="ViewModelDailyNoteRefreshTime30" xml:space="preserve">
-    <value>30 分钟 | 3.75 树脂</value>
+    <value>30 phút | 3.75 Nhựa</value> 
   </data>
   <data name="ViewModelDailyNoteRefreshTime4" xml:space="preserve">
-    <value>4 分钟 | 0.5 树脂</value>
+    <value>4 phút | 0.5 Nhựa</value> 
   </data>
   <data name="ViewModelDailyNoteRefreshTime40" xml:space="preserve">
-    <value>40 分钟 | 5 树脂</value>
+    <value>40 phút | 5 Nhựa</value> 
   </data>
   <data name="ViewModelDailyNoteRefreshTime60" xml:space="preserve">
-    <value>60 分钟 | 7.5 树脂</value>
+    <value>60 phút | 7.5 Nhựa</value> 
   </data>
   <data name="ViewModelDailyNoteRefreshTime8" xml:space="preserve">
-    <value>8 分钟 | 1 树脂</value>
+    <value>8 phút | 1 Nhựa</value> 
   </data>
   <data name="ViewModelDailyNoteRequestProgressTitle" xml:space="preserve">
-    <value>正在获取实时便笺信息，请稍候</value>
+    <value>Đang lấy thông tin Ghi chú thời gian thực, vui lòng chờ</value> 
   </data>
   <data name="ViewModelExportSuccessMessage" xml:space="preserve">
-    <value>成功保存到指定位置</value>
+    <value>Đã lưu thành công vào vị trí được chỉ định</value> 
   </data>
   <data name="ViewModelExportSuccessTitle" xml:space="preserve">
-    <value>导出成功</value>
+    <value>Xuất thành công</value> 
   </data>
   <data name="ViewModelExportWarningMessage" xml:space="preserve">
-    <value>写入文件时遇到问题</value>
+    <value>Gặp vấn đề khi ghi tệp</value> 
   </data>
   <data name="ViewModelExportWarningTitle" xml:space="preserve">
-    <value>导出失败</value>
+    <value>Xuất thất bại</value> 
   </data>
   <data name="ViewModelGachaLogCountdownCurrentWish" xml:space="preserve">
-    <value>当前卡池</value>
+    <value>Banner hiện tại</value> 
   </data>
   <data name="ViewModelGachaLogCountdownCurrentWishDelta" xml:space="preserve">
-    <value>距离 UP 结束还有 {0} 天</value>
+    <value>Còn {0} ngày là kết thúc UP</value> 
   </data>
   <data name="ViewModelGachaLogCountdownHistoryCount" xml:space="preserve">
-    <value>累计 UP 次数：{0}</value>
+    <value>Tổng số lần UP: {0}</value> 
   </data>
   <data name="ViewModelGachaLogCountdownLastTime" xml:space="preserve">
-    <value>上次 UP 时间: {0:yyyy.MM.dd}</value>
+    <value>Lần UP trước: {0:yyyy.MM.dd}</value> 
   </data>
   <data name="ViewModelGachaLogCountdownLastTimeDelta" xml:space="preserve">
-    <value>距离上次 UP 已有 {0} 天</value>
+    <value>Đã {0} ngày kể từ lần UP trước</value> 
   </data>
   <data name="ViewModelGachaLogCountdownOrderDown" xml:space="preserve">
-    <value>下半</value>
+    <value>Nửa sau</value> 
   </data>
   <data name="ViewModelGachaLogCountdownOrderUp" xml:space="preserve">
-    <value>上半</value>
+    <value>Nửa đầu</value> 
   </data>
   <data name="ViewModelGachaLogExportFileType" xml:space="preserve">
-    <value>UIGF JSON 文件</value>
+    <value>Tệp JSON UIGF</value> 
   </data>
   <data name="ViewModelGachaLogExportFormatTitle" xml:space="preserve">
-    <value>选择导出格式</value>
+    <value>Chọn định dạng xuất</value> 
   </data>
   <data name="ViewModelGachaLogExportFormatDescription" xml:space="preserve">
-    <value>UIGF v4.0 适用于大部分新版工具，UIGF v2.3 适用于部分旧版工具（如 Starward）</value>
+    <value>UIGF v4.0 dùng cho hầu hết công cụ mới, UIGF v2.3 dùng cho vài công cụ cũ (như Starward)</value> 
   </data>
   <data name="ViewModelGachaLogPredictedPullLeftToOrange" xml:space="preserve">
-    <value>{1:P3} 概率 {0} 抽后获得五星物品</value>
+    <value>{1:P3} tỷ lệ nhận vật phẩm 5 Sao sau {0} lần rút</value> 
   </data>
   <data name="ViewModelGachaLogProbabilityOfNextPullIsOrange" xml:space="preserve">
-    <value>{0:P3} 概率下一抽获得五星物品</value>
+    <value>{0:P3} tỷ lệ lần rút tới nhận vật phẩm 5 Sao</value> 
   </data>
   <data name="ViewModelGachaLogRefreshFail" xml:space="preserve">
-    <value>获取祈愿记录失败</value>
+    <value>Lấy lịch sử Cầu Nguyện thất bại</value> 
   </data>
   <data name="ViewModelGachaLogRefreshOperationCancel" xml:space="preserve">
-    <value>祈愿记录刷新操作被异常取消</value>
+    <value>Thao tác làm mới lịch sử Cầu Nguyện đã bị hủy bất thường</value> 
   </data>
   <data name="ViewModelGachaLogRemoveArchiveDescription" xml:space="preserve">
-    <value>该操作是不可逆的，该存档和其内的所有祈愿数据会丢失</value>
+    <value>Thao tác này là không thể đảo ngược, bản lưu này và toàn bộ dữ liệu Cầu Nguyện bên trong sẽ bị mất</value> 
   </data>
   <data name="ViewModelGachaLogRemoveArchiveTitle" xml:space="preserve">
-    <value>确定要删除存档 {0} 吗？</value>
+    <value>Chắc chắn muốn xóa bản lưu {0} không?</value> 
   </data>
   <data name="ViewModelGachaLogRetrieveFromLauncherCloudProgress" xml:space="preserve">
-    <value>从云服务同步祈愿记录</value>
+    <value>Đang đồng bộ lịch sử Cầu Nguyện từ Dịch vụ Cloud</value> 
   </data>
   <data name="ViewModelGachaLogUIGFExportPickerTitle" xml:space="preserve">
-    <value>导出 UIGF JSON 文件到指定路径</value>
+    <value>Xuất tệp JSON UIGF đến vị trí chỉ định</value> 
   </data>
   <data name="ViewModelGachaLogUIGFImportSuccess" xml:space="preserve">
-    <value>成功导入 {0} 条祈愿记录</value>
+    <value>Đã nhập thành công {0} bản ghi Cầu Nguyện</value> 
   </data>
   <data name="ViewModelGachaLogUIGFExportSuccess" xml:space="preserve">
-    <value>成功导出 UID:{0} 的祈愿记录</value>
+    <value>Xuất thành công lịch sử Cầu Nguyện của UID:{0}</value> 
   </data>
   <data name="ViewModelGachaLogUploadToLauncherCloudProgress" xml:space="preserve">
-    <value>正在上传到云服务</value>
+    <value>Đang tải lên Dịch vụ Cloud</value> 
   </data>
   <data name="ViewModelGachaUIGFImportPickerTitile" xml:space="preserve">
-    <value>导入 UIGF JSON 文件</value>
+    <value>Nhập tệp JSON UIGF</value> 
   </data>
   <data name="ViewModelGameConfigurationCreateFailed" xml:space="preserve">
-    <value>生成配置文件失败</value>
+    <value>Tạo tệp cấu hình thất bại</value> 
   </data>
   <data name="ViewModelGameConfigurationCreateFailedGamePathLocked" xml:space="preserve">
-    <value>游戏路径被锁定，请稍后再试</value>
+    <value>Đường dẫn game bị khóa, vui lòng thử lại sau</value> 
   </data>
   <data name="ViewModelGameConfigurationCreateFailedGamePathNullOrEmpty" xml:space="preserve">
-    <value>游戏路径为空，请先设置游戏路径</value>
+    <value>Đường dẫn game trống, vui lòng thiết lập đường dẫn game trước</value> 
   </data>
   <data name="ViewModelGamePackageGetGameBranchFailed" xml:space="preserve">
-    <value>获取游戏版本配置失败</value>
+    <value>Lấy cấu hình phiên bản game thất bại</value> 
   </data>
   <data name="ViewModelGamePackageLocalLaunchScheme" xml:space="preserve">
-    <value>本地游戏配置 [{0}]</value>
+    <value>Cấu hình game cục bộ [{0}]</value> 
   </data>
   <data name="ViewModelGamePackageLocalVersion" xml:space="preserve">
-    <value>本地版本: {0}</value>
+    <value>Phiên bản cục bộ: {0}</value> 
   </data>
   <data name="ViewModelGamePackageOperationAborted" xml:space="preserve">
-    <value>任务已中断，{0}</value>
+    <value>Nhiệm vụ bị gián đoạn, {0}</value> 
   </data>
   <data name="ViewModelGamePackageOperationCanceled" xml:space="preserve">
-    <value>已取消</value>
+    <value>Đã hủy</value> 
   </data>
   <data name="ViewModelGamePackageOperationCancelling" xml:space="preserve">
-    <value>正在取消</value>
+    <value>Đang hủy</value> 
   </data>
   <data name="ViewModelGamePackageOperationCompleteInstall" xml:space="preserve">
-    <value>安装完成</value>
+    <value>Cài đặt hoàn tất</value> 
   </data>
   <data name="ViewModelGamePackageOperationCompletePredownload" xml:space="preserve">
-    <value>预下载完成</value>
+    <value>Tải trước hoàn tất</value> 
   </data>
   <data name="ViewModelGamePackagePredownloadMergeTitle" xml:space="preserve">
-    <value>预下载完成</value>
+    <value>Tải trước hoàn tất</value> 
   </data>
   <data name="ViewModelGamePackagePredownloadMergeContent" xml:space="preserve">
-    <value>资源预下载已完成，是否立即合并更新？合并期间游戏将无法启动。</value>
+    <value>Đã tải trước tài nguyên, có hợp nhất cập nhật ngay không? Trong quá trình hợp nhất sẽ không thể khởi động game.</value> 
   </data>
   <data name="ViewModelGamePackageOperationCompleteRepair" xml:space="preserve">
-    <value>修复完成</value>
+    <value>Sửa chữa hoàn tất</value> 
   </data>
   <data name="ViewModelGamePackageOperationCompleteUpdate" xml:space="preserve">
-    <value>更新完成</value>
+    <value>Cập nhật hoàn tất</value> 
   </data>
   <data name="ViewModelGamePackageOperationSkipRepair" xml:space="preserve">
-    <value>游戏完整，无需修复</value>
+    <value>Game nguyên vẹn, không cần sửa chữa</value> 
   </data>
   <data name="ViewModelGamePackagePreVersion" xml:space="preserve">
-    <value>{0} 版本预下载已开启</value>
+    <value>Đã mở tải trước phiên bản {0}</value> 
   </data>
   <data name="ViewModelGamePackageRemoteVersion" xml:space="preserve">
-    <value>最新版本: {0}</value>
+    <value>Phiên bản mới nhất: {0}</value> 
   </data>
   <data name="ViewModelGuideActionComplete" xml:space="preserve">
-    <value>完成</value>
+    <value>Hoàn thành</value> 
   </data>
   <data name="ViewModelGuideActionNext" xml:space="preserve">
-    <value>下一步</value>
+    <value>Tiếp theo</value> 
   </data>
   <data name="ViewGuideScrollHint" xml:space="preserve">
-    <value>请滚动至底部阅读完整协议</value>
+    <value>Vui lòng cuộn xuống dưới cùng để đọc toàn bộ Thỏa thuận</value> 
   </data>
   <data name="ViewModelHardChallengeSeconds" xml:space="preserve">
-    <value>{0} 秒</value>
+    <value>{0} giây</value> 
   </data>
   <data name="ViewModelHardChalllengeDataEntryMultiPlayerName" xml:space="preserve">
-    <value>联机挑战</value>
+    <value>Khiêu chiến nhiều người</value> 
   </data>
   <data name="ViewModelHardChalllengeDataEntrySinglePlayerName" xml:space="preserve">
-    <value>单人挑战</value>
+    <value>Khiêu chiến cá nhân</value> 
   </data>
   <data name="ViewModelLauncherPassportEmailNotValidHint" xml:space="preserve">
-    <value>请输入正确的邮箱</value>
+    <value>Vui lòng nhập đúng email</value> 
   </data>
   <data name="ViewModelLauncherPassportPasswordTooShortHint" xml:space="preserve">
-    <value>密码长度不能小于 8 位</value>
+    <value>Độ dài mật khẩu không được dưới 8 ký tự</value> 
   </data>
   <data name="ViewModelImportByEmbeddedYaeErrorMessage" xml:space="preserve">
-    <value>请使用其他方法导入成就</value>
+    <value>Vui lòng dùng cách khác để nhập Thành Tựu</value> 
   </data>
   <data name="ViewModelImportFromClipboardErrorTitle" xml:space="preserve">
-    <value>剪贴板中没有有效的成就数据</value>
+    <value>Không có dữ liệu Thành Tựu hợp lệ trong bộ nhớ tạm</value> 
   </data>
   <data name="ViewModelImportFromClipboardErrorMessage" xml:space="preserve">
-    <value>请先从其他成就工具导出 UIAF 格式的数据并复制到剪贴板后再试</value>
+    <value>Vui lòng xuất dữ liệu định dạng UIAF từ công cụ Thành Tựu khác, chép vào bộ nhớ tạm rồi thử lại</value> 
   </data>
   <data name="ViewModelImportWarningMessage" xml:space="preserve">
-    <value>数据格式不正确</value>
+    <value>Định dạng dữ liệu không đúng</value> 
   </data>
   <data name="ViewModelImportWarningMessage2" xml:space="preserve">
-    <value>请先创建一个成就存档</value>
+    <value>Vui lòng tạo một bản lưu Thành Tựu trước</value> 
   </data>
   <data name="ViewModelImportWarningTitle" xml:space="preserve">
-    <value>导入失败</value>
+    <value>Nhập thất bại</value> 
   </data>
   <data name="ViewModelLaunchGameAccountAndServerNotMatch" xml:space="preserve">
-    <value>当前选中用户和游戏服务器不匹配，请重新选择</value>
+    <value>Người dùng và máy chủ game đã chọn không khớp, vui lòng chọn lại</value> 
   </data>
   <data name="ViewModelLaunchGameConfigurationFailed" xml:space="preserve">
-    <value>读取游戏配置文件时遇到问题：{0}</value>
+    <value>Gặp vấn đề khi đọc tệp cấu hình game: {0}</value> 
   </data>
   <data name="ViewModelLaunchGameConfigurationFileNotFound" xml:space="preserve">
-    <value>无法读取游戏配置文件: {0}，可能是文件不存在或权限不足</value>
+    <value>Không thể đọc tệp cấu hình game: {0}, có thể tệp không tồn tại hoặc quyền không đủ</value> 
   </data>
   <data name="ViewModelLaunchGameContentCorrupted" xml:space="preserve">
-    <value>当前选中的游戏目录 {0} 已损坏，请手动删除文件夹后重新安装游戏</value>
+    <value>Thư mục game đã chọn {0} bị hỏng, vui lòng xóa thư mục thủ công rồi cài lại game</value> 
   </data>
   <data name="ViewModelLaunchGameCreateAuthTicketFailed" xml:space="preserve">
-    <value>使用 米游社 / HoYoLAB 用户登录失败，请重新登录</value>
+    <value>Đăng nhập bằng người dùng HoyoLAB thất bại, vui lòng đăng nhập lại</value> 
   </data>
   <data name="ViewModelLaunchGameDeviceNotFound" xml:space="preserve">
-    <value>无效的游戏路径，请检查硬件连接</value>
+    <value>Đường dẫn game không hợp lệ, vui lòng kiểm tra kết nối phần cứng</value> 
   </data>
   <data name="ViewModelLaunchGameDisplayGamePath" xml:space="preserve">
-    <value>当前游戏路径：'{0}'</value>
+    <value>Đường dẫn game hiện tại: '{0}'</value> 
   </data>
   <data name="ViewModelLaunchGameEnsureGameResourceFail" xml:space="preserve">
-    <value>切换服务器失败</value>
+    <value>Chuyển đổi máy chủ thất bại</value> 
   </data>
   <data name="ViewModelLaunchGameFixConfigurationFileButtonText" xml:space="preserve">
-    <value>修复配置文件</value>
+    <value>Sửa tệp cấu hình</value> 
   </data>
   <data name="ViewModelLaunchGameFixConfigurationFileFailed" xml:space="preserve">
-    <value>修复失败</value>
+    <value>Sửa chữa thất bại</value> 
   </data>
   <data name="ViewModelLaunchGameFixConfigurationFileSucceed" xml:space="preserve">
-    <value>修复成功</value>
+    <value>Sửa chữa thành công</value> 
   </data>
   <data name="ViewModelLaunchGameGamePathNullOrEmpty" xml:space="preserve">
-    <value>尚未设置游戏目录</value>
+    <value>Chưa thiết lập thư mục game</value> 
   </data>
   <data name="ViewModelLaunchGameIdentifyMonitorsAction" xml:space="preserve">
-    <value>识别显示器</value>
+    <value>Nhận dạng Màn hình</value> 
   </data>
   <data name="ViewModelLaunchGameGamePathNotSet" xml:space="preserve">
-    <value>尚未设置游戏路径，请先在设置中配置游戏目录</value>
+    <value>Chưa thiết lập đường dẫn game, vui lòng cấu hình thư mục game trong cài đặt trước</value> 
   </data>
   <data name="ViewModelLaunchGameSchemeNotSelected" xml:space="preserve">
-    <value>尚未选择任何服务器</value>
+    <value>Chưa chọn bất kỳ máy chủ nào</value> 
   </data>
   <data name="ViewModelLaunchGameSetGamePathButtonText" xml:space="preserve">
-    <value>设置游戏目录</value>
+    <value>Thiết lập thư mục game</value> 
   </data>
   <data name="ViewModelLaunchGameSwitchGameAccountFail" xml:space="preserve">
-    <value>切换账号失败</value>
+    <value>Chuyển đổi tài khoản thất bại</value> 
   </data>
   <data name="ViewModelNotifyIconRestartAsElevatedErrorHint" xml:space="preserve">
-    <value>在重启时遇到问题，请手动重启</value>
+    <value>Gặp vấn đề khi khởi động lại, vui lòng tự khởi động lại</value> 
   </data>
   <data name="ViewModelOverlayCatalogHotKeyDisplayName" xml:space="preserve">
-    <value>热键提示</value>
+    <value>Nhắc nhở Phím tắt</value> 
   </data>
   <data name="ViewModelOverlayCatalogIslandSwitchName" xml:space="preserve">
-    <value>快捷开关</value>
+    <value>Công tắc Nhanh</value> 
   </data>
   <data name="ViewModelRoleCombatHeraldry" xml:space="preserve">
-    <value>已抵达{0}</value>
+    <value>Đã đến {0}</value> 
   </data>
   <data name="ViewModelRoleCombatRound" xml:space="preserve">
-    <value>第 {0} 幕</value>
+    <value>Màn {0}</value> 
   </data>
   <data name="ViewModelRoleCombatRoundAndTarot" xml:space="preserve">
-    <value>第 {0} 幕 圣牌 {1}</value>
+    <value>Màn {0} Thánh Bài {1}</value> 
   </data>
   <data name="ViewModelRoleCombatTarot" xml:space="preserve">
-    <value>圣牌挑战 {0}</value>
+    <value>Thử thách Thánh Bài{0}</value> 
   </data>
   <data name="ViewModelSettingActionComplete" xml:space="preserve">
-    <value>操作完成</value>
+    <value>Thao tác hoàn thành</value> 
   </data>
   <data name="ViewModelSettingAlreadyUpdated" xml:space="preserve">
-    <value>当前已是最新版本</value>
+    <value>Hiện đã là phiên bản mới nhất</value> 
   </data>
   <data name="ViewModelSettingCheckUpdateFailed" xml:space="preserve">
-    <value>检查更新时发生错误</value>
+    <value>Xảy ra lỗi khi kiểm tra cập nhật</value> 
   </data>
   <data name="ViewModelSettingClearWebCacheFail" xml:space="preserve">
-    <value>清除失败，文件目录权限不足，请使用管理员模式重试</value>
+    <value>Xóa thất bại, không đủ quyền ở thư mục tệp, vui lòng dùng quyền quản trị viên thử lại</value> 
   </data>
   <data name="ViewModelSettingClearWebCachePathInvalid" xml:space="preserve">
-    <value>清除失败，找不到目录：{0}</value>
+    <value>Xóa thất bại, không tìm thấy thư mục: {0}</value> 
   </data>
   <data name="ViewModelSettingClearWebCacheSuccess" xml:space="preserve">
-    <value>清除完成</value>
+    <value>Xóa hoàn tất</value> 
   </data>
   <data name="ViewModelSettingCopyDeviceIdSuccess" xml:space="preserve">
-    <value>复制成功</value>
+    <value>Sao chép thành công</value> 
   </data>
   <data name="ViewModelSettingCreateDesktopShortcutFailed" xml:space="preserve">
-    <value>创建桌面快捷方式失败</value>
+    <value>Tạo lối tắt desktop thất bại</value> 
   </data>
   <data name="ViewModelSettingFolderSizeDescription" xml:space="preserve">
-    <value>已使用磁盘空间：{0}</value>
+    <value>Không gian đĩa đã dùng: {0}</value> 
   </data>
   <data name="ViewModelSettingGeetestCustomUrlSucceed" xml:space="preserve">
-    <value>无感验证复合 URL 配置成功</value>
+    <value>Cấu hình URL hỗn hợp xác minh ẩn thành công</value> 
   </data>
   <data name="ViewModelSettingSetDataFolderSuccess" xml:space="preserve">
-    <value>设置数据目录成功，重启以应用更改</value>
+    <value>Thiết lập thư mục dữ liệu thành công, khởi động lại để áp dụng thay đổi</value> 
   </data>
   <data name="ViewModelSettingStorageRestartFailed" xml:space="preserve">
-    <value>重启失败，请手动重启应用</value>
+    <value>Khởi động lại thất bại, vui lòng tự khởi động lại ứng dụng</value> 
   </data>
   <data name="ViewModelSettingStorageSetDataFolderDescription" xml:space="preserve">
-    <value>选择的文件夹不为空，将会覆盖已存在的文件</value>
+    <value>Thư mục đã chọn không trống, sẽ ghi đè các tệp hiện có</value> 
   </data>
   <data name="ViewModelSettingStorageSetDataFolderDescription2" xml:space="preserve">
-    <value>不是有效的数据文件夹位置，请重新选择</value>
+    <value>Không phải vị trí thư mục dữ liệu hợp lệ, vui lòng chọn lại</value> 
   </data>
   <data name="ViewModelSettingStorageSetDataFolderDescription3" xml:space="preserve">
-    <value>选择的文件夹'{0}'不为空，将会覆盖已存在的文件</value>
+    <value>Thư mục đã chọn '{0}' không trống, sẽ ghi đè các tệp hiện có</value> 
   </data>
   <data name="ViewModelSettingStorageSetDataFolderTitle" xml:space="preserve">
-    <value>复制数据文件</value>
+    <value>Sao chép tệp dữ liệu</value> 
   </data>
   <data name="ViewModelSettingUpdateAvailable" xml:space="preserve">
-    <value>更新可用: {0}</value>
+    <value>Bản cập nhật hiện có: {0}</value> 
   </data>
   <data name="ViewModelSettingPatchDownloading" xml:space="preserve">
-    <value>正在下载增量补丁...</value>
+    <value>Đang tải xuống bản vá vi phân...</value> 
   </data>
   <data name="ViewModelSettingPatchDownloadingProgress" xml:space="preserve">
-    <value>正在下载增量补丁 {0}%</value>
+    <value>Đang tải xuống bản vá vi phân {0}%</value> 
   </data>
   <data name="ViewModelSettingPatchVerifyFailed" xml:space="preserve">
-    <value>补丁校验失败</value>
+    <value>Kiểm tra bản vá thất bại</value> 
   </data>
   <data name="ViewModelSettingPatchReadyRestarting" xml:space="preserve">
-    <value>补丁已就绪，正在重启安装...</value>
+    <value>Bản vá đã sẵn sàng, đang khởi động lại để cài đặt...</value> 
   </data>
   <data name="ViewModelSettingPatchUpdaterMissing" xml:space="preserve">
-    <value>updater.exe 不存在，无法应用更新</value>
+    <value>updater.exe không tồn tại, không thể áp dụng cập nhật</value> 
   </data>
   <data name="ViewModelMainUpdatePatchNotAvailable" xml:space="preserve">
-    <value>检测到新版本，但增量补丁暂未就绪，请稍后重试</value>
+    <value>Phát hiện phiên bản mới, nhưng bản vá vi phân chưa sẵn sàng, vui lòng thử lại sau</value> 
   </data>
   <data name="ViewModelMainUpdateMandatoryTitle" xml:space="preserve">
-    <value>发现新版本</value>
+    <value>Đã phát hiện phiên bản mới</value> 
   </data>
-    <data name="ViewModelMainUpdateMandatoryContent" xml:space="preserve">
-    <value>检测到新版本 {0}，是否立即更新？</value>
+  <data name="ViewModelMainUpdateMandatoryContent" xml:space="preserve">
+    <value>Đã phát hiện phiên bản mới {0}, có cập nhật ngay không?</value> 
   </data>
   <data name="ViewModelMainUpdateCompletedTitle" xml:space="preserve">
-    <value>更新完成</value>
+    <value>Cập nhật hoàn tất</value> 
   </data>
   <data name="ViewModelMainUpdateCompletedContent" xml:space="preserve">
-    <value>已更新到 v{0}</value>
+    <value>Đã cập nhật lên v{0}</value> 
   </data>
   <data name="ViewModelMainUpdateNowButton" xml:space="preserve">
-    <value>立即更新</value>
+    <value>Cập nhật ngay</value> 
   </data>
   <data name="ViewModelMainUpdateLaterButton" xml:space="preserve">
-    <value>稍后更新</value>
+    <value>Cập nhật sau</value> 
   </data>
   <data name="ViewModelMainUpdateDownloadFailed" xml:space="preserve">
-    <value>更新下载失败，请检查网络连接后重新启动</value>
+    <value>Tải xuống bản cập nhật thất bại, vui lòng kiểm tra mạng và khởi động lại</value> 
   </data>
   <data name="ViewModelMainUpdateRestartFailed" xml:space="preserve">
-    <value>更新程序启动失败，请稍后重试或手动重启启动器</value>
+    <value>Khởi động trình cập nhật thất bại, vui lòng thử lại sau hoặc tự khởi động lại launcher</value> 
   </data>
   <data name="ViewModelMainUpdateDownloading" xml:space="preserve">
-    <value>正在下载更新...</value>
+    <value>Đang tải xuống bản cập nhật...</value> 
   </data>
   <data name="ViewModelMainUpdateVerifying" xml:space="preserve">
-    <value>正在校验文件...</value>
+    <value>Đang xác minh tệp...</value> 
   </data>
   <data name="ViewModelMainUpdateExtracting" xml:space="preserve">
-    <value>正在解压更新...</value>
+    <value>Đang giải nén bản cập nhật...</value> 
   </data>
   <data name="ViewModelSignInReSignInDialogContent" xml:space="preserve">
-    <value>需消耗 {0} 米游币，{1} 米游币可用</value>
+    <value>Cần tiêu hao {0} Tiền HoyoLAB, {1} Tiền HoyoLAB hiện có</value> 
   </data>
   <data name="ViewModelSignInReSignInDialogContentOversea" xml:space="preserve">
-    <value>需消耗 {0} 张补签卡，{1} 张补签卡可用</value>
+    <value>Cần tiêu hao {0} Thẻ Điểm Danh Bù, {1} Thẻ hiện có</value> 
   </data>
   <data name="ViewModelSignInReSignInDialogTitle" xml:space="preserve">
-    <value>确定要补签吗？</value>
+    <value>Xác nhận muốn điểm danh bù không?</value> 
   </data>
   <data name="ViewModelSignInReSignInNotEnoughCoinMessage" xml:space="preserve">
-    <value>米游币不足</value>
+    <value>Không đủ Tiền HoyoLAB</value> 
   </data>
   <data name="ViewModelSignInTotalSignInDaysHint" xml:space="preserve">
-    <value>{0} 累计签到 {1} 天</value>
+    <value>{0} Tích lũy điểm danh {1} ngày</value> 
   </data>
   <data name="ViewModelTitleDataFolderHasReparsepoint" xml:space="preserve">
-    <value>当前数据目录 '{0}' 包含了一个或多个重新分析点（Reparse points），可能会导致部分依赖数据文件夹的功能无法正常工作，请前往设置更改路径</value>
+    <value>Thư mục dữ liệu hiện tại '{0}' chứa một hoặc nhiều điểm tái phân tích (Reparse points), có thể khiến một số tính năng phụ thuộc vào thư mục dữ liệu không hoạt động bình thường, vui lòng vào cài đặt để đổi đường dẫn</value> 
   </data>
   <data name="ViewModelUIGFExportError" xml:space="preserve">
-    <value>导出失败</value>
+    <value>Xuất thất bại</value> 
   </data>
   <data name="ViewModelUIGFExportSuccess" xml:space="preserve">
-    <value>导出成功</value>
+    <value>Xuất thành công</value> 
   </data>
   <data name="ViewModelUIGFImportDuplicatedHk4eEntry" xml:space="preserve">
-    <value>导入的 UIGF 文件中包含 UID 重复的祈愿记录项</value>
+    <value>Tệp UIGF nhập vào có chứa bản ghi Cầu Nguyện bị trùng UID</value> 
   </data>
   <data name="ViewModelUIGFImportError" xml:space="preserve">
-    <value>导入失败</value>
+    <value>Nhập thất bại</value> 
   </data>
   <data name="ViewModelUIGFImportNoHk4eEntry" xml:space="preserve">
-    <value>导入的 UIGF 文件中不包含祈愿数据</value>
+    <value>Tệp UIGF nhập vào không chứa dữ liệu Cầu Nguyện</value> 
   </data>
   <data name="ViewModelUIGFImportNoSelectedEntry" xml:space="preserve">
-    <value>请选择至少一个 UID 以导入数据</value>
+    <value>Vui lòng chọn ít nhất một UID để nhập dữ liệu</value> 
   </data>
   <data name="ViewModelUIGFImportSuccess" xml:space="preserve">
-    <value>导入成功</value>
+    <value>Nhập thành công</value> 
   </data>
   <data name="ViewModelUIGFImportingProgressTitle" xml:space="preserve">
-    <value>导入中</value>
+    <value>Đang nhập</value> 
   </data>
   <data name="ViewModelUserAdded" xml:space="preserve">
-    <value>用户 [{0}] 添加成功</value>
+    <value>Người dùng [{0}] thêm thành công</value> 
   </data>
   <data name="ViewModelUserCookieCopied" xml:space="preserve">
-    <value>用户 [{0}] 的 Cookie 复制成功</value>
+    <value>Sao chép Cookie của người dùng [{0}] thành công</value> 
   </data>
   <data name="ViewModelUserEmptyGameRole" xml:space="preserve">
-    <value>此账号尚未绑定原神游戏角色</value>
+    <value>Tài khoản này chưa liên kết với nhân vật Genshin Impact</value> 
   </data>
   <data name="ViewModelUserIncomplete" xml:space="preserve">
-    <value>此 Cookie 不完整，操作失败</value>
+    <value>Cookie này không hoàn chỉnh, thao tác thất bại</value> 
   </data>
   <data name="ViewModelUserInvalid" xml:space="preserve">
-    <value>此 Cookie 无效，操作失败</value>
+    <value>Cookie này không hợp lệ, thao tác thất bại</value> 
   </data>
   <data name="ViewModelUserRemoved" xml:space="preserve">
-    <value>用户 [{0}] 成功移除</value>
+    <value>Đã gỡ bỏ người dùng [{0}]</value> 
   </data>
   <data name="ViewModelUserUpdated" xml:space="preserve">
-    <value>用户 [{0}] 的 Cookie 更新成功</value>
+    <value>Cập nhật Cookie của người dùng [{0}] thành công</value> 
   </data>
   <data name="ViewModelViewDisposedOperationCancel" xml:space="preserve">
-    <value>页面资源已经被释放，操作取消</value>
+    <value>Tài nguyên trang đã bị giải phóng, thao tác bị hủy</value> 
   </data>
   <data name="ViewModelWikiAvatarStrategyNotFound" xml:space="preserve">
-    <value>暂无该角色的攻略信息</value>
+    <value>Tạm chưa có hướng dẫn (strategy) của nhân vật này</value> 
   </data>
   <data name="ViewModelYaeProcessNotElevatedDescription" xml:space="preserve">
-    <value>Embedded Yae 需要管理员权限以启动并加载到游戏</value>
+    <value>Embedded Yae cần quyền quản trị viên để khởi chạy và tải vào game</value> 
   </data>
   <data name="ViewModelYaeProcessNotElevatedTitle" xml:space="preserve">
-    <value>进程权限不足</value>
+    <value>Không đủ quyền tiến trình</value> 
   </data>
   <data name="ViewOverlayDisableShowDamageTextToolTip" xml:space="preserve">
-    <value>移除战斗伤害跳字</value>
+    <value>Ẩn sát thương khi chiến đấu</value> 
   </data>
   <data name="ViewOverlayLaunchGameHideQuestBannerToolTip" xml:space="preserve">
-    <value>移除地图界面任务提示</value>
+    <value>Gỡ bỏ nhắc nhở nhiệm vụ giao diện bản đồ</value> 
   </data>
   <data name="ViewPageAchievementAddArchive" xml:space="preserve">
-    <value>创建新存档</value>
+    <value>Tạo bản lưu mới</value> 
   </data>
   <data name="ViewPageAchievementAddArchiveHint" xml:space="preserve">
-    <value>创建新存档以继续</value>
+    <value>Tạo bản lưu mới để tiếp tục</value> 
   </data>
   <data name="ViewPageAchievementExportLabel" xml:space="preserve">
-    <value>导出</value>
+    <value>Xuất</value> 
   </data>
   <data name="ViewPageAchievementFilterDailyQuestItems" xml:space="preserve">
-    <value>仅委托成就</value>
+    <value>Chỉ tính Thành Tựu Ủy Thác</value> 
   </data>
   <data name="ViewPageAchievementImportFromClipboard" xml:space="preserve">
-    <value>从剪贴板导入</value>
+    <value>Nhập từ bộ nhớ tạm</value> 
   </data>
   <data name="ViewPageAchievementImportFromEmbeddedYae" xml:space="preserve">
-    <value>通过 Embedded Yae 从游戏内导入</value>
+    <value>Nhập từ game qua Embedded Yae</value> 
   </data>
   <data name="ViewPageAchievementImportFromFile" xml:space="preserve">
-    <value>从 UIAF 文件导入</value>
+    <value>Nhập từ tệp UIAF</value> 
   </data>
   <data name="ViewPageAchievementImportLabel" xml:space="preserve">
-    <value>导入</value>
+    <value>Nhập</value> 
   </data>
   <data name="ViewPageAchievementRemoveArchive" xml:space="preserve">
-    <value>删除当前存档</value>
+    <value>Xóa bản lưu hiện tại</value> 
   </data>
   <data name="ViewPageAchievementSearchPlaceholder" xml:space="preserve">
-    <value>搜索成就名称，描述，版本或编号</value>
+    <value>Tìm kiếm tên, mô tả, phiên bản hoặc ID Thành Tựu</value> 
   </data>
   <data name="ViewPageAchievementSortIncompletedItemsFirst" xml:space="preserve">
-    <value>优先未完成</value>
+    <value>Ưu tiên chưa hoàn thành</value> 
   </data>
   <data name="ViewPageAnnouncementRedeemCodeCopySucceed" xml:space="preserve">
-    <value>兑换码复制成功</value>
+    <value>Sao chép Mã Đổi Thưởng thành công</value> 
   </data>
   <data name="ViewPageAnnouncementRedeemCodeLabel" xml:space="preserve">
-    <value>前瞻直播兑换码</value>
+    <value>Mã Đổi Thưởng Livestream</value> 
   </data>
   <data name="ViewPageAnnouncementViewDetails" xml:space="preserve">
-    <value>查看详情</value>
+    <value>Xem chi tiết</value> 
   </data>
   <data name="ViewPageAvatarPropertyCalculateAll" xml:space="preserve">
-    <value>所有角色与武器</value>
+    <value>Tất cả nhân vật và vũ khí</value> 
   </data>
   <data name="ViewPageAvatarPropertyCalculateCurrent" xml:space="preserve">
-    <value>当前角色与武器</value>
+    <value>Nhân vật và vũ khí hiện tại</value> 
   </data>
   <data name="ViewPageAvatarPropertyCalculatePart" xml:space="preserve">
-    <value>部分角色与武器</value>
+    <value>Một số nhân vật và vũ khí</value> 
   </data>
   <data name="ViewPageAvatarPropertyDefaultDescription" xml:space="preserve">
-    <value>尚未获取任何角色信息</value>
+    <value>Chưa lấy bất kỳ thông tin nhân vật nào</value> 
   </data>
   <data name="ViewPageAvatarPropertyExportToTextLabel" xml:space="preserve">
-    <value>导出文本到剪贴板</value>
+    <value>Xuất văn bản vào bộ nhớ tạm</value> 
   </data>
   <data name="ViewPageAvatarPropertyHeader" xml:space="preserve">
-    <value>角色属性</value>
+    <value>Thuộc tính nhân vật</value> 
   </data>
   <data name="ViewPageAvatarPropertyRefreshAction" xml:space="preserve">
-    <value>同步</value>
+    <value>Đồng bộ</value> 
   </data>
   <data name="ViewPageAvatarPropertyRefreshFromHoyolabGameRecord" xml:space="preserve">
-    <value>从米游社原神战绩同步</value>
+    <value>Đồng bộ từ Chiến tích Genshin HoyoLAB</value> 
   </data>
   <data name="ViewPageCultivateCalculate" xml:space="preserve">
-    <value>养成计算</value>
+    <value>Tính toán bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationAddProject" xml:space="preserve">
-    <value>新建计划</value>
+    <value>Tạo kế hoạch</value> 
   </data>
   <data name="ViewPageCultivationAddProjectAction" xml:space="preserve">
-    <value>新建</value>
+    <value>Tạo mới</value> 
   </data>
   <data name="ViewPageCultivationAddProjectContinue" xml:space="preserve">
-    <value>新建养成计划以继续</value>
+    <value>Tạo mới kế hoạch bồi dưỡng để tiếp tục</value> 
   </data>
   <data name="ViewPageCultivationAddProjectDescription" xml:space="preserve">
-    <value>稍后可以前往其他页面添加养成计划项</value>
+    <value>Lát nữa có thể sang trang khác để thêm mục kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationAvatarPropertyDescription" xml:space="preserve">
-    <value>添加我的角色与武器到养成计划</value>
+    <value>Thêm nhân vật và vũ khí của tôi vào kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationClearInventory" xml:space="preserve">
-    <value>清空背包物品</value>
+    <value>Xóa vật phẩm trong ba lô</value> 
   </data>
   <data name="ViewPageCultivationCultivateEntry" xml:space="preserve">
-    <value>养成物品</value>
+    <value>Vật phẩm bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationInventoryItem" xml:space="preserve">
-    <value>背包物品</value>
+    <value>Vật phẩm ba lô</value> 
   </data>
   <data name="ViewPageCultivationMaterialList" xml:space="preserve">
-    <value>材料清单</value>
+    <value>Danh sách nguyên liệu</value> 
   </data>
   <data name="ViewPageCultivationMaterialListIncompleteFirstLabel" xml:space="preserve">
-    <value>未集齐优先</value>
+    <value>Ưu tiên chưa thu thập đủ</value> 
   </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
-    <value>树脂预估</value>
+    <value>Nhựa Hiện Có</value> 
   </data>
   <data name="ViewPageCultivationMaterialListWorldLevelTitle" xml:space="preserve">
-    <value>世界等级</value>
+    <value>Cấp Thế Giới</value> 
   </data>
   <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
-    <value>材料统计</value>
+    <value>Thống kê nguyên liệu</value> 
   </data>
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
-    <value>前往</value>
+    <value>Đi Tới</value> 
   </data>
   <data name="ViewPageCultivationRefreshInventory" xml:space="preserve">
-    <value>同步背包物品</value>
+    <value>Đồng bộ vật phẩm ba lô</value> 
   </data>
   <data name="ViewPageCultivationRefreshInventoryByCalculator" xml:space="preserve">
-    <value>通过养成计算器同步</value>
+    <value>Đồng bộ thông qua Máy tính bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationRefreshInventoryByEmbeddedYae" xml:space="preserve">
-    <value>通过 Embedded Yae 同步</value>
+    <value>Đồng bộ qua Embedded Yae</value> 
   </data>
   <data name="ViewPageCultivationRemoveEntry" xml:space="preserve">
-    <value>删除清单</value>
+    <value>Xóa danh sách</value> 
   </data>
   <data name="ViewPageCultivationRemoveProject" xml:space="preserve">
-    <value>删除当前计划</value>
+    <value>Xóa kế hoạch hiện tại</value> 
   </data>
   <data name="ViewPageCultivationResinEstimation" xml:space="preserve">
-    <value>树脂预估</value>
+    <value>Dự tính Nhựa</value> 
   </data>
   <data name="ViewPageCultivationResinWorldLevel" xml:space="preserve">
-    <value>世界等级</value>
+    <value>Cấp Thế Giới</value> 
   </data>
   <data name="ViewPageCultivationResinBlossomOfWealth" xml:space="preserve">
-    <value>藏金之花</value>
+    <value>Hoa Tàng Kim</value> 
   </data>
   <data name="ViewPageCultivationResinTalentDomain" xml:space="preserve">
-    <value>角色天赋素材</value>
+    <value>Nguyên Liệu Thiên Phú Nhân Vật</value> 
   </data>
   <data name="ViewPageCultivationResinWorldBoss" xml:space="preserve">
-    <value>世界 BOSS</value>
+    <value>BOSS Thế giới</value> 
   </data>
   <data name="ViewPageCultivationResinWeeklyBoss" xml:space="preserve">
-    <value>周常 BOSS</value>
+    <value>BOSS Tuần</value> 
   </data>
   <data name="ViewPageCultivationWikiAvatarDescription" xml:space="preserve">
-    <value>添加任意角色到养成计划</value>
+    <value>Thêm bất kỳ nhân vật nào vào kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationWikiWeaponDescription" xml:space="preserve">
-    <value>添加任意武器到养成计划</value>
+    <value>Thêm bất kỳ vũ khí nào vào kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationMyAvatarHeader" xml:space="preserve">
-    <value>我的角色</value>
+    <value>Nhân vật của tôi</value> 
   </data>
   <data name="ViewPageCultivationMyAvatarDescription" xml:space="preserve">
-    <value>从米游社同步角色与武器到养成计划</value>
+    <value>Đồng bộ nhân vật và vũ khí từ HoyoLAB vào kế hoạch bồi dưỡng</value> 
   </data>
   <data name="ViewPageCultivationSyncAllAvatarsAndWeapons" xml:space="preserve">
-    <value>同步所有角色与武器</value>
+    <value>Đồng bộ toàn bộ nhân vật và vũ khí</value> 
   </data>
   <data name="ViewPageCultivationSyncAllAvatars" xml:space="preserve">
-    <value>所有角色</value>
+    <value>Tất cả nhân vật</value> 
   </data>
   <data name="ViewPageCultivationSyncAllWeapons" xml:space="preserve">
-    <value>所有武器</value>
+    <value>Tất cả vũ khí</value> 
   </data>
   <data name="ViewPageCultivationMyAvatars" xml:space="preserve">
-    <value>我的角色</value>
+    <value>Nhân vật của tôi</value> 
   </data>
   <data name="ViewPageCultivationSyncInventoryToAllProjects" xml:space="preserve">
-    <value>背包同步影响所有计划</value>
+    <value>Đồng bộ ba lô sẽ ảnh hưởng tất cả kế hoạch</value> 
   </data>
   <data name="ViewPageCultivationFilterEntries" xml:space="preserve">
-    <value>筛选养成物品</value>
+    <value>Lọc vật phẩm bồi dưỡng</value> 
   </data>
   <data name="ViewPageDailyNoteAddEntry" xml:space="preserve">
-    <value>添加实时便笺</value>
+    <value>Thêm Ghi chú thời gian thực</value> 
   </data>
   <data name="ViewPageDailyNoteAttendanceStatusInfo" xml:space="preserve">
-    <value>历练点获取详情</value>
+    <value>Chi tiết nhận Điểm Rèn Luyện</value> 
   </data>
   <data name="ViewPageDailyNoteConfigWebhookDescription" xml:space="preserve">
-    <value>在实时便笺刷新后推送到指定的 Webhook</value>
+    <value>Đẩy thông báo tới Webhook đã chỉ định sau khi làm mới Ghi chú</value> 
   </data>
   <data name="ViewPageDailyNoteConfigWebhookHeader" xml:space="preserve">
-    <value>配置 Webhook</value>
+    <value>Cấu hình Webhook</value> 
   </data>
   <data name="ViewPageDailyNoteDataInteropHeader" xml:space="preserve">
-    <value>数据互操作</value>
+    <value>Khả năng tương tác dữ liệu</value> 
   </data>
   <data name="ViewPageDailyNoteNotificationHeader" xml:space="preserve">
-    <value>通知</value>
+    <value>Thông báo</value> 
   </data>
   <data name="ViewPageDailyNoteNotificationSetting" xml:space="preserve">
-    <value>通知设置</value>
+    <value>Cài đặt Thông báo</value> 
   </data>
   <data name="ViewPageDailyNoteNotificationUnavailableHint" xml:space="preserve">
-    <value>的通知权限已被关闭</value>
+    <value>Quyền thông báo của ứng dụng đã bị tắt</value> 
   </data>
   <data name="ViewPageDailyNoteRefresh" xml:space="preserve">
-    <value>立即刷新</value>
+    <value>Làm mới ngay</value> 
   </data>
   <data name="ViewPageDailyNoteRefreshTime" xml:space="preserve">
-    <value>刷新间隔时间</value>
+    <value>Khoảng thời gian làm mới</value> 
   </data>
   <data name="ViewPageDailyNoteReminderDescription" xml:space="preserve">
-    <value>防止通知自动收入操作中心</value>
+    <value>Tránh để thông báo tự động thu gọn vào Action Center</value> 
   </data>
   <data name="ViewPageDailyNoteReminderHeader" xml:space="preserve">
-    <value>提醒通知</value>
+    <value>Thông báo Nhắc nhở</value> 
   </data>
   <data name="ViewPageDailyNoteRemoveToolTip" xml:space="preserve">
-    <value>移除角色</value>
+    <value>Xóa nhân vật</value> 
   </data>
   <data name="ViewPageDailyNoteResinDiscountUsed" xml:space="preserve">
-    <value>本周已消耗减半次数</value>
+    <value>Số lần giảm nửa đã dùng tuần này</value> 
   </data>
   <data name="ViewPageDailyNoteSettingAutoRefresh" xml:space="preserve">
-    <value>自动刷新</value>
+    <value>Tự động làm mới</value> 
   </data>
   <data name="ViewPageDailyNoteSettingAutoRefreshDescription" xml:space="preserve">
-    <value>间隔选定的时间后刷新添加的实时便笺</value>
+    <value>Sau khoảng thời gian đã chọn, làm mới các Ghi chú thời gian thực đã thêm</value> 
   </data>
   <data name="ViewPageDailyNoteSettingRefreshHeader" xml:space="preserve">
-    <value>刷新</value>
+    <value>Làm mới</value> 
   </data>
   <data name="ViewPageDailyNoteSettingRefreshNotifyIconFailedToCreateHint" xml:space="preserve">
-    <value>通知区域图标创建失败，关闭窗口后自动刷新将不会执行</value>
+    <value>Không thể tạo biểu tượng khu vực thông báo, tự động làm mới sẽ không hoạt động sau khi đóng cửa sổ</value> 
   </data>
   <data name="ViewPageDailyNoteSilentModeDescription" xml:space="preserve">
-    <value>在我游玩原神时不通知我</value>
+    <value>Đừng làm phiền khi tôi đang chơi Genshin Impact</value> 
   </data>
   <data name="ViewPageDailyNoteSilentModeHeader" xml:space="preserve">
-    <value>免打扰模式</value>
+    <value>Chế độ Không Làm Phiền</value> 
   </data>
   <data name="ViewPageDailyNoteStartGameToolTip" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value> 
   </data>
   <data name="ViewPageDailyNoteStoredAttendance" xml:space="preserve">
-    <value>长效历练点</value>
+    <value>Điểm Rèn Luyện Dài Hạn</value> 
   </data>
   <data name="ViewPageDailyNoteVerify" xml:space="preserve">
-    <value>验证当前用户与角色</value>
+    <value>Xác minh người dùng và nhân vật hiện tại</value> 
   </data>
   <data name="ViewPageDailyNoteWeekActiveProgress" xml:space="preserve">
-    <value>砺行修远</value>
+    <value>Rèn Luyện Tiến Bước</value> 
   </data>
   <data name="ViewPageFeedbackAutoSuggestBoxPlaceholder" xml:space="preserve">
-    <value>搜索问题与建议</value>
+    <value>Tìm kiếm vấn đề và góp ý</value> 
   </data>
   <data name="ViewPageFeedbackCommonLinksHeader" xml:space="preserve">
-    <value>常用链接</value>
+    <value>Liên kết thường dùng</value> 
   </data>
   <data name="ViewPageFeedbackCurrentProxyHeader" xml:space="preserve">
-    <value>当前代理</value>
+    <value>Proxy hiện tại</value> 
   </data>
   <data name="ViewPageFeedbackCurrentProxyNoProxyDescription" xml:space="preserve">
-    <value>无代理</value>
+    <value>Không dùng Proxy</value> 
   </data>
   <data name="ViewPageFeedbackEnableLoopbackEnabledDescription" xml:space="preserve">
-    <value>已解除</value>
+    <value>Đã gỡ bỏ</value> 
   </data>
   <data name="ViewPageFeedbackEnableLoopbackHeader" xml:space="preserve">
-    <value>解除 Loopback 限制</value>
+    <value>Gỡ bỏ giới hạn Loopback</value> 
   </data>
   <data name="ViewPageFeedbackEngageWithUsDescription" xml:space="preserve">
-    <value>与我们密切联系</value>
+    <value>Kết nối chặt chẽ với chúng tôi</value> 
   </data>
   <data name="ViewPageFeedbackFeatureGuideHeader" xml:space="preserve">
-    <value>功能指南</value>
+    <value>Hướng dẫn tính năng</value> 
   </data>
   <data name="ViewPageFeedbackGithubIssuesDescription" xml:space="preserve">
-    <value>我们总是优先处理 GitHub 上的问题</value>
+    <value>Chúng tôi luôn ưu tiên xử lý các Issue trên GitHub</value> 
   </data>
   <data name="ViewPageFeedbackSearchResultPlaceholderTitle" xml:space="preserve">
-    <value>暂无搜索结果</value>
+    <value>Tạm chưa có kết quả tìm kiếm</value> 
   </data>
   <data name="ViewPageFeedbackServerStatusDescription" xml:space="preserve">
-    <value>服务可用性监控</value>
+    <value>Theo dõi độ khả dụng dịch vụ</value> 
   </data>
   <data name="ViewPageFeedbackServerStatusHeader" xml:space="preserve">
-    <value>服务</value>
+    <value>Dịch vụ</value> 
   </data>
   <data name="ViewPageGachaLogAggressiveRefresh" xml:space="preserve">
-    <value>全量刷新</value>
+    <value>Làm mới toàn bộ</value> 
   </data>
   <data name="ViewPageGachaLogHint" xml:space="preserve">
-    <value>尚未获取任何祈愿记录</value>
+    <value>Chưa lấy bất kỳ lịch sử Cầu Nguyện nào</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloud" xml:space="preserve">
-    <value>云</value>
+    <value>Đám mây</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudAfdianPurchaseDescription" xml:space="preserve">
-    <value>前往爱发电购买相关服务</value>
+    <value>Tới Afdian mua dịch vụ liên quan</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudAfdianPurchaseHeader" xml:space="preserve">
-    <value>购买 / 续费云服务</value>
+    <value>Mua / Gia hạn dịch vụ đám mây (Cloud)</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudDelete" xml:space="preserve">
-    <value>删除此 UID 的云端存档</value>
+    <value>Xóa bản lưu đám mây của UID này</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudDeveloperHint" xml:space="preserve">
-    <value>开发者账号无视服务到期时间</value>
+    <value>Tài khoản nhà phát triển không bị giới hạn thời gian dịch vụ</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudNoEntryHint" xml:space="preserve">
-    <value>无云端记录</value>
+    <value>Không có lịch sử trên đám mây</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudNotAllowed" xml:space="preserve">
-    <value>云服务时长不足</value>
+    <value>Thời hạn dịch vụ đám mây không đủ</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudRetrieve" xml:space="preserve">
-    <value>下载此 UID 的云端存档</value>
+    <value>Tải xuống bản lưu đám mây của UID này</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudSpiralAbyssActivityDescription" xml:space="preserve">
-    <value>每期深渊首次上传可免费获得 3 天时长</value>
+    <value>Tải lên La Hoàn lần đầu mỗi kỳ có thể nhận miễn phí 3 ngày</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudSpiralAbyssActivityHeader" xml:space="preserve">
-    <value>上传深渊记录</value>
+    <value>Tải lên lịch sử La Hoàn</value> 
   </data>
   <data name="ViewPageGachaLogLauncherCloudUpload" xml:space="preserve">
-    <value>上传当前的祈愿存档</value>
+    <value>Tải lên bản lưu Cầu Nguyện hiện tại</value> 
   </data>
   <data name="ViewPageGachaLogImportAction" xml:space="preserve">
-    <value>导入</value>
+    <value>Nhập</value> 
   </data>
   <data name="ViewPageGachaLogImportDescription" xml:space="preserve">
-    <value>导入来自其它 App 的数据</value>
+    <value>Nhập dữ liệu từ Ứng dụng khác</value> 
   </data>
   <data name="ViewPageGachaLogImportExportAction" xml:space="preserve">
-    <value>导入/导出记录</value>
+    <value>Nhập/Xuất bản ghi</value> 
   </data>
   <data name="ViewPageGachaLogImportHeader" xml:space="preserve">
-    <value>导入 UIGF Json</value>
+    <value>Nhập JSON UIGF</value> 
   </data>
   <data name="ViewPageGachaLogInputAction" xml:space="preserve">
-    <value>输入</value>
+    <value>Nhập vào</value> 
   </data>
   <data name="ViewPageGachaLogOrangeAvatarCountdown" xml:space="preserve">
-    <value>五星角色</value>
+    <value>Nhân vật 5 Sao</value> 
   </data>
   <data name="ViewPageGachaLogOrangeWeaponCountdown" xml:space="preserve">
-    <value>五星武器</value>
+    <value>Vũ khí 5 Sao</value> 
   </data>
   <data name="ViewPageGachaLogPivotAvatar" xml:space="preserve">
-    <value>角色</value>
+    <value>Nhân vật</value> 
   </data>
   <data name="ViewPageGachaLogPivotCountdown" xml:space="preserve">
-    <value>计时</value>
+    <value>Đếm ngược</value> 
   </data>
   <data name="ViewPageGachaLogPivotHistory" xml:space="preserve">
-    <value>历史</value>
+    <value>Lịch sử</value> 
   </data>
   <data name="ViewPageGachaLogPivotOverview" xml:space="preserve">
-    <value>总览</value>
+    <value>Tổng quan</value> 
   </data>
   <data name="ViewPageGachaLogPivotWeapon" xml:space="preserve">
-    <value>武器</value>
+    <value>Vũ khí</value> 
   </data>
   <data name="ViewPageGachaLogPurpleAvatarCountdown" xml:space="preserve">
-    <value>四星角色</value>
+    <value>Nhân vật 4 Sao</value> 
   </data>
   <data name="ViewPageGachaLogPurpleWeaponCountdown" xml:space="preserve">
-    <value>四星武器</value>
+    <value>Vũ khí 4 Sao</value> 
   </data>
   <data name="ViewPageGachaLogCountdownSearchPlaceholder" xml:space="preserve">
-    <value>搜索角色/武器</value>
+    <value>Tìm kiếm nhân vật/vũ khí</value> 
   </data>
   <data name="ViewPageGachaLogRecoverFromLauncherCloudDescription" xml:space="preserve">
-    <value>从云恢复祈愿记录</value>
+    <value>Khôi phục lịch sử Cầu Nguyện từ đám mây</value> 
   </data>
   <data name="ViewPageGachaLogRefresh" xml:space="preserve">
-    <value>刷新</value>
+    <value>Làm mới</value> 
   </data>
   <data name="ViewPageGachaLogRefreshAction" xml:space="preserve">
-    <value>获取</value>
+    <value>Lấy</value> 
   </data>
   <data name="ViewPageGachaLogRefreshByManualInput" xml:space="preserve">
-    <value>手动输入 URL</value>
+    <value>Nhập URL thủ công</value> 
   </data>
   <data name="ViewPageGachaLogRefreshByManualInputDescription" xml:space="preserve">
-    <value>使用由你提供的 URL 刷新祈愿记录</value>
+    <value>Sử dụng URL do bạn cung cấp để làm mới lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ViewPageGachaLogRefreshBySToken" xml:space="preserve">
-    <value>SToken 刷新</value>
+    <value>Làm mới bằng SToken</value> 
   </data>
   <data name="ViewPageGachaLogRefreshBySTokenDescription" xml:space="preserve">
-    <value>使用当前用户的 Cookie 信息刷新祈愿记录</value>
+    <value>Sử dụng thông tin Cookie của người dùng hiện tại để làm mới lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ViewPageGachaLogRefreshByWebCache" xml:space="preserve">
-    <value>网页缓存刷新</value>
+    <value>Làm mới bằng Cache Web</value> 
   </data>
   <data name="ViewPageGachaLogRefreshByWebCacheDescription" xml:space="preserve">
-    <value>使用游戏内浏览器的网页缓存刷新祈愿记录</value>
+    <value>Sử dụng cache trình duyệt tích hợp trong game để làm mới lịch sử Cầu Nguyện</value> 
   </data>
-<data name="ViewPageGachaLogRefreshByLogFile" xml:space="preserve">
-    <value>获取抽卡链接</value>
+  <data name="ViewPageGachaLogRefreshByLogFile" xml:space="preserve">
+    <value>Lấy link Cầu Nguyện</value> 
   </data>
   <data name="ViewPageGachaLogRefreshByLogFileDescription" xml:space="preserve">
-    <value>自动从游戏日志定位缓存获取祈愿链接并复制到剪贴板</value>
+    <value>Tự động xác định định vị cache từ nhật ký game để lấy liên kết Cầu Nguyện và sao chép vào bộ nhớ tạm</value> 
   </data>
   <data name="ViewPageGachaLogRemoveArchiveAction" xml:space="preserve">
-    <value>删除当前存档</value>
+    <value>Xóa bản lưu hiện tại</value> 
   </data>
   <data name="ViewPageGachaLogSelectArchivePlaceholder" xml:space="preserve">
-    <value>选择存档</value>
+    <value>Chọn bản lưu</value> 
   </data>
   <data name="ViewPageGachaLogLazyRefresh" xml:space="preserve">
-    <value>懒加载</value>
+    <value>Lazy Load</value> 
   </data>
   <data name="ViewPageGachaLogExportAction" xml:space="preserve">
-    <value>导出</value>
+    <value>Xuất</value> 
   </data>
   <data name="ViewPageGachaLogAvatarWishOrangeHistory" xml:space="preserve">
-    <value>角色活动祈愿 · 五星历史</value>
+    <value>Cầu Nguyện Sự Kiện Nhân Vật · Lịch sử 5 Sao</value> 
   </data>
   <data name="ViewPageGachaLogWeaponWishOrangeHistory" xml:space="preserve">
-    <value>武器活动祈愿 · 五星历史</value>
+    <value>Cầu Nguyện Sự Kiện Vũ Khí · Lịch sử 5 Sao</value> 
   </data>
   <data name="ViewPageHardChallengeNotEngaged" xml:space="preserve">
-    <value>您暂未参与本次关卡哦</value>
+    <value>Bạn chưa tham gia ải này</value> 
   </data>
   <data name="ViewPageHardChallengeTime" xml:space="preserve">
-    <value>战斗用时</value>
+    <value>Thời gian chiến đấu</value> 
   </data>
   <data name="ViewPageHomeGreetingTextCommon1" xml:space="preserve">
-    <value>已经为你启动了 {0} 次游戏</value>
+    <value>Đã khởi động game {0} lần cho bạn</value> 
   </data>
   <data name="ViewPageHomeGreetingTextCommon2" xml:space="preserve">
-    <value>你已经启动了 Manjusaka {0} 次</value>
+    <value>Bạn đã khởi động Manjusaka {0} lần</value> 
   </data>
   <data name="ViewPageHomeGreetingTextDefault" xml:space="preserve">
-    <value>旅行者，欢迎来到提瓦特大陆！</value>
+    <value>Nhà Lữ Hành, chào mừng đến với Lục Địa Teyvat!</value> 
   </data>
   <data name="ViewPageHomeGreetingTextEasterEgg" xml:space="preserve">
-    <value>你说的对，但是《》是由 DGP Studio 自主研发的一款...</value>
+    <value>Bạn nói đúng, nhưng &lt;&lt;...&gt;&gt; là một trò chơi do DGP Studio tự nghiên cứu và phát triển...</value> 
   </data>
   <data name="ViewPageHomeGreetingTextEpic1" xml:space="preserve">
-    <value>呐，旅行者，这是你来到提瓦特大陆的第 {0} 天哦</value>
+    <value>Này Nhà Lữ Hành, đây là ngày thứ {0} bạn đến Teyvat đó nha</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverview" xml:space="preserve">
-    <value>详情</value>
+    <value>Chi tiết</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewAvatarAppearanceRank" xml:space="preserve">
-    <value>角色出场</value>
+    <value>Nhân vật ra trận</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewAvatarConstellation" xml:space="preserve">
-    <value>角色持有</value>
+    <value>Sở hữu nhân vật</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewAvatarUsageRank" xml:space="preserve">
-    <value>角色使用</value>
+    <value>Sử dụng nhân vật</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation0" xml:space="preserve">
-    <value>0 命</value>
+    <value>C0</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation1" xml:space="preserve">
-    <value>1 命</value>
+    <value>C1</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation2" xml:space="preserve">
-    <value>2 命</value>
+    <value>C2</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation3" xml:space="preserve">
-    <value>3 命</value>
+    <value>C3</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation4" xml:space="preserve">
-    <value>4 命</value>
+    <value>C4</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation5" xml:space="preserve">
-    <value>5 命</value>
+    <value>C5</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellation6" xml:space="preserve">
-    <value>6 命</value>
+    <value>C6</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellationAvatar" xml:space="preserve">
-    <value>角色</value>
+    <value>Nhân vật</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewConstellationHolding" xml:space="preserve">
-    <value>持有</value>
+    <value>Đã Sở hữu</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewDataCollect" xml:space="preserve">
-    <value>数据收集统计</value>
+    <value>Thống kê thu thập dữ liệu</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewRecordTotal" xml:space="preserve">
-    <value>上传记录总数</value>
+    <value>Tổng số bản ghi đã tải lên</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewRefreshTime" xml:space="preserve">
-    <value>数据刷新时间</value>
+    <value>Thời gian làm mới dữ liệu</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyss" xml:space="preserve">
-    <value>深渊数据统计</value>
+    <value>Thống kê dữ liệu La Hoàn</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssBattleAverage" xml:space="preserve">
-    <value>平均战斗次数</value>
+    <value>Số lần chiến đấu trung bình</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssFullStar" xml:space="preserve">
-    <value>满星深渊记录</value>
+    <value>Số lần Max Sao Uyên Tinh La Hoàn</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssPassed" xml:space="preserve">
-    <value>通关深渊记录</value>
+    <value>Số lần vượt qua La Hoàn</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssStarAverage" xml:space="preserve">
-    <value>平均获取渊星</value>
+    <value>Trung bình Sao La Hoàn nhận được</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssTotal" xml:space="preserve">
-    <value>总计深渊记录</value>
+    <value>Tổng cộng bản ghi La Hoàn</value> 
   </data>
   <data name="ViewPageLauncherDatabaseOverviewTeamAppearance" xml:space="preserve">
-    <value>队伍出场</value>
+    <value>Đội ra trận</value> 
   </data>
   <data name="ViewPageLauncherPassportCDNCloudDescription" xml:space="preserve">
-    <value>获得时长后您将能够在版本更新时选择中国国内的 CDN 镜像，以获得更好的更新体验。</value>
+    <value>Sau khi có thời gian dịch vụ, bạn có thể chọn Mirror CDN nội địa Trung Quốc khi cập nhật phiên bản để có trải nghiệm tốt hơn.</value> 
   </data>
   <data name="ViewPageLauncherPassportCDNCloudHeader" xml:space="preserve">
-    <value>云 CDN 服务</value>
+    <value>Dịch vụ Cloud CDN</value> 
   </data>
   <data name="ViewPageLauncherPassportGachaLogCloudDescription" xml:space="preserve">
-    <value>获得时长后您将能够通过我们的服务器下载/上传/删除最多 5 个 UID 的祈愿记录。深境螺旋页面中，每期挑战首次上传记录时会获得免费的时长！</value>
+    <value>Sau khi có thời gian dịch vụ, bạn có thể tải xuống/tải lên/xóa lịch sử Cầu Nguyện cho tối đa 5 UID qua máy chủ của chúng tôi. Lần đầu tải lên ở giao diện La Hoàn Thâm Cảnh mỗi kỳ sẽ được tặng thời gian miễn phí!</value> 
   </data>
   <data name="ViewPageLauncherPassportGachaLogCloudHeader" xml:space="preserve">
-    <value>云祈愿记录服务</value>
+    <value>Dịch vụ Lịch sử Cầu Nguyện Cloud</value> 
   </data>
   <data name="ViewPageLauncherPassportNewUserNameHint" xml:space="preserve">
-    <value>请输入新邮箱</value>
+    <value>Vui lòng nhập email mới</value> 
   </data>
   <data name="ViewPageLauncherPassportPasswordHint" xml:space="preserve">
-    <value>请输入密码</value>
+    <value>Vui lòng nhập mật khẩu</value> 
   </data>
   <data name="ViewPageLauncherPassportPasswordRequirementHint" xml:space="preserve">
-    <value>至少需要 8 个字符</value>
+    <value>Cần ít nhất 8 ký tự</value> 
   </data>
   <data name="ViewPageLauncherPassportRedeemCodeHint" xml:space="preserve">
-    <value>请输入兑换码</value>
+    <value>Vui lòng nhập Mã Đổi Thưởng</value> 
   </data>
   <data name="ViewPageLauncherPassportSponsorAction" xml:space="preserve">
-    <value>赞助</value>
+    <value>Tài trợ</value> 
   </data>
   <data name="ViewPageLauncherPassportUnregisterHint" xml:space="preserve">
-    <value>注销账号的数据将永远丢失，无法恢复</value>
+    <value>Dữ liệu tài khoản bị hủy sẽ mất vĩnh viễn, không thể khôi phục</value> 
   </data>
   <data name="ViewPageLauncherPassportUserNameHint" xml:space="preserve">
-    <value>请输入邮箱</value>
+    <value>Vui lòng nhập email</value> 
   </data>
   <data name="ViewPageLauncherPassportVerifyCodeAction" xml:space="preserve">
-    <value>获取验证码</value>
+    <value>Nhận mã xác minh</value> 
   </data>
   <data name="ViewPageLauncherPassportVerifyCodeHint" xml:space="preserve">
-    <value>请输入验证码</value>
+    <value>Vui lòng nhập mã xác minh</value> 
   </data>
   <data name="ViewPageLaunchGameAction" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceAspectRatioDescription" xml:space="preserve">
-    <value>快速切换到指定的分辨率，启动游戏以保存当前分辨率</value>
+    <value>Chuyển đổi nhanh sang độ phân giải chỉ định, khởi động game để lưu độ phân giải hiện tại</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceAspectRatioHeader" xml:space="preserve">
-    <value>分辨率</value>
+    <value>Độ phân giải</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceAspectRatioPlaceHolder" xml:space="preserve">
-    <value>快捷设置分辨率</value>
+    <value>Cài nhanh độ phân giải</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceBorderlessDescription" xml:space="preserve">
-    <value>将窗口创建为弹出窗口，不带框架</value>
+    <value>Tạo cửa sổ dạng popup, không có khung viền</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceExclusiveDescription" xml:space="preserve">
-    <value>与游戏内浏览器不兼容，切屏等操作也能使游戏闪退</value>
+    <value>Không tương thích với trình duyệt web trong game, chuyển đổi cửa sổ có thể làm game bị crash</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceFullscreenDescription" xml:space="preserve">
-    <value>覆盖默认的全屏状态</value>
+    <value>Ghi đè trạng thái toàn màn hình mặc định</value> 
   </data>
   <data name="ViewPageLaunchGameAppearancePlatformTypeDescription" xml:space="preserve">
-    <value>选择平台类型，不同的类型会影响游戏如何呈现 UI</value>
+    <value>Chọn nền tảng, các loại khác nhau sẽ ảnh hưởng đến cách game render UI</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceScreenHeightDescription" xml:space="preserve">
-    <value>覆盖默认屏幕高度</value>
+    <value>Ghi đè chiều cao màn hình mặc định</value> 
   </data>
   <data name="ViewPageLaunchGameAppearanceScreenWidthDescription" xml:space="preserve">
-    <value>覆盖默认屏幕宽度</value>
+    <value>Ghi đè chiều rộng màn hình mặc định</value> 
   </data>
   <data name="ViewPageLaunchGameArgumentsDescription" xml:space="preserve">
-    <value>在游戏启动时修改其默认行为</value>
+    <value>Chỉnh sửa hành vi mặc định khi game khởi động</value> 
   </data>
   <data name="ViewPageLaunchGameArgumentsHeader" xml:space="preserve">
-    <value>启动参数</value>
+    <value>Tham số khởi động</value> 
   </data>
   <data name="ViewPageLaunchGameBetterGIDescription" xml:space="preserve">
-    <value>在游戏启动后尝试启动并使用 BetterGI 进行自动化任务</value>
+    <value>Thử khởi chạy và sử dụng BetterGI thực hiện tự động hóa sau khi game khởi động</value> 
   </data>
   <data name="ViewPageLaunchGameBetterGIHeader" xml:space="preserve">
-    <value>自动化任务</value>
+    <value>Tác vụ Tự động</value> 
   </data>
   <data name="ViewPageLaunchGameDangerousDescriptionHint" xml:space="preserve">
-    <value>本软件及插件功能属于《米哈游用户协议》第十条第二款规定的“插件、外挂或非经合法授权的第三方工具/服务”，您需要自行承担因使用内容而引起的所有风险，本软件无法且不会对您因前述风险而导致的任何损失或损害承担责任。
-出于安全因素考虑，我们有权不经向您特别通知而对软件及相关功能进行更新，或者对软件的部分功能效果进行改变或限制。</value>
+    <value>Phần mềm này và các chức năng plugin thuộc loại "Plugin, ngoại cảnh hoặc công cụ/dịch vụ của bên thứ ba
+     không được ủy quyền hợp pháp" theo Điều 10, Khoản 2 của "Thỏa thuận người dùng miHoYo". Bạn tự chịu mọi rủi ro do sử dụng và chúng tôi không chịu trách nhiệm về bất kỳ tổn thất hoặc thiệt hại nào do rủi ro nói trên.Vì lý do an toàn, chúng tôi có quyền cập nhật phần mềm và các chức năng liên quan mà không cần thông báo, hoặc thay đổi/hạn chế một số hiệu ứng chức năng phần mềm.</value> 
   </data>
   <data name="ViewPageLaunchGameDisableFogDescription" xml:space="preserve">
-    <value>移除光照渲染中的迷雾</value>
+    <value>Gỡ bỏ sương mù trong kết xuất ánh sáng</value> 
   </data>
   <data name="ViewPageLaunchGameDisableFogHeader" xml:space="preserve">
-    <value>移除迷雾</value>
+    <value>Xóa sương mù</value> 
   </data>
   <data name="ViewPageLaunchGameDisableFogOff" xml:space="preserve">
-    <value>保留</value>
+    <value>Giữ lại</value> 
   </data>
   <data name="ViewPageLaunchGameDisableFogOn" xml:space="preserve">
-    <value>移除</value>
+    <value>Gỡ bỏ</value> 
   </data>
   <data name="ViewPageLaunchGameElevationDescription" xml:space="preserve">
-    <value>游戏文件管理/切换游戏服务器需要管理员权限</value>
+    <value>Cần quyền quản trị viên để quản lý tệp game/chuyển đổi máy chủ</value> 
   </data>
   <data name="ViewPageLaunchGameEventCameraMoveHotSwitchHeader" xml:space="preserve">
-    <value>移除元素爆发镜头特写</value>
+    <value>Xóa hiệu ứng Cận cảnh Kỹ Năng Nộ (Q)</value> 
   </data>
   <data name="ViewPageLaunchGameFixLowFovSceneDescription" xml:space="preserve">
-    <value>修正角色/队伍配置/祈愿/纪行等特殊界面的视野</value>
+    <value>Sửa góc nhìn FOV của các giao diện đặc biệt như Nhân vật/Đội ngũ/Cầu Nguyện/Nhật Ký Hành Trình</value> 
   </data>
   <data name="ViewPageLaunchGameFixLowFovSceneHeader" xml:space="preserve">
-    <value>特殊界面修正</value>
+    <value>Chỉnh sửa giao diện đặc biệt</value> 
   </data>
   <data name="ViewPageLaunchGameFixLowFovSceneTeachingTipSubtitle" xml:space="preserve">
-    <value>启用「调整视野」后，所有场景下的迷雾显示将会遵循「移除迷雾」开关的状态。若同时启用了「特殊界面修正」，则会在原始视野小于等于 30 时，强制禁用迷雾渲染。这会让你看到正常的祈愿/纪行/角色等界面，但是在进入部分剧情时也会强制禁用迷雾。这不属于软件 BUG，不要向我们反馈。</value>
+    <value>Sau khi bật "Điều chỉnh tầm nhìn", hiển thị sương mù trong mọi cảnh sẽ tuân theo trạng thái của công tắc "Xóa sương mù". Nếu bật thêm "Chỉnh sửa giao diện đặc biệt", nó sẽ buộc tắt kết xuất sương mù khi tầm nhìn ban đầu nhỏ hơn hoặc bằng 30. Điều này giúp bạn thấy rõ giao diện Cầu Nguyện/Nhật Ký/Nhân vật bình thường, nhưng cũng sẽ buộc tắt sương mù trong một số cốt truyện. Đây không phải BUG phần mềm, xin đừng report cho chúng tôi.</value> 
   </data>
   <data name="ViewPageLaunchGameFixLowFovSceneTeachingTipTitle" xml:space="preserve">
-    <value>视野与迷雾</value>
+    <value>Tầm nhìn và Sương mù</value> 
   </data>
   <data name="ViewPageLaunchGameHideQuestBannerHotSwitchDescription" xml:space="preserve">
-    <value>强制移除地图界面左上角的任务提示</value>
+    <value>Buộc ẩn thanh thông báo nhiệm vụ góc trên bên trái ở màn hình bản đồ</value> 
   </data>
   <data name="ViewPageLaunchGameHideQuestBannerHotSwitchHeader" xml:space="preserve">
-    <value>关闭地图横幅</value>
+    <value>Đóng banner bản đồ</value> 
   </data>
   <data name="ViewPageLaunchGameHotSwitchDescription" xml:space="preserve">
-    <value>游戏启动后可以实时切换</value>
+    <value>Có thể chuyển đổi theo thời gian thực sau khi game khởi động</value> 
   </data>
   <data name="ViewPageLaunchGameInjectionDescription" xml:space="preserve">
-    <value>请您仔细甄别这些功能的危害性再选择开启这些功能</value>
+    <value>Vui lòng cân nhắc kỹ lưỡng các rủi ro trước khi quyết định bật các chức năng này</value> 
   </data>
   <data name="ViewPageLaunchGameInjectionHeader" xml:space="preserve">
-    <value>插件</value>
+    <value>Plugin</value> 
   </data>
   <data name="ViewPageLaunchGameThirdPartyTools" xml:space="preserve">
-    <value>第三方插件工具：</value>
+    <value>Công cụ Plugin bên thứ ba：</value> 
   </data>
   <data name="ViewPageLaunchGameIslandConnected" xml:space="preserve">
-    <value>已连接到游戏，更改设置将会动态反映到游戏中</value>
+    <value>Đã kết nối với game, thay đổi cài đặt sẽ phản ánh trực tiếp trong game</value> 
   </data>
   <data name="ViewPageLaunchGameIslandOptionsHeader" xml:space="preserve">
-    <value>插件选项</value>
+    <value>Tùy chọn Plugin</value> 
   </data>
-  
+
   <data name="ViewPageLaunchGameAutomationOptionsHeader" xml:space="preserve">
-    <value>自动化选项</value>
+    <value>Tùy chọn Tự động hóa</value> 
   </data>
   <data name="ViewPageLaunchGameIslandRedirectCombineEntryDescription" xml:space="preserve">
-    <value>在物品详情中点击可合成数量时直接打开合成页面而不是地图</value>
+    <value>Khi click vào số lượng có thể ghép trong chi tiết vật phẩm sẽ mở luôn giao diện Ghép thay vì mở bản đồ</value> 
   </data>
   <data name="ViewPageLaunchGameIslandRedirectCombineEntryHeader" xml:space="preserve">
-    <value>重定向合成</value>
+    <value>Chuyển hướng Ghép (Crafting)</value> 
   </data>
   <data name="ViewPageLaunchGameIslandResinListItemAllowCondensedResinHeader" xml:space="preserve">
-    <value>使用浓缩树脂领取奖励</value>
+    <value>Cho phép dùng Nhựa Cô Đặc nhận phần thưởng</value> 
   </data>
   <data name="ViewPageLaunchGameIslandResinListItemAllowFragileResinHeader" xml:space="preserve">
-    <value>使用脆弱树脂领取奖励</value>
+    <value>Cho phép dùng Nhựa Dễ Vỡ nhận phần thưởng</value> 
   </data>
   <data name="ViewPageLaunchGameIslandResinListItemAllowOriginalResinHeader" xml:space="preserve">
-    <value>使用原粹树脂领取奖励</value>
+    <value>Cho phép dùng Nhựa Nguyên Chất nhận phần thưởng</value> 
   </data>
   <data name="ViewPageLaunchGameIslandResinListItemAllowPrimogemHeader" xml:space="preserve">
-    <value>使用原石领取奖励</value>
+    <value>Cho phép dùng Nguyên Thạch nhận phần thưởng</value> 
   </data>
   <data name="ViewPageLaunchGameIslandResinListItemAllowTransientResinHeader" xml:space="preserve">
-    <value>使用须臾树脂领取奖励</value>
+    <value>Cho phép dùng Nhựa Khoảnh Khắc nhận phần thưởng</value> 
   </data>
   <data name="ViewPageLaunchGameIslandUsingTouchScreenHeader" xml:space="preserve">
-    <value>使用触摸输入</value>
+    <value>Sử dụng đầu vào cảm ứng</value> 
   </data>
   <data name="ViewPageLaunchGameKillGameProcessAction" xml:space="preserve">
-    <value>结束进程</value>
+    <value>Đóng tiến trình</value> 
   </data>
   <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
-    <value>在指定的显示器上运行</value>
+    <value>Chạy trên màn hình chỉ định</value> 
   </data>
   <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
-    <value>游戏选项</value>
+    <value>Tùy chọn Game</value> 
   </data>
   <data name="ViewPageLaunchGameOverlayDescription" xml:space="preserve">
-    <value>需要在设置中启用通知区域图标，可能需要启用无边框窗口选项来正确显示</value>
+    <value>Cần kích hoạt biểu tượng khay hệ thống trong cài đặt, có thể phải dùng chế độ Cửa sổ không viền để hiển thị đúng</value> 
   </data>
   <data name="ViewPageLaunchGameOverlayHeader" xml:space="preserve">
-    <value>悬浮窗</value>
+    <value>Cửa sổ nổi (Overlay)</value> 
   </data>
   <data name="ViewPageLaunchGameOverlayHideDescription" xml:space="preserve">
-    <value>设置悬浮窗（与游戏一同启动）的显示/隐藏快捷键</value>
+    <value>Cài đặt phím tắt Ẩn/Hiện cửa sổ nổi (khởi động cùng game)</value> 
   </data>
   <data name="ViewPageLaunchGameOverlayHideHeader" xml:space="preserve">
-    <value>显示/隐藏悬浮窗</value>
+    <value>Hiện/Ẩn Cửa sổ nổi</value> 
   </data>
   <data name="ViewPageLaunchGamePackageOperationInstall" xml:space="preserve">
-    <value>安装游戏</value>
+    <value>Cài đặt Game</value> 
   </data>
   <data name="ViewPageLaunchGamePackageOperationPredownload" xml:space="preserve">
-    <value>预下载</value>
+    <value>Tải trước</value> 
   </data>
   <data name="ViewPageLaunchGamePackageOperationPredownloadCompleteBadgeContent" xml:space="preserve">
-    <value>已完成预下载</value>
+    <value>Đã hoàn thành Tải trước</value> 
   </data>
   <data name="ViewPageLaunchGamePackagePredownloadUnavailable" xml:space="preserve">
-    <value>当前没有要预下载的资源哦</value>
+    <value>Hiện không có tài nguyên nào để tải trước</value> 
   </data>
   <data name="ViewPageLaunchGamePackageOperationUpdate" xml:space="preserve">
-    <value>更新游戏</value>
+    <value>Cập nhật Game</value> 
   </data>
   <data name="ViewPageLaunchGamePackageOperationVerify" xml:space="preserve">
-    <value>修复游戏</value>
+    <value>Sửa chữa Game</value> 
   </data>
   <data name="ViewPageLaunchGamePlayTimeDescription" xml:space="preserve">
-    <value>在游戏启动后尝试启动并使用 Starward 进行游戏时长统计</value>
+    <value>Sau khi khởi động game, thử khởi chạy Starward để thống kê thời gian chơi</value> 
   </data>
   <data name="ViewPageLaunchGamePlayTimeHeader" xml:space="preserve">
-    <value>时长统计</value>
+    <value>Thống kê thời gian chơi</value> 
   </data>
   <data name="ViewPageLaunchGameRemoveOpenTeamProgressDescription" xml:space="preserve">
-    <value>移除打开队伍配置界面时显示的进度条</value>
+    <value>Xóa thanh tiến trình hiện lên khi mở giao diện Đội Ngũ</value> 
   </data>
   <data name="ViewPageLaunchGameRemoveOpenTeamProgressHeader" xml:space="preserve">
-    <value>移除队伍配置进度条</value>
+    <value>Xóa thanh tiến trình Đội Ngũ</value> 
   </data>
   <data name="ViewPageLaunchGameSelectGamePath" xml:space="preserve">
-    <value>选择游戏路径</value>
+    <value>Chọn đường dẫn Game</value> 
   </data>
   <data name="ViewPageLaunchGameSelectGamePathHint" xml:space="preserve">
-    <value>在下方列表中选中以切换到该路径</value>
+    <value>Chọn từ danh sách bên dưới để chuyển đổi</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountDescription" xml:space="preserve">
-    <value>在游戏内切换账号，网络环境发生变化后需要重新手动检测</value>
+    <value>Chuyển đổi tài khoản trong game, nếu thay đổi mạng cần nhận diện lại bằng tay</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountDetectAction" xml:space="preserve">
-    <value>检测</value>
+    <value>Nhận diện</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountExpired" xml:space="preserve">
-    <value>MAC 地址不匹配，可能需要在游戏中重新登录</value>
+    <value>Địa chỉ MAC không khớp, có thể cần đăng nhập lại trong game</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountHeader" xml:space="preserve">
-    <value>检测账号</value>
+    <value>Nhận diện tài khoản</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountRemoveToolTip" xml:space="preserve">
-    <value>删除</value>
+    <value>Xóa</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchAccountRenameToolTip" xml:space="preserve">
-    <value>重命名</value>
+    <value>Đổi tên</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchSchemeAction" xml:space="preserve">
-    <value>转换</value>
+    <value>Chuyển đổi</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchSchemeDescription" xml:space="preserve">
-    <value>切换游戏服务器（国服 / 渠道服 / 国际服）</value>
+    <value>Chuyển đổi Server (Server Chính Thức / Server Kênh / Server Quốc Tế)</value> 
   </data>
   <data name="ViewPageLaunchGameSwitchSchemeHeader" xml:space="preserve">
-    <value>服务器</value>
+    <value>Máy chủ Game</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFovDescription" xml:space="preserve">
-    <value>调整相机视野，默认 45</value>
+    <value>Điều chỉnh tầm nhìn (FOV) Camera, mặc định 45</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFovHeader" xml:space="preserve">
-    <value>调整视野</value>
+    <value>Chỉnh Tầm nhìn</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFovHotSwitchHeader" xml:space="preserve">
-    <value>视野热开关</value>
+    <value>Công tắc nóng Tầm nhìn</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFpsHeader" xml:space="preserve">
-    <value>目标帧率</value>
+    <value>FPS Mục tiêu</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFpsHotSwitchHeader" xml:space="preserve">
-    <value>帧率热开关</value>
+    <value>Công tắc nóng FPS</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFpsTeachingTipSubtitle" xml:space="preserve">
-    <value>若在启用此功能后帧率无法超过 60/显示器帧率 但其他功能正常，那么这一定不是软件 BUG，不要向我们反馈。请自行检查 游戏设置/显卡驱动设置/显示器设置 中是否未关闭（包括但不限于）垂直同步，最大帧率限制，智能插帧等功能。</value>
+    <value>Nếu sau khi bật mà FPS vẫn không vượt quá 60 hoặc tần số quét màn hình nhưng các chức năng khác vẫn bình thường, đó CHẮC CHẮN không phải BUG phần mềm, xin đừng báo cáo. Vui lòng tự kiểm tra cài đặt trong game / Driver Card đồ họa / Cài đặt màn hình xem đã TẮT các giới hạn (bao gồm nhưng không giới hạn: V-Sync, giới hạn FPS, nội suy khung hình thông minh) chưa.</value> 
   </data>
   <data name="ViewPageLaunchGameTargetFpsTeachingTipTitle" xml:space="preserve">
-    <value>无法解锁帧率上限？</value>
+    <value>Không thể mở khóa giới hạn FPS?</value> 
   </data>
   <data name="ViewPageLaunchGameUnlockFpsDescription" xml:space="preserve">
-    <value>请在游戏内关闭「垂直同步」选项，需要高性能的显卡以支持更高的帧率</value>
+    <value>Vui lòng tắt "V-Sync" trong cài đặt game. Yêu cầu card đồ họa hiệu suất cao để hỗ trợ FPS cao hơn</value> 
   </data>
   <data name="ViewPageLaunchGameUseHoyolabAccountDescription" xml:space="preserve">
-    <value>使用当前选中的 米游社 / HoYoLAB 用户登录</value>
+    <value>Đăng nhập bằng người dùng HoyoLAB đang được chọn</value> 
   </data>
   <data name="ViewPageLaunchGameUseHoyolabAccountHeader" xml:space="preserve">
-    <value>使用 米游社 / HoYoLAB 用户登录</value>
+    <value>Đăng nhập bằng HoyoLAB</value> 
   </data>
   <data name="ViewPageLaunchGameWindowsHDRDescription" xml:space="preserve">
-    <value>充分利用支持高动态范围的显示器获得更亮、更生动、更精细的画面</value>
+    <value>Khai thác tối đa sức mạnh của màn hình HDR để có hình ảnh sáng hơn, sống động và chi tiết hơn</value> 
   </data>
   <data name="ViewPageLaunchGameWindowsHDRHeader" xml:space="preserve">
-    <value>Windows HDR（启动游戏自动开启，退出游戏自动关闭）</value>
+    <value>Windows HDR (Tự bật khi vào game, tự tắt khi thoát game)</value> 
   </data>
   <data name="ViewPageOpenScreenshotFolderAction" xml:space="preserve">
-    <value>打开截图文件夹</value>
+    <value>Mở thư mục ảnh chụp màn hình</value> 
   </data>
   <data name="ViewPageResetGamePathAction" xml:space="preserve">
-    <value>选择游戏路径</value>
+    <value>Chọn đường dẫn game</value> 
   </data>
   <data name="ViewPageRoleCombatAvatarSupportHint" xml:space="preserve">
-    <value>助演</value>
+    <value>Trợ diễn</value> 
   </data>
   <data name="ViewPageRoleCombatAvatarTrialHint" xml:space="preserve">
-    <value>试用</value>
+    <value>Dùng thử</value> 
   </data>
   <data name="ViewPageRoleCombatBackupAvatars" xml:space="preserve">
-    <value>待命角色</value>
+    <value>Nhân vật dự bị</value> 
   </data>
   <data name="ViewPageRoleCombatChoiceCardsHeader" xml:space="preserve">
-    <value>神秘收获</value>
+    <value>Chúc Phúc Ảo Cảnh</value> 
   </data>
   <data name="ViewPageRoleCombatCoinNumber" xml:space="preserve">
-    <value>消耗「幻剧之花」</value>
+    <value>Tiêu hao "Hoa Ảo Kịch"</value> 
   </data>
   <data name="ViewPageRoleCombatInitialAvatarsHeader" xml:space="preserve">
-    <value>开幕角色</value>
+    <value>Nhân vật Mở Màn</value> 
   </data>
   <data name="ViewPageRoleCombatMaxRound" xml:space="preserve">
-    <value>最佳记录</value>
+    <value>Kỷ lục tốt nhất</value> 
   </data>
   <data name="ViewPageRoleCombatMedalRound" xml:space="preserve">
-    <value>挑战星章</value>
+    <value>Huy Hiệu Minh Tinh</value> 
   </data>
   <data name="ViewPageRoleCombatNotEngagedHeader" xml:space="preserve">
-    <value>暂无演出数据</value>
+    <value>Tạm chưa có dữ liệu diễn xuất</value> 
   </data>
   <data name="ViewPageRoleCombatShortest" xml:space="preserve">
-    <value>最快演出</value>
+    <value>Diễn xuất nhanh nhất</value> 
   </data>
   <data name="ViewPageRoleCombatSpecialAvatarsHeader" xml:space="preserve">
-    <value>特邀角色</value>
+    <value>Nhân vật Khách Mời</value> 
   </data>
   <data name="ViewPageRoleCombatSplendourBuffsHeader" xml:space="preserve">
-    <value>辉彩祝福</value>
+    <value>Chúc Phúc Ảo Cảnh</value> 
   </data>
   <data name="ViewPageRoleCombatStatAvatarBonus" xml:space="preserve">
-    <value>场外声援</value>
+    <value>Hỗ trợ ngoài sân</value> 
   </data>
   <data name="ViewPageRoleCombatStatRent" xml:space="preserve">
-    <value>助演次数</value>
+    <value>Số lần Trợ Diễn</value> 
   </data>
   <data name="ViewPageRoleCombatTotalBattleTime" xml:space="preserve">
-    <value>演出总时长</value>
+    <value>Tổng thời lượng diễn xuất</value> 
   </data>
   <data name="ViewPageSettingAppearanceCloseButtonBehaviorDescription" xml:space="preserve">
-    <value>更改关闭按钮的行为</value>
+    <value>Đổi hành vi của nút Đóng (X)</value> 
   </data>
   <data name="ViewPageSettingAppearanceCloseButtonBehaviorHeader" xml:space="preserve">
-    <value>关闭按钮行为</value>
+    <value>Hành vi nút Đóng</value> 
   </data>
   <data name="ViewPageSettingRememberWindowPlacementHeader" xml:space="preserve">
-    <value>记住窗口大小和位置</value>
+    <value>Ghi nhớ kích thước và vị trí cửa sổ</value> 
   </data>
   <data name="ViewPageSettingRememberWindowPlacementDescription" xml:space="preserve">
-    <value>下次启动时恢复上次关闭时的窗口大小和位置</value>
+    <value>Khôi phục kích thước và vị trí của lần đóng trước đó vào lần khởi động tiếp theo</value> 
   </data>
   <data name="ViewPageSettingApperanceFirstDayOfWeekDescription" xml:space="preserve">
-    <value>选择适合你的一周中的首日</value>
+    <value>Chọn ngày bắt đầu tuần phù hợp với bạn</value> 
   </data>
   <data name="ViewPageSettingApperanceFirstDayOfWeekHeader" xml:space="preserve">
-    <value>一周中的首日</value>
+    <value>Ngày đầu tiên của tuần</value> 
   </data>
   <data name="ViewPageSettingApperanceHeader" xml:space="preserve">
-    <value>外观</value>
+    <value>Ngoại hình</value> 
   </data>
   <data name="ViewPageSettingApperanceLanguageDescription" xml:space="preserve">
-    <value>设置呈现语言</value>
+    <value>Thiết lập ngôn ngữ hiển thị</value> 
   </data>
   <data name="ViewPageSettingApperanceLanguageHeader" xml:space="preserve">
-    <value>语言</value>
+    <value>Ngôn ngữ</value> 
   </data>
   <data name="ViewPageSettingBackdropMaterialDescription" xml:space="preserve">
-    <value>更改窗体的背景材质</value>
+    <value>Thay đổi chất liệu nền của cửa sổ</value> 
   </data>
   <data name="ViewPageSettingBackdropMaterialHeader" xml:space="preserve">
-    <value>背景材质</value>
+    <value>Chất liệu nền (Backdrop)</value> 
   </data>
   <data name="ViewPageSettingBackgroundImageDescription" xml:space="preserve">
-    <value>更改主页的背景图片来源</value>
+    <value>Thay đổi nguồn hình nền của Trang chủ</value> 
   </data>
-<data name="ViewPageSettingBackgroundImageCustomNone" xml:space="preserve">
-    <value>未选择文件</value>
+  <data name="ViewPageSettingBackgroundImageCustomNone" xml:space="preserve">
+    <value>Chưa chọn file</value> 
   </data>
-<data name="ViewPageSettingBackgroundImageCustomHint" xml:space="preserve">
-    <value>请先选择“自定义图片或视频”选项</value>
+  <data name="ViewPageSettingBackgroundImageCustomHint" xml:space="preserve">
+    <value>Vui lòng chọn tùy chọn "Hình ảnh hoặc video tùy chỉnh" trước</value> 
   </data>
-<data name="ViewPageSettingBackgroundImageCustomBrowse" xml:space="preserve">
-    <value>浏览</value>
+  <data name="ViewPageSettingBackgroundImageCustomBrowse" xml:space="preserve">
+    <value>Duyệt</value> 
   </data>
   <data name="ViewPageSettingBackgroundImageCustomClear" xml:space="preserve">
-    <value>清除</value>
+    <value>Làm sạch</value> 
   </data>
   <data name="ViewPageSettingBackgroundSwitchIntervalHeader" xml:space="preserve">
-    <value>背景自动切换间隔</value>
+    <value>Khoảng thời gian tự động đổi nền</value> 
   </data>
   <data name="ViewPageSettingBackgroundSwitchIntervalDescription" xml:space="preserve">
-    <value>设置官方启动器背景图片自动切换的时间间隔</value>
+    <value>Cài đặt khoảng thời gian tự động chuyển đổi hình nền Launcher chính thức</value> 
   </data>
   <data name="ViewPageSettingBackgroundSwitchIntervalUnit" xml:space="preserve">
-    <value>秒</value>
+    <value>giây</value> 
   </data>
   <data name="ViewPageSettingBackgroundShowDynamicHeader" xml:space="preserve">
-    <value>显示动态背景</value>
+    <value>Hiển thị hình nền động</value> 
   </data>
   <data name="ViewPageSettingBackgroundShowDynamicDescription" xml:space="preserve">
-    <value>在官方启动器背景中显示包含视频的动态背景</value>
+    <value>Hiển thị video nền động từ Launcher chính thức</value> 
   </data>
   <data name="ViewPageSettingBackgroundShowStaticHeader" xml:space="preserve">
-    <value>显示静态背景</value>
+    <value>Hiển thị nền tĩnh</value> 
   </data>
   <data name="ViewPageSettingBackgroundShowStaticDescription" xml:space="preserve">
-    <value>在官方启动器背景中显示仅有图片的静态背景</value>
+    <value>Hiển thị hình ảnh tĩnh từ Launcher chính thức</value> 
   </data>
   <data name="ViewPageSettingHomePageCardVisibleHeader" xml:space="preserve">
-    <value>显示主页卡片</value>
+    <value>Hiển thị Thẻ trang chủ</value> 
   </data>
   <data name="ViewPageSettingHomePageCardVisibleDescription" xml:space="preserve">
-    <value>控制主页活动公告卡片的显示</value>
+    <value>Kiểm soát việc hiển thị Thẻ Thông Báo Sự Kiện ở Trang chủ</value> 
   </data>
   <data name="ViewPageSettingHomePageIndicatorVisibleHeader" xml:space="preserve">
-    <value>显示背景指示器</value>
+    <value>Hiển thị điểm báo hình nền</value> 
   </data>
   <data name="ViewPageSettingHomePageIndicatorVisibleDescription" xml:space="preserve">
-    <value>控制主页底部背景切换指示点和暂停按钮的显示</value>
+    <value>Điều khiển hiển thị chấm chuyển đổi và nút tạm dừng ở cuối trang chủ</value> 
   </data>
   <data name="ViewPageSettingBackgroundImageHeader" xml:space="preserve">
-    <value>主页背景图片</value>
+    <value>Hình nền Trang chủ</value> 
   </data>
   <data name="ViewPageSettingCacheFolderHeader" xml:space="preserve">
-    <value>缓存 文件夹</value>
+    <value>Thư mục Cache</value> 
   </data>
   <data name="ViewPageSettingCheckUpdateHeader" xml:space="preserve">
-    <value>检查更新</value>
+    <value>Kiểm tra cập nhật</value> 
   </data>
   <data name="ViewPageSettingCloseButtonBehaviorNotifyIconFailedToCreateWarning" xml:space="preserve">
-    <value>通知区域图标创建失败，无法调整关闭按钮行为</value>
+    <value>Tạo Icon khay hệ thống thất bại, không thể thay đổi hành vi nút Đóng</value> 
   </data>
-
+  
   <data name="ViewPageSettingCopyDeviceIdAction" xml:space="preserve">
-    <value>复制</value>
+    <value>Sao chép</value> 
   </data>
   <data name="ViewPageSettingCreateDesktopShortcutAction" xml:space="preserve">
-    <value>创建</value>
+    <value>Tạo</value> 
   </data>
   <data name="ViewPageSettingCreateDesktopShortcutHeader" xml:space="preserve">
-    <value>在桌面上创建新的快捷方式</value>
+    <value>Tạo lối tắt Desktop mới</value> 
   </data>
   <data name="ViewPageSettingDataFolderHeader" xml:space="preserve">
-    <value>数据 文件夹</value>
+    <value>Thư mục Dữ liệu</value> 
   </data>
   <data name="ViewPageSettingInstallFolderHeader" xml:space="preserve">
-    <value>安装 文件夹</value>
+    <value>Thư mục Cài đặt</value> 
   </data>
   <data name="ViewPageSettingDeleteCacheAction" xml:space="preserve">
-    <value>删除</value>
+    <value>Xóa</value> 
   </data>
   <data name="ViewPageSettingDeleteCacheDescription" xml:space="preserve">
-    <value>若祈愿记录缓存刷新频繁提示验证密钥过期，可以尝试此操作</value>
+    <value>Nếu liên tục báo lỗi "Khóa xác thực đã hết hạn" khi làm mới lịch sử Cầu Nguyện, có thể thử tính năng này</value> 
   </data>
   <data name="ViewPageSettingDeleteCacheHeader" xml:space="preserve">
-    <value>删除游戏内网页缓存</value>
+    <value>Xóa Cache trang web trong game</value> 
   </data>
   <data name="ViewPageSettingDeviceIdHeader" xml:space="preserve">
-    <value>设备 ID</value>
+    <value>ID Thiết bị</value> 
   </data>
   <data name="ViewPageSettingDeviceIpDescription" xml:space="preserve">
-    <value>IP：{0} 归属服务器：{1}</value>
+    <value>IP: {0} | Máy chủ quản lý: {1}</value> 
   </data>
   <data name="ViewPageSettingDeviceIpHeader" xml:space="preserve">
-    <value>设备 IP</value>
+    <value>IP Thiết bị</value> 
   </data>
   <data name="ViewPageSettingElevatedModeHeader" xml:space="preserve">
-    <value>管理员模式</value>
+    <value>Chế độ Quản Trị Viên</value> 
   </data>
   <data name="ViewPageSettingElevatedModeRestartAction" xml:space="preserve">
-    <value>以管理员身份重启</value>
+    <value>Khởi động lại bằng Quyền Quản trị</value> 
   </data>
   <data name="ViewPageSettingEmptyHistoryVisibleDescription" xml:space="preserve">
-    <value>在祈愿记录页面显示或隐藏无记录的历史祈愿活动</value>
+    <value>Hiển thị hoặc ẩn các biểu ngữ sự kiện không có bản ghi trong lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ViewPageSettingEmptyHistoryVisibleHeader" xml:space="preserve">
-    <value>无记录的历史祈愿活动</value>
+    <value>Sự kiện Cầu Nguyện trống</value> 
   </data>
   <data name="ViewPageSettingEmptyHistoryVisibleOff" xml:space="preserve">
-    <value>隐藏</value>
+    <value>Ẩn</value> 
   </data>
   <data name="ViewPageSettingEmptyHistoryVisibleOn" xml:space="preserve">
-    <value>显示</value>
+    <value>Hiển thị</value> 
   </data>
   <data name="ViewPageSettingFeedbackNavigate" xml:space="preserve">
-    <value>前往反馈</value>
+    <value>Tới Phản hồi</value> 
   </data>
   <data name="ViewModelSettingFeedbackTitle" xml:space="preserve">
-    <value>反馈</value>
+    <value>Phản hồi</value> 
   </data>
   <data name="ViewModelSettingFeedbackDescription" xml:space="preserve">
-    <value>请选择反馈方式</value>
+    <value>Vui lòng chọn hình thức phản hồi</value> 
   </data>
   <data name="ViewModelSettingFeedbackDeveloperServer" xml:space="preserve">
-    <value>开发者服务器</value>
+    <value>Máy chủ Nhà phát triển</value> 
   </data>
   <data name="ViewPageSettingGitHubNavigate" xml:space="preserve">
-<value>开源仓库</value>
+    <value>Kho lưu trữ Mã Nguồn Mở</value> 
   </data>
   <data name="ViewPageSettingGachaLogHeader" xml:space="preserve">
-    <value>祈愿记录</value>
+    <value>Lịch sử Cầu Nguyện</value> 
   </data>
   <data name="ViewPageSettingGameHeader" xml:space="preserve">
-    <value>游戏</value>
+    <value>Game</value> 
   </data>
   <data name="ViewPageSettingGeetestCustomUrlAction" xml:space="preserve">
-    <value>配置</value>
+    <value>Cấu hình</value> 
   </data>
   <data name="ViewPageSettingGeetestCustomUrlDescription" xml:space="preserve">
-    <value>配置当请求触发人机验证时使用的验证接口</value>
+    <value>Cấu hình giao diện xác minh dùng khi kích hoạt xác minh người máy (Geetest)</value> 
   </data>
   <data name="ViewPageSettingGeetestCustomUrlHeader" xml:space="preserve">
-    <value>配置验证请求接口</value>
+    <value>Cấu hình Giao diện Yêu cầu Xác minh</value> 
   </data>
   <data name="ViewPageSettingGeetestVerificationHeader" xml:space="preserve">
-    <value>无感验证</value>
+    <value>Xác minh ẩn (Geetest)</value> 
   </data>
   <data name="ViewPageSettingHomeAnnouncementRegionDescription" xml:space="preserve">
-    <value>选择想要获取公告的游戏服务器</value>
+    <value>Chọn máy chủ game muốn nhận Thông báo</value> 
   </data>
   <data name="ViewPageSettingHomeAnnouncementRegionHeader" xml:space="preserve">
-    <value>游戏公告所属服务器</value>
+    <value>Khu vực Thông báo Game</value> 
   </data>
   <data name="ViewPageSettingHomeCalendarServerTimeZoneOffsetDescription" xml:space="preserve">
-    <value>选择材料日历获取当天日期时使用的游戏服务器时区</value>
+    <value>Chọn múi giờ máy chủ được Lịch Tài Nguyên sử dụng</value> 
   </data>
   <data name="ViewPageSettingHomeCalendarServerTimeZoneOffsetHeader" xml:space="preserve">
-    <value>日历服务器</value>
+    <value>Máy chủ của Lịch</value> 
   </data>
   <data name="ViewPageSettingHomeHeader" xml:space="preserve">
-    <value>公告</value>
+    <value>Thông báo</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportCdnExpiredAtHeader" xml:space="preserve">
-    <value>云 CDN 到期时间</value>
+    <value>Hạn sử dụng Cloud CDN</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportDangerZoneDescription" xml:space="preserve">
-    <value>三思而后行</value>
+    <value>Hãy suy nghĩ kỹ trước khi hành động</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportDangerZoneHeader" xml:space="preserve">
-    <value>危险操作</value>
+    <value>Khu vực nguy hiểm</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportGachaLogExpiredAtHeader" xml:space="preserve">
-    <value>云祈愿记录服务到期时间</value>
+    <value>Hạn sử dụng Dịch vụ Lịch sử Cầu Nguyện Cloud</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportHeader" xml:space="preserve">
-    <value>通行证账号</value>
+    <value>Tài khoản Passport</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportLicensedDeveloperDescription" xml:space="preserve">
-    <value>您可以无限制使用任何基于云服务的功能</value>
+    <value>Bạn có thể sử dụng không giới hạn mọi tính năng dựa trên Cloud</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportLicensedDeveloperHeader" xml:space="preserve">
-    <value>已认证的合作开发者</value>
+    <value>Nhà phát triển Đối tác được Chứng nhận</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportLoginAction" xml:space="preserve">
-    <value>登录</value>
+    <value>Đăng nhập</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportLogoutAction" xml:space="preserve">
-    <value>退出登录</value>
+    <value>Đăng xuất</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportMaintainerDescription" xml:space="preserve">
-    <value>您可以无限制的使用任何测试功能</value>
+    <value>Bạn có thể sử dụng không giới hạn mọi chức năng thử nghiệm</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportMaintainerHeader" xml:space="preserve">
-    <value>开发 / 运维</value>
+    <value>Phát triển / Vận hành</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportRedeemCodeDescription" xml:space="preserve">
-    <value>我们有时会向某些用户赠送云兑换码</value>
+    <value>Đôi khi chúng tôi sẽ tặng Mã Đổi Thưởng Cloud cho một số người dùng nhất định</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportRedeemCodeHeader" xml:space="preserve">
-    <value>使用兑换码</value>
+    <value>Sử dụng Mã Đổi Thưởng</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportRefreshAction" xml:space="preserve">
-    <value>刷新</value>
+    <value>Làm mới</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportRegisterAction" xml:space="preserve">
-    <value>注册</value>
+    <value>Đăng ký</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportResetPasswordAction" xml:space="preserve">
-    <value>修改密码</value>
+    <value>Đổi mật khẩu</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportResetUserNameAction" xml:space="preserve">
-    <value>修改邮箱</value>
+    <value>Đổi email</value> 
   </data>
   <data name="ViewPageSettingLauncherPassportUnregisterAction" xml:space="preserve">
-    <value>注销账号</value>
+    <value>Hủy Tài Khoản</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutAutoClickingDescription" xml:space="preserve">
-    <value>更改鼠标左键自动连点功能的快捷键</value>
+    <value>Đổi phím tắt của tính năng Tự động Click chuột trái</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutAutoClickingHeader" xml:space="preserve">
-    <value>鼠标左键自动连点</value>
+    <value>Tự động Click Chuột trái</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutAutoPressingDescription" xml:space="preserve">
-    <value>更改键盘 F 键自动连按功能的快捷键</value>
+    <value>Đổi phím tắt của tính năng Tự động Nhấn phím F</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutAutoPressingHeader" xml:space="preserve">
-    <value>键盘 F 键自动连按</value>
+    <value>Tự động Nhấn Phím F</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutInGameOnlyDescription" xml:space="preserve">
-    <value>快捷键仅在游戏启动后生效</value>
+    <value>Phím tắt chỉ hoạt động sau khi khởi động game</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutInGameOnlyHeader" xml:space="preserve">
-    <value>游戏启动后生效</value>
+    <value>Có tác dụng khi game chạy</value> 
   </data>
   <data name="ViewPageSettingKeyShortcutWarningDescription" xml:space="preserve">
-    <value>对不同的功能设置相同的快捷键可能会导致非预期的结果，且需要额外的操作或重启应用才能恢复正常</value>
+    <value>Thiết lập phím tắt giống nhau cho nhiều tính năng khác nhau có thể gây ra kết quả không mong muốn và cần thao tác lại hoặc khởi động lại ứng dụng để khôi phục</value> 
   </data>
   <data name="ViewPageSettingOfficialSiteNavigate" xml:space="preserve">
-    <value>前往官网</value>
+    <value>Tới Trang chủ chính thức</value> 
   </data>
   <data name="ViewPageSettingDocsNavigate" xml:space="preserve">
-    <value>查看文档</value>
+    <value>Xem Tài liệu</value> 
   </data>
   <data name="ViewPageSettingSetDataFolderDescription" xml:space="preserve">
-    <value>更改目录后将会自动复制文件夹并自动重启，重启后自动删除之前的文件夹</value>
+    <value>Sau khi đổi đường dẫn sẽ tự động copy dữ liệu và khởi động lại, sau đó tự xóa thư mục cũ</value> 
   </data>
   <data name="ViewPageSettingSetDataFolderHeader" xml:space="preserve">
-    <value>更改数据目录</value>
+    <value>Đổi Thư mục Dữ liệu</value> 
   </data>
   <data name="ViewPageSettingSetGamePathAction" xml:space="preserve">
-    <value>设置路径</value>
+    <value>Thiết lập đường dẫn</value> 
   </data>
   <data name="ViewPageSettingSetGamePathHeader" xml:space="preserve">
-    <value>游戏路径</value>
+    <value>Đường dẫn Game</value> 
   </data>
   <data name="ViewPageSettingSetGamePathHint" xml:space="preserve">
-    <value>设置游戏路径时，请选择游戏本体（YuanShen.exe 或 GenshinImpact.exe）而不是启动器（launcher.exe）</value>
+    <value>Khi thiết lập đường dẫn, vui lòng chọn file thực thi của game (YuanShen.exe hoặc GenshinImpact.exe) thay vì launcher.exe</value> 
   </data>
   <data name="ViewPageSettingSponsorNavigate" xml:space="preserve">
-    <value>赞助我们</value>
+    <value>Tài trợ chúng tôi</value> 
   </data>
   <data name="ViewPageSettingStorageHeader" xml:space="preserve">
-    <value>存储空间</value>
+    <value>Không gian bộ nhớ</value> 
   </data>
   <data name="ViewPageSettingStorageSetAction" xml:space="preserve">
-    <value>更改</value>
+    <value>Đổi</value> 
   </data>
   <data name="ViewPageSettingThemeDescription" xml:space="preserve">
-    <value>更改窗体的颜色主题</value>
+    <value>Thay đổi Theme màu sắc của ứng dụng</value> 
   </data>
   <data name="ViewPageSettingThemeHeader" xml:space="preserve">
-    <value>颜色主题</value>
+    <value>Theme Màu</value> 
   </data>
   <data name="ViewPageSettingTranslateNavigate" xml:space="preserve">
-    <value>贡献翻译</value>
+    <value>Đóng góp Dịch thuật</value> 
   </data>
   <data name="ViewPageSettingUIGFExportContent" xml:space="preserve">
-    <value>导出</value>
+    <value>Xuất</value> 
   </data>
   <data name="ViewPageSettingUIGFExportImportDescription" xml:space="preserve">
-    <value>导出/导入 UIGF 4 文件</value>
+    <value>Xuất/Nhập tệp UIGF 4</value> 
   </data>
   <data name="ViewPageSettingUIGFExportImportHeader" xml:space="preserve">
-    <value>数据迁移</value>
+    <value>Di chuyển dữ liệu</value>    
   </data>
   <data name="ViewPageSettingUIGFImportContent" xml:space="preserve">
-    <value>导入</value>
+    <value>Nhập</value> 
   </data>
   <data name="ViewPageSettingUIGFUpgradeLegacyVersionContent" xml:space="preserve">
-    <value>升级较早版本的 UIGF 文件</value>
+    <value>Nâng cấp tệp UIGF phiên bản cũ</value> 
   </data>
   <data name="ViewPageSettingUnobtainedWishItemVisibleDescription" xml:space="preserve">
-    <value>在「祈愿记录-角色」与「祈愿记录-武器」中显示未抽取到的祈愿物品</value>
+    <value>Hiển thị các vật phẩm chưa nhận được trong mục "Lịch sử Cầu Nguyện - Nhân vật" và "Vũ khí"</value> 
   </data>
   <data name="ViewPageSettingUnobtainedWishItemVisibleHeader" xml:space="preserve">
-    <value>未抽取到的祈愿物品</value>
+    <value>Vật phẩm chưa rút được</value> 
   </data>
   <data name="ViewPageSettingWebview2Header" xml:space="preserve">
-    <value>Webview2 运行时</value>
+    <value>Webview2 Runtime</value> 
   </data>
   <data name="ViewPageSpiralAbyssTeamAppearanceDownHeader" xml:space="preserve">
-    <value>下半</value>
+    <value>Nửa sau</value> 
   </data>
   <data name="ViewPageSpiralAbyssTeamAppearanceUpHeader" xml:space="preserve">
-    <value>上半</value>
+    <value>Nửa đầu</value> 
   </data>
   <data name="ViewPageWiKiAvatarArtifactSetCombinationHeader" xml:space="preserve">
-    <value>搭配圣遗物</value>
+    <value>Ghép Thánh Di Vật</value> 
   </data>
   <data name="ViewPageWiKiAvatarAscensionMaterialsHeader" xml:space="preserve">
-    <value>养成材料</value>
+    <value>Nguyên Liệu Bồi Dưỡng</value> 
   </data>
   <data name="ViewPageWiKiAvatarAutoSuggestBoxPlaceHolder" xml:space="preserve">
-    <value>筛选角色</value>
+    <value>Lọc Nhân Vật</value> 
   </data>
   <data name="ViewPageWiKiAvatarChineseCVNameTitle" xml:space="preserve">
-    <value>汉语 CV</value>
+    <value>CV Tiếng Trung</value> 
   </data>
   <data name="ViewPageWiKiAvatarConstellationNameTitle" xml:space="preserve">
-    <value>命之座</value>
+    <value>Cung Mệnh</value> 
   </data>
   <data name="ViewPageWiKiAvatarDateofBirthTitle" xml:space="preserve">
-    <value>生日</value>
+    <value>Sinh Nhật</value> 
   </data>
   <data name="ViewPageWiKiAvatarEnglishCVNameTitle" xml:space="preserve">
-    <value>英语 CV</value>
+    <value>CV Tiếng Anh</value> 
   </data>
   <data name="ViewPageWiKiAvatarFoodHeader" xml:space="preserve">
-    <value>料理</value>
+    <value>Món Ăn</value> 
   </data>
   <data name="ViewPageWiKiAvatarGnosisTitle" xml:space="preserve">
-    <value>神之心</value>
+    <value>Thần Chi Tâm</value> 
   </data>
   <data name="ViewPageWiKiAvatarJapaneseCVNameTitle" xml:space="preserve">
-    <value>日语 CV</value>
+    <value>CV Tiếng Nhật</value> 
   </data>
   <data name="ViewPageWiKiAvatarKoreanCVNameTitle" xml:space="preserve">
-    <value>韩语 CV</value>
+    <value>CV Tiếng Hàn</value> 
   </data>
   <data name="ViewPageWiKiAvatarNameCardHeader" xml:space="preserve">
-    <value>名片</value>
+    <value>Danh Thiếp</value> 
   </data>
   <data name="ViewPageWiKiAvatarOccupationNameTitle" xml:space="preserve">
-    <value>所属</value>
+    <value>Thuộc Về</value> 
   </data>
   <data name="ViewPageWiKiAvatarOriginalFoodTitle" xml:space="preserve">
-    <value>原料理</value>
+    <value>Món Gốc</value> 
   </data>
   <data name="ViewPageWiKiAvatarQuotesHeader" xml:space="preserve">
-    <value>资料</value>
+    <value>Dữ Liệu</value> 
   </data>
   <data name="ViewPageWiKiAvatarSpecialFoodTitle" xml:space="preserve">
-    <value>特殊料理</value>
+    <value>Món Đặc Trưng</value> 
   </data>
   <data name="ViewPageWiKiAvatarStoriesHeader" xml:space="preserve">
-    <value>故事</value>
+    <value>Câu Chuyện</value> 
   </data>
   <data name="ViewPageWiKiAvatarStrategyBilibiliButtonLabel" xml:space="preserve">
-    <value>哔哩哔哩 Wiki 角色攻略</value>
+    <value>Bilibili Wiki Cẩm nang Nhân vật</value> 
   </data>
   <data name="ViewPageWiKiAvatarStrategyChineseButtonLabel" xml:space="preserve">
-    <value>米游社角色攻略</value>
+    <value>Miyoushe Cẩm nang Nhân vật</value> 
   </data>
   <data name="ViewPageWiKiAvatarStrategyOverseaButtonLabel" xml:space="preserve">
-    <value>HoYoLAB 角色攻略</value>
+    <value>HoYoLAB Cẩm nang Nhân vật</value> 
   </data>
   <data name="ViewPageWiKiAvatarTeamCombinationHeader" xml:space="preserve">
-    <value>搭配角色</value>
+    <value>Ghép Đội</value> 
   </data>
   <data name="ViewPageWiKiAvatarTraceEffectHeader" xml:space="preserve">
-    <value>游迹</value>
+    <value>Dấu Chân Phía Trước</value> 
   </data>
   <data name="ViewPageWiKiAvatarVisionTitle" xml:space="preserve">
-    <value>神之眼</value>
+    <value>Thần Chi Nhãn</value> 
   </data>
   <data name="ViewPageWiKiAvatarWeaponCombinationHeader" xml:space="preserve">
-    <value>搭配武器</value>
+    <value>Ghép Vũ Khí</value> 
   </data>
   <data name="ViewPageWiKiGeneralAddToDevPlanButtonLabel" xml:space="preserve">
-    <value>添加到养成计划</value>
+    <value>Thêm vào Kế hoạch Bồi dưỡng</value> 
   </data>
   <data name="ViewPageWiKiWeaponAfterAscensionTitle" xml:space="preserve">
-    <value>突破后</value>
+    <value>Sau Đột Phá</value> 
   </data>
   <data name="ViewPageWiKiWeaponAutoSuggestBoxPlaceHolder" xml:space="preserve">
-    <value>筛选武器</value>
+    <value>Lọc Vũ Khí</value> 
   </data>
   <data name="ViewPageWikiArchonQuestAutoSuggestBoxPlaceHolder" xml:space="preserve">
-    <value>筛选任务</value>
+    <value>Lọc Nhiệm Vụ</value> 
   </data>
   <data name="ViewPageWiKiWeaponBeforeAscensionTitle" xml:space="preserve">
-    <value>突破前</value>
+    <value>Trước Đột Phá</value> 
   </data>
   <data name="ViewPageWiKiWeaponStoryHeader" xml:space="preserve">
-    <value>武器故事</value>
+    <value>Cốt truyện Vũ Khí</value> 
   </data>
   <data name="ViewPageWikiMonsterDropItems" xml:space="preserve">
-    <value>掉落物品</value>
+    <value>Vật Phẩm Rơi</value> 
   </data>
   <data name="ViewPeriodHeader" xml:space="preserve">
-    <value>周期</value>
+    <value>Kỳ</value> 
   </data>
   <data name="ViewRoleCombatHeader" xml:space="preserve">
-    <value>幻想真境剧诗</value>
+    <value>Nhà Hát Giả Tưởng</value> 
   </data>
   <data name="ViewServiceLauncherUserCdnNotAllowedDescription" xml:space="preserve">
-    <value>未开通云 CDN 或已到期</value>
+    <value>Cloud CDN chưa mở hoặc đã quá hạn</value> 
   </data>
   <data name="ViewServiceLauncherUserCloudNotAllowedDescription" xml:space="preserve">
-    <value>未开通祈愿记录上传服务或已到期</value>
+    <value>Dịch vụ Cloud Cầu Nguyện chưa mở hoặc đã quá hạn</value> 
   </data>
   <data name="ViewServiceLauncherUserLoginFailHint" xml:space="preserve">
-    <value>登录失败，请重新登录</value>
+    <value>Đăng nhập thất bại, vui lòng thử lại</value> 
   </data>
   <data name="ViewServiceLauncherUserLoginOrRegisterHint" xml:space="preserve">
-    <value>立即登录或注册</value>
+    <value>Đăng nhập hoặc đăng ký ngay</value> 
   </data>
   <data name="ViewSettingFolderViewOpenFolderAction" xml:space="preserve">
-    <value>打开文件夹</value>
+    <value>Mở Thư Mục</value> 
   </data>
   <data name="ViewSettingHeader" xml:space="preserve">
-    <value>设置</value>
+    <value>Cài đặt</value> 
   </data>
   <data name="ViewSpiralAbyssAvatarAppearanceRankDescription" xml:space="preserve">
-    <value>角色出场率 = 本层上阵该角色次数（层内重复出现只记一次）/ 深渊记录总数</value>
+    <value>Tỷ lệ Ra trận = Số lần ra trận của nhân vật tại Tầng này (lặp lại trong tầng chỉ tính 1) / Tổng số bản ghi La Hoàn</value> 
   </data>
   <data name="ViewSpiralAbyssAvatarUsageRankDescription" xml:space="preserve">
-    <value>角色使用率 = 本层上阵该角色次数（层内重复出现只记一次）/ 持有该角色的深渊记录总数</value>
+    <value>Tỷ lệ Sử dụng = Số lần ra trận của nhân vật tại Tầng này (lặp lại trong tầng chỉ tính 1) / Tổng số bản ghi La Hoàn CÓ SỞ HỮU nhân vật đó</value> 
   </data>
   <data name="ViewSpiralAbyssBattleTimes" xml:space="preserve">
-    <value>战斗次数</value>
+    <value>Số lần Tác chiến</value> 
   </data>
   <data name="ViewSpiralAbyssDamage" xml:space="preserve">
-    <value>最强一击</value>
+    <value>Đòn đánh mạnh nhất</value> 
   </data>
   <data name="ViewSpiralAbyssDefeat" xml:space="preserve">
-    <value>最多击破</value>
+    <value>Đánh bại nhiều nhất</value> 
   </data>
   <data name="ViewSpiralAbyssDetail" xml:space="preserve">
-    <value>分期详情</value>
+    <value>Chi tiết các Kỳ</value> 
   </data>
   <data name="ViewSpiralAbyssEnergySkill" xml:space="preserve">
-    <value>元素爆发</value>
+    <value>Kỹ Năng Nộ</value> 
   </data>
   <data name="ViewSpiralAbyssHeader" xml:space="preserve">
-    <value>深境螺旋</value>
+    <value>La Hoàn Thâm Cảnh</value> 
   </data>
   <data name="ViewSpiralAbyssLauncherStatistics" xml:space="preserve">
-    <value>本期统计</value>
+    <value>Thống kê Kỳ này</value> 
   </data>
   <data name="ViewSpiralAbyssLevelBattleCaptionDown" xml:space="preserve">
-    <value>下半</value>
+    <value>Nửa sau</value> 
   </data>
   <data name="ViewSpiralAbyssLevelBattleCaptionUp" xml:space="preserve">
-    <value>上半</value>
+    <value>Nửa đầu</value> 
   </data>
   <data name="ViewSpiralAbyssMaxFloor" xml:space="preserve">
-    <value>最深抵达</value>
+    <value>Vào sâu nhất</value> 
   </data>
   <data name="ViewSpiralAbyssNormalSkill" xml:space="preserve">
-    <value>元素战技</value>
+    <value>Kỹ Năng Nguyên Tố</value> 
   </data>
   <data name="ViewSpiralAbyssRecordBattleAvatars" xml:space="preserve">
-    <value>上场角色</value>
+    <value>Nhân vật ra trận</value> 
   </data>
   <data name="ViewSpiralAbyssRecordMonsterAttacksMonolith" xml:space="preserve">
-    <value>攻击地脉镇石</value>
+    <value>Tấn Công Cơ Quan Bảo Vệ</value> 
   </data>
   <data name="ViewSpiralAbyssRefresh" xml:space="preserve">
-    <value>刷新数据</value>
+    <value>Làm mới Dữ liệu</value> 
   </data>
   <data name="ViewSpiralAbyssReveal" xml:space="preserve">
-    <value>出战次数</value>
+    <value>Số Lần Xuất Trận</value> 
   </data>
   <data name="ViewSpiralAbyssStatistics" xml:space="preserve">
-    <value>统计数据</value>
+    <value>Dữ liệu Thống Kê</value> 
   </data>
   <data name="ViewSpiralAbyssTakeDamage" xml:space="preserve">
-    <value>最多承伤</value>
+    <value>Chịu Đòn nhiều nhất</value> 
   </data>
   <data name="ViewSpiralAbyssTotalStar" xml:space="preserve">
-    <value>获得渊星</value>
+    <value>Sao La Hoàn nhận được</value> 
   </data>
   <data name="ViewSpiralAbyssUploadRecord" xml:space="preserve">
-    <value>上传数据</value>
+    <value>Tải lên Dữ liệu</value> 
   </data>
   <data name="ViewTitileUpdatePackageAvailableContent" xml:space="preserve">
-    <value>是否立即更新？</value>
+    <value>Bạn có muốn cập nhật ngay?</value> 
   </data>
   <data name="ViewTitleAutoClicking" xml:space="preserve">
-    <value>自动连点</value>
+    <value>Auto Click</value> 
   </data>
   <data name="ViewTitleAutoPressing" xml:space="preserve">
-    <value>自动连按</value>
+    <value>Auto Pressing</value> 
   </data>
   <data name="ViewTitleMetadataInitializing" xml:space="preserve">
-    <value>正在初始化元数据</value>
+    <value>Đang khởi tạo Siêu dữ liệu (Metadata)</value> 
   </data>
   <data name="ViewTitleUpdatePackageAvailableTitle" xml:space="preserve">
-    <value> {0} 版本现已可用</value>
+    <value> Đã có bản cập nhật {0}</value>
   </data>
   <data name="ViewToolHeader" xml:space="preserve">
-    <value>工具</value>
+    <value>Công cụ</value> 
   </data>
   <data name="ViewUserCookieOperation" xml:space="preserve">
-    <value>米游社</value>
+    <value>HoyoLAB</value> 
   </data>
   <data name="ViewUserCookieOperation2" xml:space="preserve">
-    <value>HoYoLAB</value>
+    <value>HoYoLAB</value> 
   </data>
   <data name="ViewUserCookieOperation3" xml:space="preserve">
-    <value>当前用户</value>
+    <value>Người dùng hiện tại</value> 
   </data>
   <data name="ViewUserCookieOperationGameRecordIndexAction" xml:space="preserve">
-    <value>旅行工具</value>
+    <value>Công cụ Lữ Hành</value> 
   </data>
   <data name="ViewUserCookieOperationLoginByPasswordAction" xml:space="preserve">
-    <value>账密登录</value>
+    <value>Đăng nhập bằng Mật Khẩu</value> 
   </data>
   <data name="ViewUserCookieOperationLoginMobileCaptchaAction" xml:space="preserve">
-    <value>手机验证码</value>
+    <value>Mã Xác Minh Số Điện Thoại</value> 
   </data>
   <data name="ViewUserCookieOperationLoginQRCodeAction" xml:space="preserve">
-    <value>扫码登录</value>
+    <value>Quét Mã Đăng Nhập</value> 
   </data>
   <data name="ViewUserCookieOperationManualInputAction" xml:space="preserve">
-    <value>手动输入</value>
+    <value>Nhập Thủ Công</value> 
   </data>
   <data name="ViewUserCookieOperationRefreshCookieAction" xml:space="preserve">
-    <value>刷新 Cookie</value>
+    <value>Làm Mới Cookie</value> 
   </data>
   <data name="ViewUserCopyCookieAction" xml:space="preserve">
-    <value>复制 Cookie</value>
+    <value>Sao chép Cookie</value> 
   </data>
   <data name="ViewUserDefaultDescription" xml:space="preserve">
-    <value>请先登录</value>
+    <value>Vui lòng đăng nhập trước</value> 
   </data>
   <data name="ViewUserNoUserHint" xml:space="preserve">
-    <value>尚未登录</value>
+    <value>Chưa đăng nhập</value> 
   </data>
   <data name="ViewUserRefreshCookieTokenSuccess" xml:space="preserve">
-    <value>刷新 CookieToken 成功</value>
+    <value>Làm mới CookieToken thành công</value> 
   </data>
   <data name="ViewUserRefreshCookieTokenWarning" xml:space="preserve">
-    <value>刷新 CookieToken 失败</value>
+    <value>Làm mới CookieToken thất bại</value> 
   </data>
   <data name="ViewUserRemoveAction" xml:space="preserve">
-    <value>移除用户</value>
+    <value>Xóa người dùng</value> 
   </data>
   <data name="ViewUserRole" xml:space="preserve">
-    <value>角色</value>
+    <value>Nhân vật</value> 
   </data>
   <data name="ViewUserUser" xml:space="preserve">
-    <value>用户</value>
+    <value>Người dùng</value> 
   </data>
   <data name="ViewWebView2WindowLoadFailedHint" xml:space="preserve">
-    <value>WebView2 加载失败</value>
+    <value>Tải WebView2 thất bại</value> 
   </data>
   <data name="ViewWelcomeBase" xml:space="preserve">
-    <value>我们将为你下载最基本的图像资源</value>
+    <value>Chúng tôi sẽ tải xuống các tài nguyên hình ảnh cơ bản nhất cho bạn</value> 
   </data>
   <data name="ViewEmotionIconHeader" xml:space="preserve">
-    <value>派蒙画作</value>
+    <value>Paimon Vẽ Tay</value> 
   </data>
   <data name="ViewWikiAvatarHeader" xml:space="preserve">
-    <value>角色资料</value>
+    <value>Dữ liệu Nhân vật</value> 
   </data>
   <data name="ViewWikiMonsterHeader" xml:space="preserve">
-    <value>怪物资料</value>
+    <value>Dữ liệu Quái vật</value> 
   </data>
   <data name="ViewWikiWeaponHeader" xml:space="preserve">
-    <value>武器资料</value>
+    <value>Dữ liệu Vũ khí</value> 
   </data>
   <data name="ViewWikiArchonQuestHeader" xml:space="preserve">
-    <value>任务合集</value>
+    <value>Tổng Hợp Nhiệm Vụ</value> 
   </data>
   <data name="ViewWikiFoodHeader" xml:space="preserve">
-    <value>食物资料</value>
+    <value>Dữ liệu Món Ăn</value> 
   </data>
   <data name="ViewWikiFoodEffectRecoveryHp" xml:space="preserve">
-    <value>恢复生命</value>
+    <value>Hồi Phục HP</value> 
   </data>
   <data name="ViewWikiFoodEffectRecoveryHpAll" xml:space="preserve">
-    <value>恢复全队</value>
+    <value>Hồi Phục Toàn Đội</value> 
   </data>
   <data name="ViewWikiFoodEffectRevive" xml:space="preserve">
-    <value>复苏</value>
+    <value>Hồi Sinh</value> 
   </data>
   <data name="ViewWikiFoodEffectAtkAdd" xml:space="preserve">
-    <value>攻击力</value>
+    <value>Tấn Công</value> 
   </data>
   <data name="ViewWikiFoodEffectCritRate" xml:space="preserve">
-    <value>暴击率</value>
+    <value>Tỷ Lệ Bạo Kích</value> 
   </data>
   <data name="ViewWikiFoodEffectDefAdd" xml:space="preserve">
-    <value>防御力</value>
+    <value>Phòng Ngự</value> 
   </data>
   <data name="ViewWikiFoodEffectSPAdd" xml:space="preserve">
-    <value>体力恢复</value>
+    <value>Hồi Phục Thể Lực</value> 
   </data>
   <data name="ViewWikiFoodEffectSPReduce" xml:space="preserve">
-    <value>体力消耗</value>
+    <value>Tiêu Hao Thể Lực</value> 
   </data>
   <data name="ViewWikiFoodEffectClimate" xml:space="preserve">
-    <value>耐寒耐热</value>
+    <value>Chống Lạnh / Nóng</value> 
   </data>
   <data name="ViewWikiFoodEffectAdventure" xml:space="preserve">
-    <value>探索</value>
+    <value>Thám Hiểm</value> 
   </data>
   <data name="ViewWikiFoodEffectSpecial" xml:space="preserve">
-    <value>特殊效果</value>
+    <value>Hiệu Ứng Đặc Biệt</value> 
   </data>
   <data name="ViewWikiFoodRankStar" xml:space="preserve">
-    <value>{0}星</value>
+    <value>{0} Sao</value> 
   </data>
   <data name="ViewWikiFoodEffectTitle" xml:space="preserve">
-    <value>效果</value>
+    <value>Hiệu Ứng</value> 
   </data>
   <data name="ViewWikiFoodRecipeTitle" xml:space="preserve">
-    <value>配方材料</value>
+    <value>Nguyên Liệu Công Thức</value> 
   </data>
   <data name="ViewWikiFoodCookingTitle" xml:space="preserve">
-    <value>手工烹饪</value>
+    <value>Nấu Ăn Thủ Công</value> 
   </data>
   <data name="ViewWikiFoodCategorySpecial" xml:space="preserve">
-    <value>特色料理</value>
+    <value>Món Đặc Trưng</value> 
   </data>
   <data name="ViewWikiFoodElementalSkill" xml:space="preserve">
-    <value>元素战技</value>
+    <value>Kỹ Năng Nguyên Tố</value> 
   </data>
   <data name="ViewWikiFoodSearchPlaceholder" xml:space="preserve">
-    <value>搜索食物...</value>
+    <value>Tìm món ăn...</value> 
   </data>
   <data name="ViewWikiFoodInventoryHeader" xml:space="preserve">
-    <value>背包食物</value>
+    <value>Món Ăn Ba Lô</value> 
   </data>
   <data name="ViewWindowCompactWebViewTitle" xml:space="preserve">
-    <value>紧凑网页窗口</value>
+    <value>Cửa Sổ Web Gọn</value> 
   </data>
   <data name="ViewWindowCompactWebView2HotKeyDisabledMessage" xml:space="preserve">
-    <value>以管理员身份运行以启用全局快捷键功能</value>
+    <value>Chạy dưới quyền quản trị viên để bật tính năng phím tắt toàn cầu</value> 
   </data>
   <data name="ViewWindowExceptionClose" xml:space="preserve">
-    <value>关闭</value>
+    <value>Đóng</value> 
   </data>
   <data name="ViewWindowExceptionHeader" xml:space="preserve">
-    <value>遇到了无法恢复的致命错误</value>
+    <value>Gặp Lỗi Nghiêm Trọng Không Thể Phục Hồi</value> 
   </data>
   <data name="ViewWindowExceptionTitle" xml:space="preserve">
-    <value>我们遇到了一点问题</value>
+    <value>Chúng tôi gặp một chút rắc rối</value> 
   </data>
   <data name="ViewWindowScriptingExecute" xml:space="preserve">
-    <value>执行</value>
+    <value>Thực thi</value> 
   </data>
   <data name="ViewWindowScriptingTitle" xml:space="preserve">
-    <value>执行调试脚本</value>
+    <value>Thực thi Script Debug</value> 
   </data>
   <data name="WebAnnouncementTimeDaysBegin" xml:space="preserve">
-    <value>{0} 天后开始</value>
+    <value>Bắt đầu sau {0} ngày</value> 
   </data>
   <data name="WebAnnouncementTimeDaysEnd" xml:space="preserve">
-    <value>{0} 天后结束</value>
+    <value>Kết thúc sau {0} ngày</value> 
   </data>
   <data name="WebAnnouncementTimeHoursBegin" xml:space="preserve">
-    <value>{0} 小时后开始</value>
+    <value>Bắt đầu sau {0} giờ</value> 
   </data>
   <data name="WebAnnouncementTimeHoursEnd" xml:space="preserve">
-    <value>{0} 小时后结束</value>
+    <value>Kết thúc sau {0} giờ</value> 
   </data>
   <data name="WebAnnouncementTimeEnded" xml:space="preserve">
-    <value>已结束</value>
+    <value>Đã Kết Thúc</value> 
   </data>
   <data name="WebAnnouncementTimeSuffixBegin" xml:space="preserve">
-    <value>后开始</value>
+    <value>sẽ bắt đầu</value> 
   </data>
   <data name="WebAnnouncementTimeSuffixEnd" xml:space="preserve">
-    <value>后结束</value>
+    <value>sẽ kết thúc</value> 
   </data>
   <data name="WebBridgeShareCopyToClipboardFailed" xml:space="preserve">
-    <value>打开剪贴板失败</value>
+    <value>Mở bộ nhớ tạm thất bại</value> 
   </data>
   <data name="WebBridgeShareCopyToClipboardSuccess" xml:space="preserve">
-    <value>已复制到剪贴板</value>
+    <value>Đã chép vào bộ nhớ tạm</value> 
   </data>
   <data name="WebBridgeShareFilePickerTitle" xml:space="preserve">
-    <value>保存分享图片</value>
+    <value>Lưu ảnh chia sẻ</value> 
   </data>
   <data name="WebBridgeShareSaveAsFileFailed" xml:space="preserve">
-    <value>图片保存失败</value>
+    <value>Lưu ảnh thất bại</value> 
   </data>
   <data name="WebBridgeShareSaveAsFileSuccess" xml:space="preserve">
-    <value>图片保存成功</value>
+    <value>Lưu ảnh thành công</value> 
   </data>
   <data name="WebBridgeShareSaveKindCopyToClipboard" xml:space="preserve">
-    <value>复制到剪贴板</value>
+    <value>Chép vào bộ nhớ tạm</value> 
   </data>
   <data name="WebBridgeShareSaveKindSaveAsFile" xml:space="preserve">
-    <value>保存为文件</value>
+    <value>Lưu thành Tệp</value> 
   </data>
   <data name="WebDailyNoteArchonQuestChapterFinished" xml:space="preserve">
-    <value>所有魔神任务已完成</value>
+    <value>Toàn bộ Nhiệm Vụ Ma Thần đã hoàn thành</value> 
   </data>
   <data name="WebDailyNoteArchonQuestStatusFinished" xml:space="preserve">
-    <value>全部完成</value>
+    <value>Hoàn Thành Hết</value> 
   </data>
   <data name="WebDailyNoteArchonQuestStatusNotOpen" xml:space="preserve">
-    <value>尚未开启</value>
+    <value>Chưa Mở</value> 
   </data>
   <data name="WebDailyNoteArchonQuestStatusOngoing" xml:space="preserve">
-    <value>进行中</value>
+    <value>Đang Tiến Hành</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusFinishedNonReward" xml:space="preserve">
-    <value>已完成</value>
+    <value>Đã Hoàn Thành</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusForbid" xml:space="preserve">
-    <value>禁止领取</value>
+    <value>Cấm Nhận</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusInvalid" xml:space="preserve">
-    <value>无效</value>
+    <value>Không Hợp Lệ</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusTakenAward" xml:space="preserve">
-    <value>已领取</value>
+    <value>Đã Nhận</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusUnfinished" xml:space="preserve">
-    <value>尚未完成</value>
+    <value>Chưa Hoàn Thành</value> 
   </data>
   <data name="WebDailyNoteAttendanceRewardStatusWaitTaken" xml:space="preserve">
-    <value>等待领取</value>
+    <value>Chờ Nhận</value> 
   </data>
   <data name="WebDailyNoteExpeditionRemainTime" xml:space="preserve">
-    <value>{0} 时 {1} 分</value>
+    <value>{0} giờ {1} phút</value> 
   </data>
   <data name="WebDailyNoteExtraTaskRewardNotAllowed" xml:space="preserve">
-    <value>今日完成委托数量不足</value>
+    <value>Số ủy thác hôm nay không đủ</value> 
   </data>
   <data name="WebDailyNoteExtraTaskRewardNotTaken" xml:space="preserve">
-    <value>「每日委托」奖励未领取</value>
+    <value>Thưởng "Nhiệm Vụ Hằng Ngày" chưa nhận</value> 
   </data>
   <data name="WebDailyNoteExtraTaskRewardReceived" xml:space="preserve">
-    <value>「每日委托」奖励已领取</value>
+    <value>Thưởng "Nhiệm Vụ Hằng Ngày" đã nhận</value> 
   </data>
   <data name="WebDailyNoteHomeCoinRecovery" xml:space="preserve">
-    <value>预计 {0} {1:HH:mm} 达到存储上限</value>
+    <value>Dự tính đạt giới hạn vào {0} {1:HH:mm}</value> 
   </data>
   <data name="WebDailyNoteHomeCoinRecoveryCompleted" xml:space="preserve">
-    <value>洞天宝钱已达存储上限</value>
+    <value>Tiền Động Tiên đã đầy</value> 
   </data>
   <data name="WebDailyNoteHomeCoinRecoveryTargetTime" xml:space="preserve">
-    <value>将于 {0:MM.dd HH:mm} 达到存储上限</value>
+    <value>Sẽ đạt giới hạn vào {0:MM.dd HH:mm}</value> 
   </data>
   <data name="WebDailyNoteHomeLocked" xml:space="preserve">
-    <value>尚未解锁洞天</value>
+    <value>Chưa mở khóa Động Tiên</value> 
   </data>
   <data name="WebDailyNoteResinRecovery" xml:space="preserve">
-    <value>将于 {0} {1:HH:mm} 后全部恢复</value>
+    <value>Khôi phục hoàn toàn sau {0} {1:HH:mm}</value> 
   </data>
   <data name="WebDailyNoteResinRecoveryCompleted" xml:space="preserve">
-    <value>原粹树脂已完全恢复</value>
+    <value>Nhựa Nguyên Chất đã đầy</value> 
   </data>
   <data name="WebDailyNoteResinRecoveryTargetTime" xml:space="preserve">
-    <value>将于 {0:MM.dd HH:mm} 全部恢复</value>
+    <value>Khôi phục hoàn toàn vào {0:MM.dd HH:mm}</value> 
   </data>
   <data name="WebDailyNoteStoredAttendanceRefreshCountdown" xml:space="preserve">
-    <value>{0:c} 后重置</value>
+    <value>Reset sau {0:c}</value> 
   </data>
   <data name="WebDailyNoteTransformerAppend" xml:space="preserve">
-    <value>后可再次使用</value>
+    <value>sau mới có thể dùng lại</value> 
   </data>
   <data name="WebDailyNoteTransformerDays" xml:space="preserve">
-    <value>{0} 天</value>
+    <value>{0} ngày</value> 
   </data>
   <data name="WebDailyNoteTransformerHours" xml:space="preserve">
-    <value>{0} 时</value>
+    <value>{0} giờ</value> 
   </data>
   <data name="WebDailyNoteTransformerMinutes" xml:space="preserve">
-    <value>{0} 分</value>
+    <value>{0} phút</value> 
   </data>
   <data name="WebDailyNoteTransformerNotObtained" xml:space="preserve">
-    <value>尚未获得</value>
+    <value>Chưa nhận được</value> 
   </data>
   <data name="WebDailyNoteTransformerNotObtainedDetail" xml:space="preserve">
-    <value>尚未获得参量质变仪</value>
+    <value>Bạn chưa nhận được Máy Biến Đổi Tham Số</value> 
   </data>
   <data name="WebDailyNoteTransformerNotReached" xml:space="preserve">
-    <value>冷却中</value>
+    <value>Đang Hồi Chiêu</value> 
   </data>
   <data name="WebDailyNoteTransformerReached" xml:space="preserve">
-    <value>可使用</value>
+    <value>Có Thể Dùng</value> 
   </data>
   <data name="WebDailyNoteTransformerReady" xml:space="preserve">
-    <value>已准备完成</value>
+    <value>Đã Sẵn Sàng</value> 
   </data>
   <data name="WebDailyNoteTransformerSeconds" xml:space="preserve">
-    <value>{0} 秒</value>
+    <value>{0} giây</value> 
   </data>
   <data name="WebDailyNoteVerificationFailed" xml:space="preserve">
-    <value>验证失败，请手动验证或前往「米游社-旅行工具-原神战绩-实时便笺」页面查看</value>
+    <value>Xác minh thất bại, vui lòng xác minh thủ công hoặc tới "HoyoLAB - Công cụ Lữ Hành - Chiến tích Genshin - Ghi chú Thời Gian Thực" để xem</value> 
   </data>
   <data name="WebDailyNoteWeekActiveProgressFinished" xml:space="preserve">
-    <value>本周已完成</value>
+    <value>Tuần này đã xong</value> 
   </data>
   <data name="WebDailyNoteWeekActiveProgressLocked" xml:space="preserve">
-    <value>尚未解锁</value>
+    <value>Chưa Mở Khóa</value> 
   </data>
   <data name="WebDailyNoteWeekActiveProgressPeriod" xml:space="preserve">
-    <value>阶段进度 {0}/{1}</value>
+    <value>Tiến độ Giai đoạn {0}/{1}</value> 
   </data>
   <data name="WebEnkaResponseStatusCode400" xml:space="preserve">
-    <value>错误的 UID 格式</value>
+    <value>Định dạng UID sai</value> 
   </data>
   <data name="WebEnkaResponseStatusCode404" xml:space="preserve">
-    <value>角色 UID 不存在，请稍候再试</value>
+    <value>UID Nhân vật không tồn tại, vui lòng thử lại sau</value> 
   </data>
   <data name="WebEnkaResponseStatusCode424" xml:space="preserve">
-    <value>游戏维护中</value>
+    <value>Game đang bảo trì</value> 
   </data>
   <data name="WebEnkaResponseStatusCode429" xml:space="preserve">
-    <value>请求过快，请稍后再试</value>
+    <value>Yêu cầu quá nhanh, vui lòng thử lại sau</value> 
   </data>
   <data name="WebEnkaResponseStatusCode500" xml:space="preserve">
-    <value>服务器偶发错误</value>
+    <value>Lỗi máy chủ phát sinh</value> 
   </data>
   <data name="WebEnkaResponseStatusCode503" xml:space="preserve">
-    <value>服务器严重错误</value>
+    <value>Lỗi máy chủ nghiêm trọng</value> 
   </data>
   <data name="WebEnkaResponseStatusCodeUnknown" xml:space="preserve">
-    <value>未知的服务器错误</value>
+    <value>Lỗi máy chủ không xác định</value> 
   </data>
   <data name="WebGachaConfigTypeAvatarEventWish" xml:space="preserve">
-    <value>角色活动祈愿</value>
+    <value>Cầu Nguyện Sự Kiện Nhân Vật</value> 
   </data>
   <data name="WebGachaConfigTypeAvatarEventWish2" xml:space="preserve">
-    <value>角色活动祈愿-2</value>
+    <value>Cầu Nguyện Sự Kiện Nhân Vật-2</value> 
   </data>
   <data name="WebGachaConfigTypeChronicledWish" xml:space="preserve">
-    <value>集录祈愿</value>
+    <value>Cầu Nguyện Sử Tập</value> 
   </data>
   <data name="WebGachaConfigTypeNoviceWish" xml:space="preserve">
-    <value>新手祈愿</value>
+    <value>Cầu Nguyện Tân Thủ</value> 
   </data>
   <data name="WebGachaConfigTypePermanentWish" xml:space="preserve">
-    <value>常驻祈愿</value>
+    <value>Cầu Nguyện Thường</value> 
   </data>
   <data name="WebGachaConfigTypeWeaponEventWish" xml:space="preserve">
-    <value>武器活动祈愿</value>
+    <value>Cầu Nguyện Sự Kiện Vũ Khí</value> 
   </data>
   <data name="WebGameResourcePathCopySucceed" xml:space="preserve">
-    <value>下载链接复制成功</value>
+    <value>Copy Link Tải thành công</value> 
   </data>
   <data name="WebHardChallengeBestAvatarTypeAllAttack" xml:space="preserve">
-    <value>最高总伤害</value>
+    <value>Tổng Sát Thương Cao Nhất</value> 
   </data>
   <data name="WebHardChallengeBestAvatarTypeOneAttack" xml:space="preserve">
-    <value>最强一击</value>
+    <value>Đòn Đánh Mạnh Nhất</value> 
   </data>
   <data name="WebHoyolabInvalidRegion" xml:space="preserve">
-    <value>无效的服务器</value>
+    <value>Server không hợp lệ</value> 
   </data>
   <data name="WebHoyolabInvalidUid" xml:space="preserve">
-    <value>无效的 UID</value>
+    <value>UID không hợp lệ</value> 
   </data>
   <data name="WebHoyolabRegionCNGF01" xml:space="preserve">
-    <value>国服 官方服</value>
+    <value>Server CN Chính Thức</value> 
   </data>
   <data name="WebHoyolabRegionCNQD01" xml:space="preserve">
-    <value>国服 渠道服</value>
+    <value>Server CN Kênh</value> 
   </data>
   <data name="WebHoyolabRegionOSASIA" xml:space="preserve">
-    <value>国际服 亚服</value>
+    <value>Server Quốc Tế Asia</value> 
   </data>
   <data name="WebHoyolabRegionOSCHT" xml:space="preserve">
-    <value>国际服 港澳台服</value>
+    <value>Server Quốc Tế TW/HK/MO</value> 
   </data>
   <data name="WebHoyolabRegionOSEURO" xml:space="preserve">
-    <value>国际服 欧服</value>
+    <value>Server Quốc Tế Europe</value> 
   </data>
   <data name="WebHoyolabRegionOSUSA" xml:space="preserve">
-    <value>国际服 美服</value>
+    <value>Server Quốc Tế America</value> 
   </data>
   <data name="WebLauncherServiceUnAvailable" xml:space="preserve">
-    <value>服务维护中</value>
+    <value>Dịch vụ đang bảo trì</value> 
   </data>
   <data name="WebIndexOrSpiralAbyssVerificationFailed" xml:space="preserve">
-    <value>验证失败，请手动验证或前往「米游社-旅行工具-原神战绩」页面查看</value>
+    <value>Xác minh thất bại, vui lòng xác minh thủ công hoặc tới "HoyoLAB - Công cụ Lữ Hành - Chiến Tích Genshin" để xem</value> 
   </data>
   <data name="WebRequestBuilderExceptionDescription" xml:space="preserve">
-    <value>在请求 {0} 时遇到问题</value>
+    <value>Gặp lỗi khi yêu cầu {0}</value> 
   </data>
   <data name="WebResponse" xml:space="preserve">
-    <value>状态：{0} | 信息：{1}</value>
+    <value>Trạng thái: {0} | Tin nhắn: {1}</value> 
   </data>
   <data name="WebResponseRefreshCookieHint" xml:space="preserve">
-    <value>请刷新 Cookie，原始消息：{0}</value>
+    <value>Vui lòng làm mới Cookie, Tin nhắn gốc: {0}</value> 
   </data>
   <data name="WebResponseRequestException" xml:space="preserve">
-    <value>[{0}] 中的 [{1}] 网络请求异常，请稍后再试</value>
+    <value>Lỗi yêu cầu mạng [{1}] ở [{0}], vui lòng thử lại sau</value> 
   </data>
   <data name="WebResponseSignInErrorHint" xml:space="preserve">
-    <value>登录失败，请前往 HoYoLAB 初始化账号，原始消息：{0}</value>
+    <value>Đăng nhập thất bại, vui lòng tới HoYoLAB khởi tạo tài khoản, Tin nhắn gốc: {0}</value> 
   </data>
   <data name="WindowIdentifyMonitorHeader" xml:space="preserve">
-    <value>显示器编号</value>
+    <value>ID Màn Hình</value> 
   </data>
   <data name="UIViewMainTitleBarInvertTheme" xml:space="preserve">
-    <value>主题切换</value>
+    <value>Chuyển đổi Giao Diện</value> 
   </data>
   <data name="ViewPageSettingAlwaysRunAsAdminText" xml:space="preserve">
-    <value>始终以管理员身份运行</value>
+    <value>Luôn Chạy Dưới Quyền Quản Trị Viên</value> 
   </data>
   <data name="ViewPageSettingAlwaysRunAsAdminTextDes" xml:space="preserve">
-    <value>将在手动启动应用时生效，建议开启自启动和管理员自启动以免启动各种功能时可能的UAC弹窗打扰</value>
+    <value>Sẽ có hiệu lực khi mở ứng dụng thủ công, khuyên dùng khi bật "Khởi động cùng hệ thống" hoặc "Chạy Quản trị viên khi khởi động" để tránh phiền phức bị UAC báo hỏi lúc bật chức năng</value> 
   </data>
   <data name="ViewPageSettingAutoStartHeader" xml:space="preserve">
-    <value>开机自启动</value>
+    <value>Khởi Động Cùng Hệ Thống</value> 
   </data>
   <data name="ViewPageSettingAutoStartDescription" xml:space="preserve">
-    <value>程序将在当前用户登录时启动，是否以管理员运行仅在修改时同步管理员模式选项（修改需以管理员身份运行）</value>
+    <value>Chương trình sẽ bật khi người dùng log in, Tùy chọn chạy Quản trị viên chỉ được đồng bộ nếu Sửa Cấu Hình khi dùng Quyền Quản Trị</value> 
   </data>
   <data name="ViewPageSettingAppBehaviorHeader" xml:space="preserve">
-    <value>应用行为</value>
+    <value>Hành Vi Ứng Dụng</value> 
   </data>
   <data name="ViewCardSignInAutoSignIn" xml:space="preserve">
-    <value>自动签到</value>
+    <value>Tự Động Điểm Danh</value> 
   </data>
   <data name="ServiceMetadataWeaponIdNotFound" xml:space="preserve">
-    <value>未找到武器元数据</value>
+    <value>Không tìm thấy Metadata Vũ Khí</value> 
   </data>
   <data name="ServiceMetadataAvatarIdNotFound" xml:space="preserve">
-    <value>未找到角色元数据</value>
+    <value>Không tìm thấy Metadata Nhân Vật</value> 
   </data>
   <data name="ServiceGachaLogIdPlacesUnsupported" xml:space="preserve">
-    <value>不支持的祈愿记录 ID 来源</value>
+    <value>Nguồn ID Bản ghi Cầu Nguyện Không Hỗ Trợ</value> 
   </data>
   <data name="ServiceGachaLogWeaponIdNotFound" xml:space="preserve">
-    <value>未找到武器 ID</value>
+    <value>Không Tìm Thấy ID Vũ Khí</value> 
   </data>
   <data name="ServiceGachaLogAvatarIdNotFound" xml:space="preserve">
-    <value>未找到角色 ID</value>
+    <value>Không Tìm Thấy ID Nhân Vật</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartOptionsHeader" xml:space="preserve">
-    <value>自定义启动</value>
+    <value>Khởi Động Tùy Chỉnh</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartDescription" xml:space="preserve">
-    <value>自定义启动选项允许快速启动其他路径的程序，内的游戏选项包括启动参数将不会生效</value>
+    <value>Tùy chọn khởi động tùy chỉnh cho phép chạy nhanh các ứng dụng khác, cài đặt Game hoặc Tham số khởi động trong Launcher sẽ không còn tác dụng với nó</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartCustomizeHeader" xml:space="preserve">
-    <value>用户自定义程序启动</value>
+    <value>Khởi chạy Phần mềm Tùy chỉnh Người dùng</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartPickPathHeader" xml:space="preserve">
-    <value>选择启动程序</value>
+    <value>Chọn Ứng dụng Khởi chạy</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartPickPathDescription" xml:space="preserve">
-    <value>选择需要启动的程序路径，以 '.exe' 结尾</value>
+    <value>Chọn đường dẫn ứng dụng để chạy, phải là đuôi '.exe'</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartOpenCommunityAction" xml:space="preserve">
-    <value>前往社区获取分享的程序</value>
+    <value>Tới cộng đồng lấy ứng dụng được chia sẻ</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartGame" xml:space="preserve">
-    <value>启动自定义程序</value>
+    <value>Mở phần mềm tùy chỉnh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartLoading" xml:space="preserve">
-    <value>正在加载自定义启动列表</value>
+    <value>Đang tải danh sách Khởi động Tùy chỉnh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartFeedMissing" xml:space="preserve">
-    <value>未配置自定义启动源地址</value>
+    <value>Chưa cài đặt link nguồn Khởi động Tùy chỉnh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartPick" xml:space="preserve">
-    <value>请选择一个自定义启动程序</value>
+    <value>Vui lòng chọn 1 Phần mềm Tùy chỉnh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartLoadFailed" xml:space="preserve">
-    <value>加载自定义启动列表失败</value>
+    <value>Lỗi khi Tải danh sách Khởi động Tùy chỉnh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartPickWarning" xml:space="preserve">
-    <value>请先选择自定义启动程序</value>
+    <value>Bạn cần chọn 1 Phần mềm Tùy chỉnh trước</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartCompleted" xml:space="preserve">
-    <value>已完成，程序路径：{0}</value>
+    <value>Hoàn tất, Đường dẫn Phần mềm: {0}</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartFailed" xml:space="preserve">
-    <value>下载或解压失败，请重试</value>
+    <value>Tải xuống hoặc Giải nén Thất bại, hãy thử lại</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartExecutableMissing" xml:space="preserve">
-    <value>未找到可执行文件</value>
+    <value>Không tìm thấy file thực thi</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartDownloading" xml:space="preserve">
-    <value>正在下载 {0}（{1}/{2}）</value>
+    <value>Đang tải {0} ({1}/{2})</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartExtracting" xml:space="preserve">
-    <value>正在解压 {0}（{1}/{2}）</value>
+    <value>Đang giải nén {0} ({1}/{2})</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartTitle" xml:space="preserve">
-    <value>下载来自自定义源的自定义程序</value>
+    <value>Tải các Phần mềm Tùy chỉnh qua Nguồn Custom</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartPrimary" xml:space="preserve">
-    <value>下载</value>
+    <value>Tải Xuống</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartEmpty" xml:space="preserve">
-    <value>暂无可用的自定义启动程序</value>
+    <value>Tạm chưa có Phần mềm Khởi động Tùy chỉnh nào cả</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartStatusHeader" xml:space="preserve">
-    <value>当前执行状态</value>
+    <value>Tình Trạng Thực Thi</value> 
   </data>
   <data name="ViewPageLaunchGameAdvancedStartOpenDownloaderAction" xml:space="preserve">
-    <value>快速获取并下载清单列表中的程序</value>
+    <value>Tải nhanh các phần mềm có trong Danh sách</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartUnknownServer" xml:space="preserve">
-    <value>未知服务器</value>
+    <value>Máy chủ Vô danh</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartDnsFailed" xml:space="preserve">
-    <value>无法连接到服务器 '{0}'：DNS 解析失败。 可能原因：
-1.	域名不存在或拼写错误
-2.	DNS 服务器故障
-3.	网络连接问题
-4.	防火墙或安全软件阻止了 DNS 查询 请检查网络设置后重试。</value>
+    <value>Không kết nối được tới '{0}': Phân giải DNS thất bại.Khả năng do:
+1. Domain không tồn tại hoặc Ghi sai
+2. Máy chủ DNS gặp lỗi
+3. Mạng bị ngắt kết nối
+4. Tường Lửa hoặc Antivirus cản truy vấn DNS. Vui lòng kiểm tra cài đặt mạng rồi thử lại.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartConnectionRefused" xml:space="preserve">
-    <value>服务器拒绝连接，请稍后重试。</value>
+    <value>Server từ chối kết nối, vui lòng thử lại sau.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartTimedOut" xml:space="preserve">
-    <value>连接超时，请检查网络连接。</value>
+    <value>Hết thời gian kết nối, vui lòng check lại mạng.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartNetworkDown" xml:space="preserve">
-    <value>网络连接不可用，请检查网络状态。</value>
+    <value>Mạng không hoạt động, hãy kiểm tra lại kết nối mạng.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartNetworkUnreachable" xml:space="preserve">
-    <value>网络不可达，请检查网络连接。</value>
+    <value>Mạng ngoài tầm với, xin vui lòng kiểm tra kết nối mạng.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartDnsNoData" xml:space="preserve">
-    <value>DNS 查询成功但未找到服务器记录，请确认地址正确性。</value>
+    <value>DNS phân giải nhưng Không Tìm Thấy Record Máy Chủ, vui lòng kiểm tra độ chính xác của địa chỉ.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartNetworkError" xml:space="preserve">
-    <value>网络连接错误：{0} (错误代码: {1})</value>
+    <value>Lỗi kết nối Mạng: {0} (Mã Lỗi: {1})</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartHttpError" xml:space="preserve">
-    <value>服务器返回错误：{0} {1}</value>
+    <value>Server trả Lỗi: {0} {1}</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartUnknownServerResponse" xml:space="preserve">
-    <value>服务器返回未知错误：{0}</value>
+    <value>Server trả Lỗi Bất Định: {0}</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartSecurityFailed" xml:space="preserve">
-    <value>安全连接失败：{0}，请检查系统时间和证书设置。</value>
+    <value>Kết nối Bảo mật Thất Bại: {0}. Xin kiểm tra giờ hệ thống và cài đặt Chứng chỉ.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartNetworkRequestFailed" xml:space="preserve">
-    <value>网络请求失败：{0}</value>
+    <value>Yêu cầu mạng Thất bại: {0}</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartDownloadCanceled" xml:space="preserve">
-    <value>下载 {0} 已被取消。</value>
+    <value>Đã Hủy tải xuống {0}.</value> 
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartDownloadTimeout" xml:space="preserve">
-    <value>下载 {0} 超时，请检查网络连接并重试。</value>
+    <value>Thời gian tải xuống {0} Quá Hạn, hãy kiểm tra mạng rồi làm lại.</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartOperationCanceled" xml:space="preserve">
-    <value>操作已取消：{0}</value>
+    <value>Thao tác đã hủy: {0}</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartIOError" xml:space="preserve">
-    <value>文件读写错误：{0}</value>
+    <value>Lỗi đọc ghi tệp: {0}</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartUnsupportedContentType" xml:space="preserve">
-    <value>不支持的响应内容类型：{0}</value>
+    <value>Loại nội dung phản hồi không được hỗ trợ: {0}</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartInvalidHeaders" xml:space="preserve">
-    <value>无效的 HTTP 头设置：{0}</value>
+    <value>Cài đặt Header HTTP không hợp lệ: {0}</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartUnknownError" xml:space="preserve">
-    <value>下载 {0} 时发生未知错误。 错误类型: {1} 请重试或联系支持。</value>
+    <value>Xảy ra lỗi không xác định khi tải {0}. Loại lỗi: {1} Vui lòng thử lại hoặc liên hệ bộ phận hỗ trợ.</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStart7zEntryDataError" xml:space="preserve">
-    <value>7z 解压失败（条目: {0}）：数据错误，归档可能损坏或使用了不受支持的 7z 压缩格式。请重试下载或使用 ZIP 包。</value>
+    <value>Giải nén 7z thất bại (Mục: {0}): Lỗi dữ liệu, tệp nén có thể bị hỏng hoặc sử dụng định dạng nén 7z không được hỗ trợ. Vui lòng tải lại hoặc sử dụng gói ZIP.</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStart7zDataError" xml:space="preserve">
-    <value>7z 解压失败：归档数据损坏或采用了不受支持的 7z 压缩方式。请重试下载或提供 ZIP 格式包。</value>
+    <value>Giải nén 7z thất bại: Dữ liệu tệp nén bị hỏng hoặc sử dụng phương pháp nén 7z không được hỗ trợ. Vui lòng tải lại hoặc cung cấp gói định dạng ZIP.</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartUnsupportedArchiveFormat" xml:space="preserve">
-    <value>不支持的归档格式！</value>
+    <value>Định dạng tệp nén không được hỗ trợ!</value>
   </data>
   <data name="ViewModelLaunchGameAdvancedStartProgramPathNotSet" xml:space="preserve">
-    <value>未设置自定义启动程序路径</value>
+    <value>Chưa thiết lập đường dẫn ứng dụng khởi động tùy chỉnh</value>
   </data>
   <data name="ViewModelLaunchGameAdvancedStartProgramNotExists" xml:space="preserve">
-    <value>自定义启动程序不存在</value>
+    <value>Ứng dụng khởi động tùy chỉnh không tồn tại</value>
   </data>
   <data name="ViewModelLaunchGameAdvancedStartProgramLaunched" xml:space="preserve">
-    <value>已启动自定义程序</value>
+    <value>Đã khởi chạy ứng dụng tùy chỉnh</value>
   </data>
   <data name="ViewModelLaunchGameAdvancedStartProgramPathSaved" xml:space="preserve">
-    <value>已保存自定义启动程序路径</value>
+    <value>Đã lưu đường dẫn ứng dụng khởi động tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartManager" xml:space="preserve">
-    <value>管理自定义程序启动</value>
+    <value>Quản lý khởi động ứng dụng tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartListSetter" xml:space="preserve">
-    <value>设置程序清单源</value>
+    <value>Thiết lập nguồn danh sách ứng dụng</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartGameDelayedStart" xml:space="preserve">
-    <value>启动延迟启动清单中程序</value>
+    <value>Khởi chạy ứng dụng trong danh sách khởi động trễ</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartDelayedStartList" xml:space="preserve">
-    <value>延时启动程序列表</value>
+    <value>Danh sách ứng dụng khởi động trễ</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartSourceDescription" xml:space="preserve">
-    <value>填写目标 json 格式的 http 链接</value>
+    <value>Điền liên kết http định dạng json mục tiêu</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedDelayedStartTitle" xml:space="preserve">
-    <value>延迟启动程序清单表</value>
+    <value>Bảng danh sách ứng dụng khởi động trễ</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartSourceSetterTitle" xml:space="preserve">
-    <value>程序列表获取源设置</value>
+    <value>Cài đặt nguồn lấy danh sách ứng dụng</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartSourceSetterBackToDefaultButton" xml:space="preserve">
-    <value>恢复默认</value>
+    <value>Khôi phục mặc định</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartSourceSetterSaveSuccess" xml:space="preserve">
-    <value>保存成功</value>
+    <value>Lưu thành công</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartDelayedStartListDelayedTime" xml:space="preserve">
-    <value>延迟（秒）</value>
+    <value>Độ trễ (giây)</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartDelayedStartListPath" xml:space="preserve">
-    <value>应用路径</value>
+    <value>Đường dẫn ứng dụng</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartDelayedStartListName" xml:space="preserve">
-    <value>应用名</value>
+    <value>Tên ứng dụng</value>
   </data>
   <data name="ViewDialogLaunchGameAdvancedStartInfoBarMessage" xml:space="preserve">
-    <value>将会下载到设置的数据目录的 AdvancedStart 文件夹下，可前往设置调整或自行管理</value>
+    <value>Sẽ được tải xuống thư mục AdvancedStart trong thư mục dữ liệu đã thiết lập, có thể vào Cài đặt để điều chỉnh hoặc tự quản lý</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartCoStartHeader" xml:space="preserve">
-    <value>连带启动</value>
+    <value>Khởi động kèm</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartCoStartDescription" xml:space="preserve">
-    <value>设置不同位置的启动是否触发延迟启动</value>
+    <value>Cài đặt xem việc khởi động ở các vị trí khác nhau có kích hoạt khởi động trễ hay không</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartCoStartAdvancedHeader" xml:space="preserve">
-    <value>启动自定义程序时触发延迟启动</value>
+    <value>Kích hoạt khởi động trễ khi khởi động ứng dụng tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameAdvancedStartCoStartGameHeader" xml:space="preserve">
-    <value>启动游戏时触发延迟启动</value>
+    <value>Kích hoạt khởi động trễ khi khởi động game</value>
   </data>
   <data name="ViewPageSettingOpenSourceSupportHeader" xml:space="preserve">
-    <value>开源支持</value>
+    <value>Hỗ trợ mã nguồn mở</value>
   </data>
   <data name="ViewCommonLoginRequiredHint" xml:space="preserve">
-    <value>请先登录后使用</value>
+    <value>Vui lòng đăng nhập trước khi sử dụng</value>
   </data>
   <data name="ViewCommonLoginQRCodeHeader" xml:space="preserve">
-    <value>扫码登录</value>
+    <value>Quét mã đăng nhập</value>
   </data>
   <data name="ViewCommonLoginQRCodeDescription" xml:space="preserve">
-    <value>使用米游社 App 扫码登录</value>
+    <value>Sử dụng App Miyoushe để quét mã đăng nhập</value>
   </data>
   <data name="ViewCommonLoginMobileCaptchaHeader" xml:space="preserve">
-    <value>手机验证码</value>
+    <value>Mã xác minh điện thoại</value>
   </data>
   <data name="ViewCommonLoginMobileCaptchaDescription" xml:space="preserve">
-    <value>使用手机号接收验证码登录</value>
+    <value>Sử dụng số điện thoại nhận mã xác minh để đăng nhập</value>
   </data>
   <data name="ViewCommonLoginManualInputHeader" xml:space="preserve">
-    <value>手动输入</value>
+    <value>Nhập thủ công</value>
   </data>
   <data name="ViewCommonLoginManualInputDescription" xml:space="preserve">
-    <value>手动输入 Cookie 登录</value>
+    <value>Nhập thủ công Cookie để đăng nhập</value>
   </data>
   <data name="ViewCommonConfirmButton" xml:space="preserve">
-    <value>确定</value>
+    <value>Xác nhận</value>
   </data>
   <data name="ViewCommonCancelButton" xml:space="preserve">
-    <value>取消</value>
+    <value>Hủy</value>
   </data>
   <data name="ViewHomeHeader" xml:space="preserve">
-    <value>主页</value>
+    <value>Trang chủ</value>
   </data>
   <data name="ViewAnnouncementNavHeader" xml:space="preserve">
-    <value>公告</value>
+    <value>Thông báo</value>
   </data>
   <data name="ViewSignInHeader" xml:space="preserve">
-    <value>签到福利</value>
+    <value>Phúc lợi Điểm danh</value>
   </data>
   <data name="ViewUserOverseaLoginTitle" xml:space="preserve">
-    <value>国际服账号登录 (HoYoLAB)</value>
+    <value>Đăng nhập tài khoản Server Quốc Tế (HoYoLAB)</value>
   </data>
   <data name="ViewUserOverseaThirdPartyHeader" xml:space="preserve">
-    <value>第三方登录</value>
+    <value>Đăng nhập bên thứ ba</value>
   </data>
   <data name="ViewUserOverseaThirdPartyDescription" xml:space="preserve">
-    <value>使用第三方账号登录 HoYoLAB</value>
+    <value>Sử dụng tài khoản bên thứ ba để đăng nhập HoYoLAB</value>
   </data>
   <data name="ViewUserOverseaPasswordHeader" xml:space="preserve">
-    <value>账密登录</value>
+    <value>Đăng nhập bằng tài khoản mật khẩu</value>
   </data>
   <data name="ViewUserOverseaPasswordDescription" xml:space="preserve">
-    <value>使用 HoYoLAB 账号密码登录</value>
+    <value>Sử dụng tài khoản mật khẩu HoYoLAB để đăng nhập</value>
   </data>
   <data name="ViewUserOverseaManualInputDescription" xml:space="preserve">
-    <value>手动输入国际服 Cookie 登录</value>
+    <value>Nhập thủ công Cookie Server Quốc Tế để đăng nhập</value>
   </data>
   <data name="ViewUserCurrentAccountHeader" xml:space="preserve">
-    <value>当前账号</value>
+    <value>Tài khoản hiện tại</value>
   </data>
   <data name="ViewPageAvatarPropertyRefreshLabel" xml:space="preserve">
-    <value>刷新</value>
+    <value>Làm mới</value>
   </data>
   <data name="ViewPageAvatarPropertyWeaponAffixPrefix" xml:space="preserve">
-    <value>精炼</value>
+    <value>Tinh Luyện</value>
   </data>
   <data name="ViewPageAvatarPropertyWeaponAffixSuffix" xml:space="preserve">
-    <value>阶</value>
+    <value>Bậc</value>
   </data>
   <data name="ViewPageHomeTabActivity" xml:space="preserve">
-    <value>活动</value>
+    <value>Sự kiện</value>
   </data>
   <data name="ViewPageHomeTabAnnouncement" xml:space="preserve">
-    <value>公告</value>
+    <value>Thông báo</value>
   </data>
   <data name="ViewPageHomeTabInfo" xml:space="preserve">
-    <value>资讯</value>
+    <value>Tin tức</value>
   </data>
   <data name="ViewPageHomeLaunchGameButton" xml:space="preserve">
-    <value>开始游戏</value>
+    <value>Bắt đầu game</value>
   </data>
   <data name="ViewPageHomeStopGameButton" xml:space="preserve">
-    <value>停止游戏</value>
+    <value>Dừng game</value>
   </data>
   <data name="ViewPageLaunchGameCleanButton" xml:space="preserve">
-    <value>清理</value>
+    <value>Dọn dẹp</value>
   </data>
   <data name="ViewPageLaunchGameCleanTooltip" xml:space="preserve">
-    <value>清理转换缓存资源，释放磁盘空间</value>
+    <value>Dọn dẹp tài nguyên cache chuyển đổi, giải phóng dung lượng ổ đĩa</value>
   </data>
   <data name="ViewPageLaunchGameServerInfoTooltip" xml:space="preserve">
-    <value>查看服务器说明</value>
+    <value>Xem mô tả máy chủ</value>
   </data>
   <data name="ViewPageLaunchGameHdrManualHeader" xml:space="preserve">
-    <value>HDR 手动控制</value>
+    <value>HDR điều khiển thủ công</value>
   </data>
   <data name="ViewPageLaunchGameHdrManualDescription" xml:space="preserve">
-    <value>手动开启或关闭显示器 HDR（独立于游戏启动）</value>
+    <value>Bật hoặc tắt thủ công HDR của màn hình (Độc lập với lúc game khởi động)</value>
   </data>
   <data name="ViewPageLaunchGameCommandLineHeader" xml:space="preserve">
-    <value>启动参数</value>
+    <value>Tham số khởi động</value>
   </data>
   <data name="ViewPageLaunchGameCommandLineDescription" xml:space="preserve">
-    <value>自定义游戏启动参数</value>
+    <value>Tùy chỉnh tham số khởi động game</value>
   </data>
   <data name="ViewPageLaunchGameWindowedHeader" xml:space="preserve">
-    <value>窗口</value>
+    <value>Cửa sổ</value>
   </data>
   <data name="ViewPageLaunchGameWindowedDescription" xml:space="preserve">
-    <value>以窗口模式启动</value>
+    <value>Khởi động ở chế độ cửa sổ</value>
   </data>
   <data name="ViewPageLaunchGameBorderlessHeader" xml:space="preserve">
-    <value>无边框窗口</value>
+    <value>Cửa sổ không viền</value>
   </data>
   <data name="ViewPageLaunchGameBorderlessDescription" xml:space="preserve">
-    <value>以无边框窗口模式启动</value>
+    <value>Khởi động ở chế độ cửa sổ không viền</value>
   </data>
   <data name="ViewPageLaunchGameFullScreenHeader" xml:space="preserve">
-    <value>全屏</value>
+    <value>Toàn màn hình</value>
   </data>
   <data name="ViewPageLaunchGameFullScreenDescription" xml:space="preserve">
-    <value>以全屏模式启动</value>
+    <value>Khởi động ở chế độ toàn màn hình</value>
   </data>
   <data name="ViewPageLaunchGameResolutionPresetHeader" xml:space="preserve">
-    <value>分辨率预设</value>
+    <value>Preset độ phân giải</value>
   </data>
   <data name="ViewPageLaunchGameResolutionPresetDescription" xml:space="preserve">
-    <value>快速选择常用分辨率</value>
+    <value>Chọn nhanh độ phân giải thường dùng</value>
   </data>
   <data name="ViewPageLaunchGameResolutionCustom" xml:space="preserve">
-    <value>自定义</value>
+    <value>Tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameScreenWidthHeader" xml:space="preserve">
-    <value>屏幕宽度</value>
+    <value>Chiều rộng màn hình</value>
   </data>
   <data name="ViewPageLaunchGameScreenWidthDescription" xml:space="preserve">
-    <value>自定义屏幕宽度</value>
+    <value>Tùy chỉnh chiều rộng màn hình</value>
   </data>
   <data name="ViewPageLaunchGameScreenHeightHeader" xml:space="preserve">
-    <value>屏幕高度</value>
+    <value>Chiều cao màn hình</value>
   </data>
   <data name="ViewPageLaunchGameScreenHeightDescription" xml:space="preserve">
-    <value>自定义屏幕高度</value>
+    <value>Tùy chỉnh chiều cao màn hình</value>
   </data>
   <data name="ViewPageLaunchGameProgramLinkHeader" xml:space="preserve">
-    <value>程序联动</value>
+    <value>Liên kết ứng dụng</value>
   </data>
   <data name="ViewPageLaunchGameProgramLinkDescription" xml:space="preserve">
-    <value>启动游戏后自动运行其他程序</value>
+    <value>Tự động chạy ứng dụng khác sau khi khởi động game</value>
   </data>
   <data name="ViewPageLaunchGameBgiHeader" xml:space="preserve">
-    <value>BGI 联动启动</value>
+    <value>Khởi động liên kết BGI</value>
   </data>
   <data name="ViewPageLaunchGameBgiDescription" xml:space="preserve">
-    <value>启动游戏后自动启动 BetterGI</value>
+    <value>Tự động khởi động BetterGI sau khi khởi động game</value>
   </data>
   <data name="ViewPageLaunchGameBgiSelectButton" xml:space="preserve">
-    <value>选择 BGI 程序</value>
+    <value>Chọn ứng dụng BGI</value>
   </data>
   <data name="ViewPageLaunchGameClearSelection" xml:space="preserve">
-    <value>清除选择</value>
+    <value>Xóa lựa chọn</value>
   </data>
   <data name="ViewPageLaunchGameBgiDelayHeader" xml:space="preserve">
-    <value>BGI 延迟启动</value>
+    <value>BGI khởi động trễ</value>
   </data>
   <data name="ViewPageLaunchGameDelayParamDescription" xml:space="preserve">
-    <value>延迟/参数</value>
+    <value>Độ trễ/Tham số</value>
   </data>
   <data name="ViewPageLaunchGameDelayNone" xml:space="preserve">
-    <value>无延迟 (0秒)</value>
+    <value>Không trễ (0 giây)</value>
   </data>
   <data name="ViewPageLaunchGameDelay3s" xml:space="preserve">
-    <value>3 秒</value>
+    <value>3 giây</value>
   </data>
   <data name="ViewPageLaunchGameDelay5s" xml:space="preserve">
-    <value>5 秒</value>
+    <value>5 giây</value>
   </data>
   <data name="ViewPageLaunchGameDelay10s" xml:space="preserve">
-    <value>10 秒</value>
+    <value>10 giây</value>
   </data>
   <data name="ViewPageLaunchGameDelay15s" xml:space="preserve">
-    <value>15 秒</value>
+    <value>15 giây</value>
   </data>
   <data name="ViewPageLaunchGameArgsPlaceholder" xml:space="preserve">
-    <value>启动参数(可选)</value>
+    <value>Tham số khởi động (tùy chọn)</value>
   </data>
   <data name="ViewPageLaunchGameSelectProgramButton" xml:space="preserve">
-    <value>选择程序</value>
+    <value>Chọn ứng dụng</value>
   </data>
   <data name="ViewPageLaunchGameAttachProgram1Header" xml:space="preserve">
-    <value>附加程序启动 1</value>
+    <value>Khởi động ứng dụng đính kèm 1</value>
   </data>
   <data name="ViewPageLaunchGameAttachProgram1Description" xml:space="preserve">
-    <value>启动游戏后自动运行自定义程序</value>
+    <value>Tự động chạy ứng dụng tùy chỉnh sau khi khởi động game</value>
   </data>
   <data name="ViewPageLaunchGameAttachDelay1Header" xml:space="preserve">
-    <value>延迟启动 1</value>
+    <value>Khởi động trễ 1</value>
   </data>
   <data name="ViewPageLaunchGameAttachProgram2Header" xml:space="preserve">
-    <value>附加程序启动 2</value>
+    <value>Khởi động ứng dụng đính kèm 2</value>
   </data>
   <data name="ViewPageLaunchGameAttachDelay2Header" xml:space="preserve">
-    <value>延迟启动 2</value>
+    <value>Khởi động trễ 2</value>
   </data>
   <data name="ViewPageLaunchGameAttachProgram3Header" xml:space="preserve">
-    <value>附加程序启动 3</value>
+    <value>Khởi động ứng dụng đính kèm 3</value>
   </data>
   <data name="ViewPageLaunchGameAttachDelay3Header" xml:space="preserve">
-    <value>延迟启动 3</value>
+    <value>Khởi động trễ 3</value>
   </data>
   <data name="ViewPageLaunchGameIslandFovToggleHeader" xml:space="preserve">
-    <value>视野热开关</value>
+    <value>Công tắc nóng Tầm nhìn</value>
   </data>
   <data name="ViewPageLaunchGameIslandFovAdjustHeader" xml:space="preserve">
-    <value>调整视野</value>
+    <value>Chỉnh Tầm nhìn</value>
   </data>
   <data name="ViewPageLaunchGameIslandDisableFogHeader" xml:space="preserve">
-    <value>移除迷雾</value>
+    <value>Xóa sương mù</value>
   </data>
   <data name="ViewPageLaunchGameIslandCraftRedirectHeader" xml:space="preserve">
-    <value>可合成重定向</value>
+    <value>Chuyển hướng Đài Ghép</value>
   </data>
   <data name="ViewPageLaunchGameIslandFpsHeader" xml:space="preserve">
-    <value>帧率模式</value>
+    <value>Chế độ FPS</value>
   </data>
   <data name="ViewPageLaunchGameIslandFpsTargetHeader" xml:space="preserve">
-    <value>目标帧率</value>
+    <value>FPS Mục tiêu</value>
   </data>
   <data name="ViewPageLaunchGameIslandDisableCharFadeHeader" xml:space="preserve">
-    <value>禁用角色渐隐</value>
+    <value>Tắt mờ dần nhân vật</value>
   </data>
   <data name="ViewPageLaunchGameIslandDisableVSyncHeader" xml:space="preserve">
-    <value>禁用垂直同步</value>
+    <value>Tắt V-Sync (Đồng bộ dọc)</value>
   </data>
   <data name="ViewPageLaunchGameIslandHideQuestBannerHeader" xml:space="preserve">
-    <value>隐藏地图卡片</value>
+    <value>Ẩn banner nhiệm vụ</value>
   </data>
   <data name="ViewPageLaunchGameIslandHideMenuUidHeader" xml:space="preserve">
-    <value>隐藏菜单UID</value>
+    <value>Ẩn UID Menu</value>
   </data>
   <data name="ViewPageLaunchGameIslandFixLowFovHeader" xml:space="preserve">
-    <value>低视距修正</value>
+    <value>Sửa tầm nhìn thấp</value>
   </data>
   <data name="ViewPageLaunchGameIslandPortableCraftHeader" xml:space="preserve">
-    <value>随身合成台</value>
+    <value>Đài Ghép tùy thân</value>
   </data>
   <data name="ViewPageLaunchGameIslandModifierKeyHeader" xml:space="preserve">
-    <value>修饰键</value>
+    <value>Phím bổ trợ</value>
   </data>
   <data name="ViewPageLaunchGameIslandVkCodeHeader" xml:space="preserve">
-    <value>VK码</value>
+    <value>Mã VK</value>
   </data>
   <data name="ViewPageLaunchGameIslandRemoveTeamProgressHeader" xml:space="preserve">
-    <value>移除队伍配置进度条</value>
+    <value>Xóa thanh tiến trình Đội Ngũ</value>
   </data>
   <data name="ViewPageLaunchGameIslandDisableQAnimHeader" xml:space="preserve">
-    <value>移除Q动画播放</value>
+    <value>Xóa hiệu ứng Cận cảnh Nộ (Q)</value>
   </data>
   <data name="ViewPageLaunchGameIslandReloadHotkeyHeader" xml:space="preserve">
-    <value>重载配置热键</value>
+    <value>Phím tắt tải lại cấu hình</value>
   </data>
   <data name="ViewPageLaunchGameIslandRemoveDamageTextHeader" xml:space="preserve">
-    <value>移除战斗伤害数字</value>
+    <value>Xóa số sát thương chiến đấu</value>
   </data>
   <data name="ViewPageLaunchGameIslandTouchScreenHeader" xml:space="preserve">
-    <value>手机端模式</value>
+    <value>Chế độ Mobile</value>
   </data>
   <data name="ViewPageLaunchGameIslandHideGameUidHeader" xml:space="preserve">
-    <value>隐藏游戏内UID</value>
+    <value>Ẩn UID trong game</value>
   </data>
   <data name="ViewPageLaunchGameIslandCookingHotkeyHeader" xml:space="preserve">
-    <value>烹饪快捷键</value>
+    <value>Phím tắt Nấu Ăn</value>
   </data>
   <data name="ViewPageLaunchGameIslandForgeHotkeyHeader" xml:space="preserve">
-    <value>锻造快捷键</value>
+    <value>Phím tắt Rèn</value>
   </data>
   <data name="ViewPageLaunchGameIslandGuiHotkeyHeader" xml:space="preserve">
-    <value>GUI快捷键</value>
+    <value>Phím tắt GUI</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamHeader" xml:space="preserve">
-    <value>自由相机</value>
+    <value>Camera tự do</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamLockHeader" xml:space="preserve">
-    <value>固定镜头</value>
+    <value>Khóa ống kính</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamMoveSpeedHeader" xml:space="preserve">
-    <value>移动速度</value>
+    <value>Tốc độ di chuyển</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamSprintMultHeader" xml:space="preserve">
-    <value>加速倍率</value>
+    <value>Bội số tăng tốc</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamMouseSensitivityHeader" xml:space="preserve">
-    <value>鼠标灵敏度</value>
+    <value>Độ nhạy chuột</value>
   </data>
   <data name="ViewPageLaunchGameIslandFreeCamPitchLimitHeader" xml:space="preserve">
-    <value>俯仰角限制</value>
+    <value>Giới hạn góc Pitch</value>
   </data>
   <data name="ViewPageLaunchGameIslandNoGrassHeader" xml:space="preserve">
-    <value>除草</value>
+    <value>Nhổ cỏ</value>
   </data>
   <data name="ViewPageLaunchGameIslandNoTreeLeafHeader" xml:space="preserve">
-    <value>隐藏树叶</value>
+    <value>Ẩn lá cây</value>
   </data>
   <data name="ViewPageLaunchGameIslandDispatchHotkeyHeader" xml:space="preserve">
-    <value>探索派遣快捷键</value>
+    <value>Phím tắt Phái Đi Thám Hiểm</value>
   </data>
   <data name="ViewPageLaunchGameIslandToggleOn" xml:space="preserve">
-    <value>开</value>
+    <value>Bật</value>
   </data>
   <data name="ViewPageLaunchGameIslandToggleOff" xml:space="preserve">
-    <value>关</value>
+    <value>Tắt</value>
   </data>
-
   <data name="ViewPageLaunchGameIslandToggleKeep" xml:space="preserve">
-    <value>保留</value>
+    <value>Giữ lại</value>
   </data>
   <data name="ViewPageLaunchGameIslandToggleRemove" xml:space="preserve">
-    <value>移除</value>
+    <value>Gỡ bỏ</value>
   </data>
   <data name="ViewPageLaunchGameIslandToggleHide" xml:space="preserve">
-    <value>隐藏</value>
+    <value>Ẩn</value>
   </data>
   <data name="ViewPageLaunchGameIslandToggleShow" xml:space="preserve">
-    <value>显示</value>
+    <value>Hiện</value>
   </data>
   <data name="ViewPageLaunchGameIslandModifierNone" xml:space="preserve">
-    <value>无</value>
+    <value>Không có</value>
   </data>
   <data name="ViewPageLaunchGameAutomationHotkeyHint" xml:space="preserve">
-    <value>快捷键按一下开启，再按一下关闭</value>
+    <value>Nhấn phím tắt một lần để bật, nhấn lần nữa để tắt</value>
   </data>
   <data name="ViewPageLaunchGameVkReferenceHeader" xml:space="preserve">
-    <value>VK码参考</value>
+    <value>Tham khảo mã VK</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllHeader" xml:space="preserve">
-    <value>自定义插件</value>
+    <value>Plugin tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllDescription" xml:space="preserve">
-    <value>允许添加自定义 DLL 文件作为插件加载</value>
+    <value>Cho phép thêm tệp DLL tùy chỉnh tải dưới dạng plugin</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllEnabledHeader" xml:space="preserve">
-    <value>启用自定义插件</value>
+    <value>Bật Plugin tùy chỉnh</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllEnabledDescription" xml:space="preserve">
-    <value>开启后，启动游戏时将加载下方列表中的 DLL 插件</value>
+    <value>Sau khi bật, khi khởi động game sẽ tải các plugin DLL trong danh sách dưới đây</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllListHeader" xml:space="preserve">
-    <value>DLL 文件列表</value>
+    <value>Danh sách tệp DLL</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllListEmpty" xml:space="preserve">
-    <value>尚未添加任何 DLL 文件</value>
+    <value>Chưa thêm bất kỳ tệp DLL nào</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllAdd" xml:space="preserve">
-    <value>添加 DLL</value>
+    <value>Thêm DLL</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllRemove" xml:space="preserve">
-    <value>移除</value>
+    <value>Xóa</value>
   </data>
   <data name="ViewPageLaunchGameCustomDllWarning" xml:space="preserve">
-    <value>注意：加载第三方 DLL 插件可能导致封号风险，请谨慎使用</value>
+    <value>Chú ý: Tải plugin DLL bên thứ ba có nguy cơ bị khóa tài khoản, vui lòng sử dụng cẩn thận</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryDigit" xml:space="preserve">
-    <value>数字键</value>
+    <value>Phím số</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryLetter" xml:space="preserve">
-    <value>字母键</value>
+    <value>Phím chữ</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryFunction" xml:space="preserve">
-    <value>功能键</value>
+    <value>Phím chức năng</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryNumpad" xml:space="preserve">
-    <value>小键盘</value>
+    <value>Phím Numpad (phím số phụ)</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryControl" xml:space="preserve">
-    <value>控制键</value>
+    <value>Phím điều khiển</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryNavigation" xml:space="preserve">
-    <value>导航键</value>
+    <value>Phím điều hướng</value>
   </data>
   <data name="ViewPageLaunchGameVkCategorySymbol" xml:space="preserve">
-    <value>符号键</value>
+    <value>Phím ký hiệu</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryMouse" xml:space="preserve">
-    <value>鼠标按键</value>
+    <value>Nút chuột</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryMedia" xml:space="preserve">
-    <value>多媒体键</value>
+    <value>Phím đa phương tiện</value>
   </data>
   <data name="ViewPageLaunchGameVkCategoryOther" xml:space="preserve">
-    <value>其他按键</value>
+    <value>Các phím khác</value>
   </data>
   <data name="ViewPageLaunchGameVkMouseLeft" xml:space="preserve">
-    <value>鼠标左键</value>
+    <value>Chuột trái</value>
   </data>
   <data name="ViewPageLaunchGameVkMouseRight" xml:space="preserve">
-    <value>鼠标右键</value>
+    <value>Chuột phải</value>
   </data>
   <data name="ViewPageLaunchGameVkMouseMiddle" xml:space="preserve">
-    <value>鼠标中键</value>
+    <value>Chuột giữa</value>
   </data>
   <data name="ViewPageLaunchGameVkMouseSide1" xml:space="preserve">
-    <value>鼠标侧键1</value>
+    <value>Nút sườn chuột 1</value>
   </data>
   <data name="ViewPageLaunchGameVkMouseSide2" xml:space="preserve">
-    <value>鼠标侧键2</value>
+    <value>Nút sườn chuột 2</value>
   </data>
   <data name="ViewPageLaunchGameServerInfoNoDescription" xml:space="preserve">
-    <value>暂无说明</value>
+    <value>Tạm chưa có mô tả</value>
   </data>
   <data name="ViewPageLaunchGameInjectionConfirmText" xml:space="preserve">
-    <value>我已知晓此些功能带来的风险并自愿使用</value>
+    <value>Tôi đã biết rủi ro của những chức năng này và tự nguyện sử dụng</value>
   </data>
   <data name="ViewPageLaunchGameInjectionInputPlaceholder" xml:space="preserve">
-    <value>请在此手动输入上方红色确认文字</value>
+    <value>Vui lòng nhập thủ công dòng chữ xác nhận màu đỏ bên trên vào đây</value>
   </data>
   <data name="ViewPageLaunchGameInjectionDisclaimerTitle" xml:space="preserve">
-    <value>插件功能风险告知协议</value>
+    <value>Thỏa thuận thông báo rủi ro tính năng Plugin</value>
   </data>
   <data name="ViewPageLaunchGameInjectionDisclaimerContent" xml:space="preserve">
-    <value>开启插件功能后，ky3 Launcher 将向原神游戏进程加载消息模块（DLL 插件），以实现以下功能：
+    <value>Sau khi bật tính năng plugin, ky3 Launcher sẽ nạp Plugin DLL vào tiến trình game Genshin Impact, nhằm thực hiện các tính năng sau:
 
-· 视野调整 / 移除迷雾
-· 帧率解锁 / 禁用垂直同步
-· 禁用角色渐隐 / 移除 Q 动画播放
-· 隐藏地图卡片 / 隐藏菜单 UID / 隐藏游戏内 UID
-· 随身合成台 / 可合成重定向
-· 移除队伍配置进度条 / 移除战斗伤害数字
-· 探索派遣快捷键 / 烹饪快捷键 / 锻造快捷键
-· 手机端模式 / 重载配置热键
+· Chỉnh tầm nhìn / Xóa sương mù
+· Mở khóa FPS / Tắt V-Sync
+· Ẩn che nhân vật khi nhìn gần / Xóa Hoạt ảnh Nộ (Q)
+· Ẩn banner nhiệm vụ / Ẩn UID Menu / Ẩn UID trong game
+· Đài Ghép tức thì / Chuyển hướng Đài Ghép trực tiếp (không cần dịch chuyển)
+· Đổi tổ đội tức thì / Ẩn sát thương khi chiến đấu
+· Phím tắt Phái Đi Thám Hiểm / Phím tắt Nấu Ăn / Phím tắt Rèn
+· Chế độ Mobile / Phím tắt tải lại cấu hình
 
-风险提示：
-1. 上述功能通过修改游戏运行时内存实现，属于第三方干预行为。
-2. 使用这些功能违反《原神》用户服务协议，可能导致账号被永久封禁。
-3. 插件加载操作可能引起游戏崩溃、数据异常或与反作弊系统冲突。
-4. 开发者不对因使用插件功能导致的任何后果（包括但不限于封号、数据丢失）承担任何责任。
-5. 您应自行承担使用这些功能所带来的全部风险。
+Cảnh báo rủi ro:
+1. Các chức năng trên được thực hiện bằng cách sửa đổi bộ nhớ khi game đang chạy, thuộc về hành vi can thiệp của bên thứ ba.
+2. Việc sử dụng các chức năng này vi phạm Thỏa thuận Dịch vụ Người dùng "Genshin Impact" và có thể dẫn đến việc tài khoản bị khóa vĩnh viễn.
+3. Thao tác tải plugin có thể gây crash game, bất thường dữ liệu hoặc xung đột với hệ thống chống gian lận.
+4. Nhà phát triển không chịu bất kỳ trách nhiệm nào đối với bất kỳ hậu quả nào (bao gồm nhưng không giới hạn việc bị khóa tài khoản, mất dữ liệu) do việc sử dụng chức năng plugin gây ra.
+5. Bạn phải tự chịu toàn bộ rủi ro do việc sử dụng các chức năng này mang lại.
 
-如您已充分了解上述风险并自愿使用，请在下方手动输入以下文字：</value>
+Nếu bạn đã hiểu đầy đủ các rủi ro trên và tự nguyện sử dụng, vui lòng nhập thủ công dòng chữ sau vào bên dưới:</value>
   </data>
   <data name="ViewPageLaunchGameInjectionDialogTitle" xml:space="preserve">
-    <value>风险确认</value>
+    <value>Xác nhận rủi ro</value>
   </data>
   <data name="ViewPageLaunchGameInjectionConfirmButton" xml:space="preserve">
-    <value>确认开启</value>
+    <value>Xác nhận bật</value>
   </data>
   <data name="ViewPageLaunchGameInjectionErrorTitle" xml:space="preserve">
-    <value>输入不正确</value>
+    <value>Nhập không chính xác</value>
   </data>
   <data name="ViewPageLaunchGameInjectionErrorContent" xml:space="preserve">
-    <value>您输入的确认文字与要求不一致，插件功能未开启。</value>
+    <value>Dòng chữ xác nhận bạn nhập không khớp với yêu cầu, chức năng plugin chưa được bật.</value>
   </data>
   <data name="ViewPageLaunchGameHdrUnavailableTitle" xml:space="preserve">
-    <value>HDR 不可用</value>
+    <value>HDR không khả dụng</value>
   </data>
   <data name="ViewPageLaunchGameHdrUnavailableContent" xml:space="preserve">
-    <value>当前显示器不支持 HDR，无法开启。</value>
+    <value>Màn hình hiện tại không hỗ trợ HDR, không thể bật.</value>
   </data>
   <data name="ViewPageAvatarPropertyPropertiesHeader" xml:space="preserve">
-    <value>角色属性</value>
+    <value>Thuộc tính nhân vật</value>
   </data>
   <data name="ViewDialogCleanResourceTitle" xml:space="preserve">
-    <value>清理转换资源</value>
+    <value>Dọn dẹp tài nguyên chuyển đổi</value>
   </data>
   <data name="ViewDialogCleanResourceCloseButton" xml:space="preserve">
-    <value>取消</value>
+    <value>Hủy</value>
   </data>
   <data name="ViewDialogCleanResourcePrimaryButton" xml:space="preserve">
-    <value>清理选中</value>
+    <value>Dọn dẹp mục đã chọn</value>
   </data>
   <data name="ViewDialogCleanResourceDescription" xml:space="preserve">
-    <value>选择要清理的转换缓存资源，此操作不会影响游戏本体。</value>
+    <value>Chọn tài nguyên cache chuyển đổi muốn dọn dẹp, thao tác này không ảnh hưởng đến bản thân game.</value>
   </data>
   <data name="ViewDialogCleanResourceSelectedText" xml:space="preserve">
-    <value>选中：{0}</value>
+    <value>Đã chọn: {0}</value>
   </data>
   <data name="ViewDialogCleanResourceChunksName" xml:space="preserve">
-    <value>转换下载分块</value>
+    <value>Phân mảnh tải xuống chuyển đổi</value>
   </data>
   <data name="ViewDialogCleanResourceOverseaName" xml:space="preserve">
-    <value>国际服备份资源</value>
+    <value>Tài nguyên dự phòng Server Quốc Tế</value>
   </data>
   <data name="ViewDialogCleanResourceChineseName" xml:space="preserve">
-    <value>国服备份资源</value>
+    <value>Tài nguyên dự phòng Server Chính Thức</value>
   </data>
   <data name="ViewDialogCleanResourceNoSize" xml:space="preserve">
-    <value>无</value>
+    <value>Trống</value>
   </data>
   <data name="ServiceBackgroundActivityFullTrustReady" xml:space="preserve">
-    <value>已就绪 在使用时执行</value>
+    <value>Đã sẵn sàng. Sẽ thực thi khi sử dụng</value>
   </data>
   <data name="ServiceBackgroundActivityFullTrustNotReady" xml:space="preserve">
-    <value>未就绪</value>
+    <value>Chưa sẵn sàng</value>
   </data>
   <data name="ServiceAppOptionsBackdropAcrylic" xml:space="preserve">
-    <value>Acrylic - 亚克力毛玻璃</value>
+    <value>Acrylic - Kính mờ Acrylic</value>
   </data>
   <data name="ServiceAppOptionsBackdropAcrylicThin" xml:space="preserve">
-    <value>AcrylicThin - 薄亚克力</value>
+    <value>AcrylicThin - Acrylic mỏng</value>
   </data>
   <data name="ServiceAppOptionsBackdropMica" xml:space="preserve">
-    <value>Mica - 云母</value>
+    <value>Mica - Vân mẫu</value>
   </data>
   <data name="ServiceAppOptionsBackdropMicaAlt" xml:space="preserve">
-    <value>MicaAlt - 云母变体</value>
+    <value>MicaAlt - Biến thể Vân mẫu</value>
   </data>
   <data name="ServiceBackgroundActivityFullTrustInit" xml:space="preserve">
-    <value>功能插件组件</value>
+    <value>Thành phần Plugin chức năng</value>
   </data>
   <data name="ServiceBackgroundActivityFullTrustInitDescription" xml:space="preserve">
-    <value>已就绪</value>
+    <value>Đã sẵn sàng</value>
   </data>
   <data name="ServiceLaunchSchemeDescCnDefault" xml:space="preserve">
-    <value>官服默认渠道</value>
+    <value>Kênh mặc định Server Chính Thức</value>
   </data>
   <data name="ServiceLaunchSchemeDescCnOfficialDefault" xml:space="preserve">
-    <value>官服默认启动器，适合大多数玩家</value>
+    <value>Launcher mặc định Server Chính Thức, phù hợp với đa số người chơi</value>
   </data>
   <data name="ServiceLaunchSchemeDescCnOfficialOfficial" xml:space="preserve">
-    <value>官服完整启动器，米哈游官方渠道</value>
+    <value>Launcher đầy đủ Server Chính Thức, kênh chính thức miHoYo</value>
   </data>
   <data name="ServiceLaunchSchemeDescCnOfficialNoTapTap" xml:space="preserve">
-    <value>非TapTap渠道版，适合小米/华为等应用商店</value>
+    <value>Phiên bản không phải kênh TapTap, phù hợp với kho ứng dụng Xiaomi/Huawei</value>
   </data>
   <data name="ServiceLaunchSchemeDescCnBili" xml:space="preserve">
-    <value>B站专属服务器，需使用B站账号登录</value>
+    <value>Máy chủ độc quyền Bilibili, cần sử dụng tài khoản Bilibili để đăng nhập</value>
   </data>
   <data name="ServiceLaunchSchemeDescOsDefault" xml:space="preserve">
-    <value>国际服默认渠道</value>
+    <value>Kênh mặc định Server Quốc Tế</value>
   </data>
   <data name="ServiceLaunchSchemeDescOsOfficialDefault" xml:space="preserve">
-    <value>国际服默认启动器，全球通用</value>
+    <value>Launcher mặc định Server Quốc Tế, thông dụng toàn cầu</value>
   </data>
   <data name="ServiceLaunchSchemeDescOsOfficialOfficial" xml:space="preserve">
-    <value>国际服完整启动器，米哈游国际渠道</value>
+    <value>Launcher đầy đủ Server Quốc Tế, kênh Quốc tế của miHoYo</value>
   </data>
   <data name="ServiceLaunchSchemeDescOsEpic" xml:space="preserve">
-    <value>Epic游戏商城版本</value>
+    <value>Phiên bản Epic Games Store</value>
   </data>
   <data name="ServiceLaunchSchemeDescOsGoogle" xml:space="preserve">
-    <value>Google Play商店版本</value>
+    <value>Phiên bản Google Play Store</value>
   </data>
   <data name="ServiceMetadataInitReady" xml:space="preserve">
-    <value>已就绪，可以正常使用全部功能</value>
+    <value>Đã sẵn sàng, có thể sử dụng bình thường toàn bộ chức năng</value>
   </data>
   <data name="ViewModelLaunchGameErrorTitle" xml:space="preserve">
-    <value>启动游戏</value>
+    <value>Khởi động game</value>
   </data>
   <data name="ViewModelResumeGameErrorTitle" xml:space="preserve">
-    <value>恢复游戏</value>
+    <value>Khôi phục game</value>
   </data>
   <data name="ViewModelServerConvertTitle" xml:space="preserve">
-    <value>服务器转换</value>
+    <value>Chuyển đổi máy chủ</value>
   </data>
   <data name="ViewModelServerConvertAccessDeniedAdmin" xml:space="preserve">
-    <value>游戏目录权限不足，即使以管理员身份运行仍无法写入，请检查目录权限设置</value>
+    <value>Quyền thư mục game không đủ, mặc dù chạy bằng quyền quản trị viên vẫn không thể ghi, vui lòng kiểm tra cài đặt quyền thư mục</value>
   </data>
   <data name="ViewModelServerConvertAccessDenied" xml:space="preserve">
-    <value>游戏目录权限不足，请以管理员身份重启应用后重试</value>
+    <value>Quyền thư mục game không đủ, vui lòng khởi động lại ứng dụng bằng quyền quản trị viên rồi thử lại</value>
   </data>
   <data name="ViewModelServerConvertRestartAsAdmin" xml:space="preserve">
-    <value>以管理员重启</value>
+    <value>Khởi động lại bằng quyền Quản trị viên</value>
   </data>
   <data name="ViewModelServerConvertSuccessText" xml:space="preserve">
-    <value>服务器转换完成，当前服务器：{0}</value>
+    <value>Chuyển đổi máy chủ hoàn tất, máy chủ hiện tại: {0}</value>
   </data>
   <data name="ViewModelServerConvertSuccessWithDescText" xml:space="preserve">
-    <value>服务器转换完成，当前服务器：{0}
+    <value>Chuyển đổi máy chủ hoàn tất, máy chủ hiện tại: {0}
 {1}</value>
   </data>
   <data name="ViewModelCleanResourceSuccessText" xml:space="preserve">
-    <value>已清理 {0} 项资源，释放 {1} 空间</value>
+    <value>Đã dọn dẹp {0} mục tài nguyên, giải phóng {1} không gian</value>
   </data>
   <data name="ViewModelCleanResourcePartialError" xml:space="preserve">
-    <value>部分资源清理失败</value>
+    <value>Dọn dẹp một phần tài nguyên thất bại</value>
   </data>
   <data name="ViewModelGamePackageSchemeText" xml:space="preserve">
-    <value>服务器: {0}</value>
+    <value>Máy chủ: {0}</value>
   </data>
   <data name="ViewModelGamePackageSizeText" xml:space="preserve">
-    <value>占用大小: {0} GB</value>
+    <value>Dung lượng chiếm dụng: {0} GB</value>
   </data>
   <data name="WebResponseAccountNotLoggedIn" xml:space="preserve">
-    <value>账号未登录或登录已过期，请在软件内重新登录米游社账号</value>
+    <value>Tài khoản chưa đăng nhập hoặc đã hết hạn đăng nhập, vui lòng đăng nhập lại tài khoản Miyoushe trong phần mềm</value>
   </data>
   <data name="WebResponseAccountRisk" xml:space="preserve">
-    <value>当前账号存在风险，请不要担心这是米游社防人机验证，请先通过验证或过段时间再试</value>
+    <value>Tài khoản hiện tại có rủi ro, xin đừng lo lắng đây là xác minh chống bot của Miyoushe, vui lòng vượt qua xác minh trước hoặc thử lại sau</value>
   </data>
   <data name="WebResponseDataNotPublic" xml:space="preserve">
-    <value>用户数据未公开，请前往 HoYoLAB 将战绩设为公开</value>
+    <value>Dữ liệu người dùng không công khai, vui lòng đến HoYoLAB thiết lập Chiến tích thành công khai</value>
   </data>
   <data name="WebResponseTooManyRequests" xml:space="preserve">
-    <value>请求过于频繁，请稍后再试</value>
+    <value>Yêu cầu quá thường xuyên, vui lòng thử lại sau</value>
   </data>
   <data name="WebResponseAccountOrPasswordError" xml:space="preserve">
-    <value>账号或密码错误</value>
+    <value>Lỗi tài khoản hoặc mật khẩu</value>
   </data>
   <data name="ViewModelLaunchGameUnsupportedChannelOptions" xml:space="preserve">
-    <value>不支持的 ChannelOptions: {0}</value>
+    <value>Không hỗ trợ ChannelOptions: {0}</value>
   </data>
   <data name="ViewGuideTitle" xml:space="preserve">
-    <value>ky3 Launcher 用户使用协议与隐私政策</value>
+    <value>Thỏa thuận Sử dụng Người dùng &amp; Chính sách Quyền riêng tư ky3 Launcher</value>
   </data>
   <data name="ViewGuideWarning" xml:space="preserve">
-    <value>重要提示：请您务必仔细阅读以下全部内容（特别是关于免责、风险提示及管辖权的条款）。在适用法律允许的最大范围内，使用本软件即表示您已完全理解、同意并自愿承担本协议的全部约束。本软件包含的插件加载等高级功能明确违反游戏官方用户协议，存在导致游戏账号被永久封禁的绝对风险。如您不同意本协议的任何内容，请立即停止使用并彻底卸载本软件。</value>
+    <value>Mẹo quan trọng: Vui lòng đọc cẩn thận tất cả nội dung dưới đây (đặc biệt là điều khoản về Miễn trừ trách nhiệm, Cảnh báo rủi ro và Quyền tài phán). Trong phạm vi tối đa mà pháp luật hiện hành cho phép, việc sử dụng phần mềm này đồng nghĩa với việc bạn đã hiểu đầy đủ, đồng ý và tự nguyện chịu sự ràng buộc của toàn bộ thỏa thuận này. Các tính năng nâng cao như tải plugin có trong phần mềm này rõ ràng vi phạm thỏa thuận người dùng chính thức của trò chơi, có rủi ro tuyệt đối dẫn đến việc tài khoản game bị cấm vĩnh viễn. Nếu bạn không đồng ý với bất kỳ nội dung nào trong thỏa thuận này, vui lòng ngừng sử dụng ngay lập tức và gỡ bỏ hoàn toàn phần mềm này.</value>
   </data>
   <data name="ViewGuideFooter" xml:space="preserve">
-    <value>最后更新时间：2026 年
+    <value>Cập nhật lần cuối: Năm 2026
 
-点击下方复选框即表示您已仔细阅读、充分理解本协议中的所有免责与风险条款，并自愿承担使用本软件带来的全部后果。
-感谢您对本项目的支持与信任，祝您在提瓦特大陆旅途愉快！</value>
+Nhấn vào hộp kiểm bên dưới đồng nghĩa với việc bạn đã đọc kỹ, hiểu rõ tất cả các điều khoản miễn trừ và cảnh báo rủi ro trong thỏa thuận này, đồng thời tự nguyện chịu mọi hậu quả phát sinh từ việc sử dụng phần mềm này.
+Cảm ơn bạn đã hỗ trợ và tin tưởng dự án của chúng tôi, chúc bạn có một chuyến đi vui vẻ tại Lục địa Teyvat!</value>
   </data>
   <data name="ViewGuide1Title" xml:space="preserve">
-    <value>第一章  软件概述与授权许可</value>
+    <value>Chương I. Tổng quan phần mềm và Cấp phép ủy quyền</value>
   </data>
   <data name="ViewGuide1_1Title" xml:space="preserve">
-    <value>【1.1 软件简介】</value>
+    <value>【1.1 Giới thiệu phần mềm】</value>
   </data>
   <data name="ViewGuide1_1Text1" xml:space="preserve">
-    <value>ky3 Launcher（以下简称"本软件"）是一款基于 Snap Hutao 开源项目进行二次开发的原神第三方辅助工具。本软件遵循 MIT 开源许可协议发布，旨在为原神玩家提供优化体验，体感，等便捷功能。</value>
+    <value>ky3 Launcher (sau đây gọi là "Phần mềm này") là một công cụ hỗ trợ bên thứ ba của Genshin Impact được phát triển dựa trên dự án mã nguồn mở Snap Hutao. Phần mềm này được phát hành theo giấy phép mã nguồn mở MIT, nhằm cung cấp cho người chơi Genshin Impact những trải nghiệm tối ưu, cảm giác chơi tốt hơn và các tính năng tiện lợi khác.</value>
   </data>
   <data name="ViewGuide1_1Text2" xml:space="preserve">
-    <value>本软件的原始项目 Snap Hutao(现已停止维护） 由 DGP Studio 开发并维护，Launcher 基于其开源代码进行功能定制、界面优化与持续更新。</value>
+    <value>Dự án gốc Snap Hutao (hiện đã ngừng bảo trì) được phát triển và duy trì bởi DGP Studio, Launcher dựa trên mã nguồn mở của dự án này để tùy chỉnh tính năng, tối ưu hóa giao diện và cập nhật liên tục.</value>
   </data>
   <data name="ViewGuide1_2Title" xml:space="preserve">
-    <value>【1.2 授权许可】</value>
+    <value>【1.2 Cấp phép ủy quyền】</value>
   </data>
   <data name="ViewGuide1_2Text" xml:space="preserve">
-    <value>根据 MIT 开源许可协议，您可以自由地使用、复制、修改和分发本软件，但须遵守以下条件：</value>
+    <value>Theo giấy phép mã nguồn mở MIT, bạn có thể tự do sử dụng, sao chép, sửa đổi và phân phối phần mềm này, nhưng phải tuân thủ các điều kiện sau:</value>
   </data>
   <data name="ViewGuide1_2Bullet1" xml:space="preserve">
-    <value>在所有副本或重要部分中保留原始版权声明与 MIT 许可证文本。</value>
+    <value>Giữ lại thông báo bản quyền gốc và toàn văn giấy phép MIT trong tất cả các bản sao hoặc phần quan trọng.</value>
   </data>
   <data name="ViewGuide1_2Bullet2" xml:space="preserve">
-    <value>在二次分发或修改版本中明确标注您的修改内容，不得冒充原始项目。</value>
+    <value>Trong các phiên bản phân phối lại hoặc sửa đổi, hãy ghi rõ nội dung bạn đã sửa đổi và không được mạo danh dự án gốc.</value>
   </data>
   <data name="ViewGuide1_2Bullet3" xml:space="preserve">
-    <value>本软件按"原样"（AS IS）提供，不附带任何明示或暗示的担保。</value>
+    <value>Phần mềm này được cung cấp "nguyên trạng" (AS IS), không đi kèm với bất kỳ hình thức bảo đảm rõ ràng hay ngụ ý nào.</value>
   </data>
   <data name="ViewGuide1_3Title" xml:space="preserve">
-    <value>【1.3 使用限制】</value>
+    <value>【1.3 Hạn chế sử dụng】</value>
   </data>
   <data name="ViewGuide1_3Text" xml:space="preserve">
-    <value>您在使用本软件时，应当严格遵守以下限制：</value>
+    <value>Khi sử dụng phần mềm này, bạn phải tuân thủ nghiêm ngặt các giới hạn sau:</value>
   </data>
   <data name="ViewGuide1_3Bullet1" xml:space="preserve">
-    <value>不得将本软件用于任何违反您所在国家或地区法律法规的用途。</value>
+    <value>Không được sử dụng phần mềm này cho bất kỳ mục đích nào vi phạm pháp luật và quy định của quốc gia hoặc khu vực bạn đang ở.</value>
   </data>
   <data name="ViewGuide1_3Bullet2" xml:space="preserve">
-    <value>不得利用本软件进行任何形式的游戏作弊、外挂制作、传播或非法牟利。</value>
+    <value>Không được sử dụng phần mềm này để thực hiện bất kỳ hình thức gian lận, chế tạo phần mềm gian lận, phát tán hoặc trục lợi bất hợp pháp nào trong game.</value>
   </data>
   <data name="ViewGuide1_3Bullet3" xml:space="preserve">
-    <value>不得对本软件进行反编译、反汇编或逆向工程（法律明确允许且不可通过协议排除的除外）。</value>
+    <value>Không được biên dịch ngược, dịch ngược hoặc đảo ngược kỹ thuật phần mềm này (ngoại trừ trường hợp pháp luật cho phép rõ ràng và không thể loại trừ thông qua thỏa thuận).</value>
   </data>
   <data name="ViewGuide1_3Bullet4" xml:space="preserve">
-    <value>不得删除或篡改本软件中的版权声明、许可声明或其他权利标识。</value>
+    <value>Không được xóa hoặc sửa đổi thông báo bản quyền, tuyên bố cấp phép hoặc các nhãn hiệu quyền khác trong phần mềm này.</value>
   </data>
   <data name="ViewGuide2Title" xml:space="preserve">
-    <value>第二章  核心功能说明</value>
+    <value>Chương II. Hướng dẫn Tính năng Cốt lõi</value>
   </data>
   <data name="ViewGuide2Text" xml:space="preserve">
-    <value>本软件提供以下核心功能，所有功能均在本地运行，通过调用游戏官方公开接口获取数据：</value>
+    <value>Phần mềm này cung cấp các tính năng cốt lõi sau, tất cả đều chạy cục bộ và lấy dữ liệu bằng cách gọi các giao diện (API) công khai chính thức của game:</value>
   </data>
   <data name="ViewGuide2_1Title" xml:space="preserve">
-    <value>【2.1 游戏启动管理】</value>
+    <value>【2.1 Quản lý Khởi động Game】</value>
   </data>
   <data name="ViewGuide2_1Bullet1" xml:space="preserve">
-    <value>支持自定义游戏启动参数（分辨率、窗口模式、HDR、附加程序选择等）。</value>
+    <value>Hỗ trợ tùy chỉnh tham số khởi động game (Độ phân giải, Chế độ cửa sổ, HDR, Chọn ứng dụng đính kèm...).</value>
   </data>
   <data name="ViewGuide2_1Bullet2" xml:space="preserve">
-    <value>支持多账号管理与快速切换，登录凭证存储在本地 SQLite 数据库中。</value>
+    <value>Hỗ trợ quản lý và chuyển đổi nhanh nhiều tài khoản, thông tin đăng nhập được lưu trong cơ sở dữ liệu SQLite cục bộ.</value>
   </data>
   <data name="ViewGuide2_1Bullet3" xml:space="preserve">
-    <value>支持 FPS 解锁功能，通过插件加载技术修改游戏帧率限制。</value>
+    <value>Hỗ trợ tính năng mở khóa FPS, sửa đổi giới hạn tốc độ khung hình của game thông qua kỹ thuật tải plugin.</value>
   </data>
   <data name="ViewGuide2_1Bullet4" xml:space="preserve">
-    <value>支持 Island 游戏内增强功能（包括帧率解锁、游戏内辅助等）。</value>
+    <value>Hỗ trợ tính năng nâng cao trong game Island (bao gồm mở khóa FPS, hỗ trợ trong game...).</value>
   </data>
   <data name="ViewGuide2_2Title" xml:space="preserve">
-    <value>【2.2 祈愿记录分析】</value>
+    <value>【2.2 Phân tích Lịch sử Cầu Nguyện】</value>
   </data>
   <data name="ViewGuide2_2Bullet1" xml:space="preserve">
-    <value>通过读取游戏日志文件获取祈愿记录查询地址。</value>
+    <value>Lấy địa chỉ tra cứu lịch sử Cầu Nguyện thông qua việc đọc tệp nhật ký game.</value>
   </data>
   <data name="ViewGuide2_2Bullet2" xml:space="preserve">
-    <value>使用您的账号凭证直接访问米哈游官方 API 拉取祈愿数据。</value>
+    <value>Sử dụng cookie tài khoản của bạn để truy cập trực tiếp vào API chính thức của miHoYo nhằm lấy dữ liệu Cầu Nguyện.</value>
   </data>
   <data name="ViewGuide2_2Bullet3" xml:space="preserve">
-    <value>在本地进行数据统计分析，包括出货率、保底计数、历史记录等。</value>
+    <value>Thống kê và phân tích dữ liệu cục bộ, bao gồm tỷ lệ ra hàng, đếm bảo hiểm, lịch sử...</value>
   </data>
   <data name="ViewGuide2_2Bullet4" xml:space="preserve">
-    <value>支持 UIGF 标准格式的数据导入与导出，便于与其他工具互通。</value>
+    <value>Hỗ trợ nhập và xuất dữ liệu định dạng chuẩn UIGF, thuận tiện cho việc tương tác với các công cụ khác.</value>
   </data>
   <data name="ViewGuide2_3Title" xml:space="preserve">
-    <value>【2.3 成就管理】</value>
+    <value>【2.3 Quản lý Thành Tựu】</value>
   </data>
   <data name="ViewGuide2_3Bullet1" xml:space="preserve">
-    <value>本地记录与追踪您的游戏成就完成进度。</value>
+    <value>Ghi lại cục bộ và theo dõi tiến độ hoàn thành thành tựu trong game của bạn.</value>
   </data>
   <data name="ViewGuide2_3Bullet2" xml:space="preserve">
-    <value>支持成就数据的存档与管理。</value>
+    <value>Hỗ trợ lưu trữ và quản lý dữ liệu thành tựu.</value>
   </data>
   <data name="ViewGuide2_3Bullet3" xml:space="preserve">
-    <value>所有成就数据仅存储在本地数据库中。</value>
+    <value>Toàn bộ dữ liệu thành tựu chỉ được lưu trữ trong cơ sở dữ liệu cục bộ.</value>
   </data>
   <data name="ViewGuide2_4Title" xml:space="preserve">
-    <value>【2.4 深境螺旋与幻想真境剧诗记录】</value>
+    <value>【2.4 Ghi chú La Hoàn Thâm Cảnh &amp; Nhà Hát Giả Tưởng】</value>
   </data>
   <data name="ViewGuide2_4Bullet1" xml:space="preserve">
-    <value>获取并记录您的深境螺旋挑战数据。</value>
+    <value>Nhận và ghi lại dữ liệu khiêu chiến La Hoàn Thâm Cảnh của bạn.</value>
   </data>
   <data name="ViewGuide2_4Bullet2" xml:space="preserve">
-    <value>获取并记录您的幻想真境剧诗挑战数据。</value>
+    <value>Nhận và ghi lại dữ liệu khiêu chiến Nhà Hát Giả Tưởng của bạn.</value>
   </data>
   <data name="ViewGuide2_4Bullet3" xml:space="preserve">
-    <value>所有记录数据存储在本地 SQLite 数据库中。</value>
+    <value>Toàn bộ dữ liệu bản ghi được lưu trữ trong cơ sở dữ liệu SQLite cục bộ.</value>
   </data>
   <data name="ViewGuide2_5Title" xml:space="preserve">
-    <value>【2.5 角色展柜（Enka.Network）】</value>
+    <value>【2.5 Tủ Kính Nhân Vật (Enka.Network)】</value>
   </data>
   <data name="ViewGuide2_5Bullet1" xml:space="preserve">
-    <value>通过 Enka.Network 第三方 API 获取您的角色展柜数据。</value>
+    <value>Lấy dữ liệu tủ kính nhân vật của bạn thông qua API của bên thứ ba Enka.Network.</value>
   </data>
   <data name="ViewGuide2_5Bullet2" xml:space="preserve">
-    <value>展示角色装备、圣遗物、属性等详细信息。</value>
+    <value>Hiển thị thông tin chi tiết về trang bị, thánh di vật, thuộc tính... của nhân vật.</value>
   </data>
   <data name="ViewGuide2_5Bullet3" xml:space="preserve">
-    <value>此功能依赖第三方服务 Enka.Network 的可用性。</value>
+    <value>Tính năng này phụ thuộc vào tính khả dụng của dịch vụ bên thứ ba Enka.Network.</value>
   </data>
   <data name="ViewGuide2_6Title" xml:space="preserve">
-    <value>【2.6 实时便笺】</value>
+    <value>【2.6 Ghi chú Thời Gian Thực】</value>
   </data>
   <data name="ViewGuide2_6Bullet1" xml:space="preserve">
-    <value>通过米哈游官方 API 查询您的实时游戏数据。</value>
+    <value>Tra cứu dữ liệu trò chơi theo thời gian thực của bạn thông qua API chính thức của miHoYo.</value>
   </data>
   <data name="ViewGuide2_6Bullet2" xml:space="preserve">
-    <value>包括树脂恢复、每日委托、探索派遣等信息。</value>
+    <value>Bao gồm thông tin hồi nhựa, nhiệm vụ hằng ngày, phái đi thám hiểm...</value>
   </data>
   <data name="ViewGuide2_6Bullet3" xml:space="preserve">
-    <value>需要您的账号 Cookie 授权。</value>
+    <value>Cần ủy quyền Cookie tài khoản của bạn.</value>
   </data>
   <data name="ViewGuide2_7Title" xml:space="preserve">
-    <value>【2.7 插件加载】</value>
+    <value>【2.7 Tải Plugin】</value>
   </data>
   <data name="ViewGuide2_7Bullet1" xml:space="preserve">
-    <value>本软件包含的插件选项功能，通过向游戏进程加载动态链接库（DLL 插件）实现。</value>
+    <value>Các chức năng tùy chọn plugin có trong phần mềm này được thực hiện bằng cách nạp thư viện liên kết động (Plugin DLL) vào tiến trình game.</value>
   </data>
   <data name="ViewGuide2_7Bullet2" xml:space="preserve">
-    <value>插件加载过程通过共享内存与游戏进程通信，传递配置参数。</value>
+    <value>Quá trình nạp plugin giao tiếp với tiến trình game qua bộ nhớ dùng chung, truyền các tham số cấu hình.</value>
   </data>
   <data name="ViewGuide2_7Bullet3" xml:space="preserve">
-    <value>此功能可能被部分安全软件误报，但不包含任何恶意代码。</value>
+    <value>Chức năng này có thể bị một số phần mềm bảo mật báo cáo sai, nhưng không chứa bất kỳ mã độc hại nào.</value>
   </data>
   <data name="ViewGuide3Title" xml:space="preserve">
-    <value>第三章  知识产权与开源声明</value>
+    <value>Chương III. Quyền Sở hữu Trí tuệ và Tuyên bố Mã Nguồn Mở</value>
   </data>
   <data name="ViewGuide3_1Title" xml:space="preserve">
-    <value>【3.1 版权归属】</value>
+    <value>【3.1 Quyền Sở hữu Bản quyền】</value>
   </data>
   <data name="ViewGuide3_1Bullet1" xml:space="preserve">
-    <value>本软件的原始代码版权归 DGP Studio 所有，基于 MIT 许可协议开源。</value>
+    <value>Bản quyền mã nguồn gốc của phần mềm này thuộc về DGP Studio, phát hành dưới giấy phép MIT.</value>
   </data>
   <data name="ViewGuide3_1Bullet2" xml:space="preserve">
-    <value>Launcher 对二次开发部分的代码享有相应权利，同样遵循 MIT 许可协议。</value>
+    <value>Launcher có các quyền tương ứng đối với phần mã được phát triển lại, cũng tuân theo giấy phép MIT.</value>
   </data>
   <data name="ViewGuide3_1Bullet3" xml:space="preserve">
-    <value>本软件使用的游戏素材（角色图片、武器图标等）版权归上海米哈游网络科技股份有限公司（miHoYo / HoYoverse）所有。</value>
+    <value>Tài nguyên game (hình ảnh nhân vật, biểu tượng vũ khí...) được sử dụng trong phần mềm này thuộc bản quyền của Công ty TNHH Công nghệ Mạng miHoYo Thượng Hải (miHoYo / HoYoverse).</value>
   </data>
   <data name="ViewGuide3_2Title" xml:space="preserve">
-    <value>【3.2 开源许可】</value>
+    <value>【3.2 Giấy phép Mã Nguồn Mở】</value>
   </data>
   <data name="ViewGuide3_2Text" xml:space="preserve">
-    <value>本软件基于 MIT License 发布，完整许可证文本如下：</value>
+    <value>Phần mềm này được phát hành dựa trên MIT License, toàn văn giấy phép như sau:</value>
   </data>
   <data name="ViewGuide3_3Title" xml:space="preserve">
-    <value>【3.3 商标声明】</value>
+    <value>【3.3 Tuyên bố Thương hiệu】</value>
   </data>
   <data name="ViewGuide3_3Bullet1" xml:space="preserve">
-    <value>"原神"（Genshin Impact）是上海米哈游网络科技股份有限公司的合法注册商标。</value>
+    <value>"Genshin Impact" là thương hiệu đã đăng ký hợp pháp của Công ty TNHH Công nghệ Mạng miHoYo Thượng Hải.</value>
   </data>
   <data name="ViewGuide3_3Bullet2" xml:space="preserve">
-    <value>"Snap Hutao" 是 DGP Studio 的项目名称。</value>
+    <value>"Snap Hutao" là tên dự án của DGP Studio.</value>
   </data>
   <data name="ViewGuide3_3Bullet3" xml:space="preserve">
-    <value>本软件名称 "ky3 Launcher" 仅用于标识本二次开发项目，不构成对任何官方商标的侵犯。</value>
+    <value>Tên phần mềm "ky3 Launcher" chỉ được dùng để nhận diện dự án phát triển lại này, không cấu thành hành vi xâm phạm bất kỳ thương hiệu chính thức nào.</value>
   </data>
   <data name="ViewGuide3_3Bullet4" xml:space="preserve">
-    <value>本软件的所有界面设计、文案排版如涉及官方游戏元素，均属于米哈游公司的合理使用范畴，本软件不主张对其拥有任何商业或排他性权利。</value>
+    <value>Nếu mọi thiết kế giao diện, bố cục văn bản của phần mềm này liên quan đến các yếu tố game chính thức thì đều thuộc phạm vi sử dụng hợp lý của miHoYo, phần mềm này không xác nhận có bất kỳ quyền thương mại hay độc quyền nào đối với chúng.</value>
   </data>
   <data name="ViewGuide4Title" xml:space="preserve">
-    <value>第四章  用户数据与隐私政策</value>
+    <value>Chương IV. Dữ liệu Người dùng &amp; Chính sách Quyền riêng tư</value>
   </data>
   <data name="ViewGuide4Text" xml:space="preserve">
-    <value>我们深知用户数据安全的重要性，特此详细说明本软件的数据处理方式和隐私保护措施。</value>
+    <value>Chúng tôi hiểu sâu sắc tầm quan trọng của việc bảo mật dữ liệu người dùng, qua đây giải thích chi tiết các phương thức xử lý dữ liệu và biện pháp bảo vệ quyền riêng tư của phần mềm này.</value>
   </data>
   <data name="ViewGuide4_1Title" xml:space="preserve">
-    <value>【4.1 数据存储方式】</value>
+    <value>【4.1 Phương thức Lưu trữ Dữ liệu】</value>
   </data>
   <data name="ViewGuide4_1Bullet1" xml:space="preserve">
-    <value>默认情况下的本地化：除非您主动开启并授权使用云端同步等在线增值服务（详见4.5节），否则您的所有基础用户数据均仅存储在您的本地设备中，不会被隐蔽上传到任何服务器。</value>
+    <value>Bản địa hóa trong trạng thái mặc định: Trừ khi bạn chủ động bật và ủy quyền sử dụng các dịch vụ giá trị gia tăng trực tuyến như đồng bộ hóa đám mây (xem chi tiết ở mục 4.5), tất cả dữ liệu người dùng cơ bản của bạn sẽ CHỈ được lưu trữ trên thiết bị cục bộ của bạn, không bị âm thầm tải lên bất kỳ máy chủ nào.</value>
   </data>
   <data name="ViewGuide4_1Bullet2" xml:space="preserve">
-    <value>数据位置：默认存储在 %LOCALAPPDATA%\ky3 Launcher 目录下，您可以在设置中自定义数据文件夹位置。</value>
+    <value>Vị trí dữ liệu: Mặc định được lưu trữ trong thư mục %LOCALAPPDATA%\ky3 Launcher, bạn có thể tùy chỉnh đường dẫn thư mục dữ liệu trong Cài đặt.</value>
   </data>
   <data name="ViewGuide4_1Bullet3" xml:space="preserve">
-    <value>数据格式：数据使用 SQLite 数据库和 JSON 文件存储，均为标准开放格式，您可以使用任何兼容工具查看。</value>
+    <value>Định dạng dữ liệu: Dữ liệu được lưu trữ bằng cơ sở dữ liệu SQLite và các tệp JSON, cả hai đều là định dạng mở tiêu chuẩn, bạn có thể sử dụng bất kỳ công cụ tương thích nào để xem.</value>
   </data>
   <data name="ViewGuide4_1Bullet4" xml:space="preserve">
-    <value>加密存储：账号 Cookie 等敏感信息使用 Windows 数据保护 API（DPAPI）进行加密存储，确保只有当前 Windows 用户账户才能解密访问。</value>
+    <value>Lưu trữ mã hóa: Thông tin nhạy cảm như Cookie tài khoản được mã hóa bằng API Bảo vệ Dữ liệu Windows (DPAPI), đảm bảo chỉ tài khoản người dùng Windows hiện tại mới có thể giải mã và truy cập.</value>
   </data>
   <data name="ViewGuide4_2Title" xml:space="preserve">
-    <value>【4.2 数据收集声明】</value>
+    <value>【4.2 Tuyên bố Thu thập Dữ liệu】</value>
   </data>
   <data name="ViewGuide4_2Bullet1" xml:space="preserve">
-    <value>本软件不包含任何商业广告 SDK、恶意用户行为追踪组件或隐蔽的数据埋点代码。</value>
+    <value>Phần mềm này không chứa bất kỳ SDK quảng cáo thương mại, thành phần theo dõi hành vi người dùng độc hại hoặc mã ngầm thu thập dữ liệu nào.</value>
   </data>
   <data name="ViewGuide4_2Bullet2" xml:space="preserve">
-    <value>除您主动使用的在线功能（如数据同步）外，本软件不会主动将您的游戏账号、密码、Cookie 或个人数据上传至任何开发者服务器。</value>
+    <value>Ngoại trừ các chức năng trực tuyến bạn chủ động sử dụng (như Đồng bộ dữ liệu), phần mềm này sẽ không chủ động tải tài khoản game, mật khẩu, Cookie hoặc dữ liệu cá nhân của bạn lên bất kỳ máy chủ nào của nhà phát triển.</value>
   </data>
   <data name="ViewGuide4_2Bullet3" xml:space="preserve">
-    <value>使用在线功能时，仅传输提供该功能所必需的最少数据量。</value>
+    <value>Khi sử dụng các chức năng trực tuyến, chỉ truyền đi một lượng dữ liệu tối thiểu cần thiết để cung cấp tính năng đó.</value>
   </data>
   <data name="ViewGuide4_3Title" xml:space="preserve">
-    <value>【4.3 网络通信说明】</value>
+    <value>【4.3 Giải thích về Giao tiếp Mạng】</value>
   </data>
   <data name="ViewGuide4_3Text" xml:space="preserve">
-    <value>本软件在运行过程中可能进行以下网络通信，所有通信均为实现软件功能所必需：</value>
+    <value>Phần mềm này có thể tiến hành các hoạt động giao tiếp mạng sau đây trong quá trình chạy, tất cả đều nhằm mục đích thực hiện chức năng của phần mềm:</value>
   </data>
   <data name="ViewGuide4_3Bullet1" xml:space="preserve">
-    <value>米哈游官方 API：使用您的账号凭证（Cookie）直接访问米哈游官方服务器获取游戏数据（祈愿记录、实时便笺、深渊数据等）。</value>
+    <value>API chính thức miHoYo: Sử dụng chứng chỉ tài khoản của bạn (Cookie) để truy cập trực tiếp vào máy chủ chính thức của miHoYo nhằm lấy dữ liệu game (Lịch sử cầu nguyện, ghi chú thời gian thực, dữ liệu la hoàn, v.v.).</value>
   </data>
   <data name="ViewGuide4_3Bullet2" xml:space="preserve">
-    <value>Enka.Network API：访问 enka.network 获取角色展柜数据，仅需提供游戏 UID（非敏感信息）即可查询。</value>
+    <value>API Enka.Network: Truy cập enka.network để lấy dữ liệu tủ kính nhân vật, chỉ cần cung cấp UID trò chơi (không phải thông tin nhạy cảm) là có thể truy vấn.</value>
   </data>
   <data name="ViewGuide4_3Bullet3" xml:space="preserve">
-    <value>GitHub：访问 GitHub 检查软件是否有新版本可用，此过程仅传输版本号等基础握手信息。</value>
+    <value>GitHub: Truy cập GitHub để kiểm tra xem phần mềm có phiên bản mới hay không, quá trình này chỉ truyền đi các thông tin bắt tay cơ bản như số phiên bản.</value>
   </data>
   <data name="ViewGuide4_3Bullet4" xml:space="preserve">
-    <value>静态资源 CDN：首次使用时从开发者服务器或对象存储OSS下载游戏角色、武器等静态资源图片。</value>
+    <value>CDN Tài nguyên tĩnh: Tải xuống các ảnh tài nguyên tĩnh như ảnh nhân vật, icon vũ khí từ máy chủ nhà phát triển hoặc lưu trữ đối tượng OSS trong lần đầu sử dụng.</value>
   </data>
   <data name="ViewGuide4_3Bullet5" xml:space="preserve">
-    <value>开发者服务器：本软件可能与开发者运营的服务器通信，用于提供数据同步、展柜代理等在线增值功能。</value>
+    <value>Máy chủ nhà phát triển: Phần mềm này có thể giao tiếp với máy chủ do nhà phát triển vận hành, dùng để cung cấp các chức năng giá trị gia tăng trực tuyến như đồng bộ dữ liệu, proxy tủ kính.</value>
   </data>
   <data name="ViewGuide4_4Title" xml:space="preserve">
-    <value>【4.4 崩溃报告服务（Sentry）】</value>
+    <value>【4.4 Dịch vụ Báo cáo Crash (Sentry)】</value>
   </data>
   <data name="ViewGuide4_4Text" xml:space="preserve">
-    <value>本软件集成了 Sentry 崩溃报告服务，用于收集匿名的应用崩溃信息和性能数据，以帮助开发者改进软件质量。</value>
+    <value>Phần mềm này đã tích hợp dịch vụ báo cáo lỗi Sentry, dùng để thu thập ẩn danh các thông tin crash ứng dụng và dữ liệu hiệu suất, nhằm giúp nhà phát triển cải thiện chất lượng phần mềm.</value>
   </data>
   <data name="ViewGuide4_4Bullet1" xml:space="preserve">
-    <value>收集的信息包括：软件版本号、操作系统版本、崩溃堆栈信息、性能指标等纯技术数据。</value>
+    <value>Các thông tin được thu thập bao gồm: Số phiên bản phần mềm, phiên bản hệ điều hành, thông tin ngăn xếp crash, chỉ số hiệu suất và các dữ liệu kỹ thuật thuần túy khác.</value>
   </data>
   <data name="ViewGuide4_4Bullet2" xml:space="preserve">
-    <value>严格禁止收集：您的游戏账号、Cookie、真实姓名、物理位置或其他任何可直接识别您身份的敏感数据。</value>
+    <value>Nghiêm cấm thu thập: Tài khoản trò chơi, Cookie, tên thật, vị trí địa lý hoặc bất kỳ dữ liệu nhạy cảm nào khác có thể trực tiếp nhận diện danh tính của bạn.</value>
   </data>
   <data name="ViewGuide4_4Bullet3" xml:space="preserve">
-    <value>本软件会在首次启动时或设置菜单中提供崩溃报告的明确开启/关闭选项，您可以自由决定是否参与。</value>
+    <value>Phần mềm này sẽ cung cấp tùy chọn Bật/Tắt rõ ràng cho báo cáo lỗi trong lần đầu khởi động hoặc trong menu Cài đặt, bạn có thể tự do quyết định có tham gia hay không.</value>
   </data>
   <data name="ViewGuide4_5Title" xml:space="preserve">
-    <value>【4.5 开发者服务器】</value>
+    <value>【4.5 Máy chủ của Nhà phát triển】</value>
   </data>
   <data name="ViewGuide4_5Text1" xml:space="preserve">
-    <value>本软件可能连接开发者运营的后端服务器，用于提供以下增值功能：</value>
+    <value>Phần mềm này có thể kết nối với máy chủ backend do nhà phát triển vận hành để cung cấp các tính năng giá trị gia tăng sau:</value>
   </data>
   <data name="ViewGuide4_5Bullet1" xml:space="preserve">
-    <value>数据同步与云备份：在您明确授权的情况下，将祈愿记录等数据同步至开发者服务器，便于跨设备使用。</value>
+    <value>Đồng bộ hóa dữ liệu và Sao lưu đám mây: Nếu được bạn ủy quyền rõ ràng, hệ thống sẽ đồng bộ hóa lịch sử Cầu Nguyện và các dữ liệu khác lên máy chủ của nhà phát triển, thuận tiện cho việc sử dụng đa thiết bị.</value>
   </data>
   <data name="ViewGuide4_5Bullet2" xml:space="preserve">
-    <value>Enka 展柜代理：通过开发者服务器代理 Enka.Network 请求，提升访问稳定性与速度。</value>
+    <value>Enka Proxy Tủ Kính: Sử dụng máy chủ của nhà phát triển làm proxy cho các yêu cầu Enka.Network, giúp tăng độ ổn định và tốc độ truy cập.</value>
   </data>
   <data name="ViewGuide4_5Bullet3" xml:space="preserve">
-    <value>其他在线功能：随软件版本更新，可能新增更多需要服务器支持的功能。</value>
+    <value>Các chức năng trực tuyến khác: Cùng với việc cập nhật phần mềm, có thể bổ sung thêm nhiều chức năng cần có máy chủ hỗ trợ.</value>
   </data>
   <data name="ViewGuide4_5Text2" xml:space="preserve">
-    <value>使用上述功能时，开发者承诺：</value>
+    <value>Khi sử dụng các tính năng trên, Nhà phát triển cam kết:</value>
   </data>
   <data name="ViewGuide4_5Promise1" xml:space="preserve">
-    <value>仅收集提供服务所必需的最少数据，并采取合理的技术措施保障传输及存储安全。</value>
+    <value>Chỉ thu thập dữ liệu tối thiểu cần thiết cho việc cung cấp dịch vụ, đồng thời áp dụng các biện pháp kỹ thuật hợp lý để đảm bảo tính an toàn cho quá trình truyền tải và lưu trữ.</value>
   </data>
   <data name="ViewGuide4_5Promise2" xml:space="preserve">
-    <value>绝对不会将您的任何数据出售、共享或非法提供给无关的第三方。</value>
+    <value>Tuyệt đối không bán, chia sẻ hoặc cung cấp trái phép bất kỳ dữ liệu nào của bạn cho bất kỳ bên thứ ba không liên quan nào.</value>
   </data>
   <data name="ViewGuide4_5Promise3" xml:space="preserve">
-    <value>您可以随时选择不使用需要服务器连接的功能，软件的核心本地功能不受任何影响。</value>
+    <value>Bạn có quyền tùy ý chọn không sử dụng các chức năng yêu cầu kết nối với máy chủ, điều này sẽ không ảnh hưởng đến các chức năng cục bộ cốt lõi của phần mềm.</value>
   </data>
   <data name="ViewGuide4_6Title" xml:space="preserve">
-    <value>【4.6 第三方服务与跨境数据流动】</value>
+    <value>【4.6 Dịch vụ của Bên thứ ba và Luân chuyển Dữ liệu Xuyên biên giới】</value>
   </data>
   <data name="ViewGuide4_6Text" xml:space="preserve">
-    <value>本软件可能使用以下第三方服务，这些服务有其独立的隐私政策，且其服务器可能位于您所在国家或地区境外：</value>
+    <value>Phần mềm này có thể sử dụng các dịch vụ bên thứ ba sau, những dịch vụ này có chính sách bảo mật độc lập của riêng họ và các máy chủ của họ có thể nằm ngoài quốc gia hoặc khu vực của bạn:</value>
   </data>
   <data name="ViewGuide4_6Bullet1" xml:space="preserve">
-    <value>米哈游官方 API：受米哈游用户协议和隐私政策约束。</value>
+    <value>API chính thức miHoYo: Chịu sự ràng buộc của Thỏa thuận Người dùng và Chính sách Bảo mật của miHoYo.</value>
   </data>
   <data name="ViewGuide4_6Bullet2" xml:space="preserve">
-    <value>GitHub：受 GitHub 隐私政策约束，用于软件更新检查和版本下载。</value>
+    <value>GitHub: Chịu sự ràng buộc của Chính sách Bảo mật GitHub, dùng để kiểm tra và tải bản cập nhật phần mềm.</value>
   </data>
   <data name="ViewGuide4_6Bullet3" xml:space="preserve">
-    <value>Enka.Network：受其独立的隐私政策约束，用于角色展柜数据查询。</value>
+    <value>Enka.Network: Chịu sự ràng buộc của Chính sách Bảo mật độc lập của nền tảng, dùng để tra cứu dữ liệu tủ kính nhân vật.</value>
   </data>
   <data name="ViewGuide4_6Bullet4" xml:space="preserve">
-    <value>开发者服务器：用于下载静态资源（角色图片、武器图标等）。</value>
+    <value>Máy chủ của Nhà phát triển: Dùng để tải xuống các tài nguyên tĩnh (hình ảnh nhân vật, biểu tượng vũ khí...).</value>
   </data>
   <data name="ViewGuide4_6Bullet5" xml:space="preserve">
-    <value>Sentry：受 Sentry 隐私政策约束，用于匿名崩溃报告。</value>
+    <value>Sentry: Chịu sự ràng buộc của Chính sách Bảo mật Sentry, dùng cho báo cáo crash ẩn danh.</value>
   </data>
   <data name="ViewGuide4_6Bullet6" xml:space="preserve">
-    <value>使用涉及第三方接口的功能（如 Enka 展柜、GitHub 更新、Sentry 报错），即视为您知晓并同意相关非敏感数据可能发生合法的跨境传输。</value>
+    <value>Việc sử dụng các chức năng liên quan đến giao diện bên thứ ba (như Tủ kính Enka, cập nhật GitHub, báo lỗi Sentry) có nghĩa là bạn biết và đồng ý rằng các dữ liệu phi nhạy cảm liên quan có thể trải qua việc truyền tải xuyên biên giới hợp pháp.</value>
   </data>
   <data name="ViewGuide4_7Title" xml:space="preserve">
-    <value>【4.7 数据安全建议】</value>
+    <value>【4.7 Lời khuyên An toàn Dữ liệu】</value>
   </data>
   <data name="ViewGuide4_7Bullet1" xml:space="preserve">
-    <value>定期备份：强烈建议您定期备份数据文件夹，以防不可预见的硬件故障导致意外数据丢失。</value>
+    <value>Sao lưu định kỳ: Rất khuyến khích bạn thường xuyên sao lưu thư mục dữ liệu nhằm phòng ngừa trường hợp lỗi phần cứng không mong muốn dẫn đến thất thoát dữ liệu.</value>
   </data>
   <data name="ViewGuide4_7Bullet2" xml:space="preserve">
-    <value>妥善保管：请绝对保密您的数据文件夹，其中包含可直接登录您账号的加密凭证，请勿分享给他人。</value>
+    <value>Bảo quản an toàn: Vui lòng tuyệt đối bảo mật thư mục dữ liệu của bạn, nó chứa các chứng chỉ mã hóa có thể trực tiếp đăng nhập vào tài khoản của bạn, vui lòng không chia sẻ cho người khác.</value>
   </data>
   <data name="ViewGuide4_7Bullet3" xml:space="preserve">
-    <value>系统安全：建议保持操作系统和安全软件更新，防范木马或恶意软件窃取您的本地数据。</value>
+    <value>Bảo mật hệ thống: Khuyến khích luôn cập nhật hệ điều hành và phần mềm diệt virus nhằm chống lại trojan hoặc mã độc ăn cắp dữ liệu cục bộ của bạn.</value>
   </data>
   <data name="ViewGuide4_7Bullet4" xml:space="preserve">
-    <value>官方渠道：请务必仅从官方 GitHub 仓库或认定的可信来源下载本软件，拒绝使用来路不明的魔改版本。</value>
+    <value>Kênh chính thức: Xin nhất định chỉ tải phần mềm này từ kho lưu trữ GitHub chính thức hoặc các nguồn đáng tin cậy được công nhận, từ chối sử dụng các phiên bản sửa đổi (mod) không rõ nguồn gốc.</value>
   </data>
   <data name="ViewGuide4_8Title" xml:space="preserve">
-    <value>【4.8 用户数据权利】</value>
+    <value>【4.8 Quyền Lợi Dữ liệu Người dùng】</value>
   </data>
   <data name="ViewGuide4_8Bullet1" xml:space="preserve">
-    <value>完全控制权：您对存储在本地的所有数据拥有 100% 的控制权和所有权。</value>
+    <value>Quyền kiểm soát tuyệt đối: Bạn sở hữu 100% quyền kiểm soát và quyền sở hữu đối với tất cả dữ liệu được lưu trữ cục bộ.</value>
   </data>
   <data name="ViewGuide4_8Bullet2" xml:space="preserve">
-    <value>随时删除：您可以随时删除数据文件夹或卸载软件，无需担心云端产生无法清除的残留数据。</value>
+    <value>Xóa bất kỳ lúc nào: Bạn có thể xóa thư mục dữ liệu hoặc gỡ cài đặt phần mềm bất cứ lúc nào mà không cần lo lắng về việc đám mây sẽ tạo ra các dữ liệu rác không thể xóa được.</value>
   </data>
   <data name="ViewGuide4_8Bullet3" xml:space="preserve">
-    <value>数据导出：所有数据以标准格式存储，您可以自由导出、备份和迁移。</value>
+    <value>Xuất dữ liệu: Tất cả dữ liệu được lưu trữ ở định dạng chuẩn, bạn có thể tự do xuất, sao lưu và di chuyển.</value>
   </data>
   <data name="ViewGuide4_8Bullet4" xml:space="preserve">
-    <value>数据可移植：祈愿记录支持 UIGF 标准格式导出，可无缝迁移至其他兼容该标准的工具。</value>
+    <value>Khả năng mang theo dữ liệu: Lịch sử Cầu Nguyện hỗ trợ xuất dữ liệu định dạng chuẩn UIGF, có thể di chuyển liền mạch đến các công cụ khác tương thích với tiêu chuẩn này.</value>
   </data>
   <data name="ViewGuide5Title" xml:space="preserve">
-    <value>第五章  免责声明与风险提示（必读）</value>
+    <value>Chương V. Miễn trừ Trách nhiệm &amp; Cảnh báo Rủi ro (Bắt buộc phải đọc)</value>
   </data>
   <data name="ViewGuide5_1Title" xml:space="preserve">
-    <value>【5.1 与游戏官方的关系】</value>
+    <value>【5.1 Mối quan hệ với Trò chơi Chính thức】</value>
   </data>
   <data name="ViewGuide5_1Bullet1" xml:space="preserve">
-    <value>本软件是完全独立的第三方辅助体验工具，与上海米哈游网络科技股份有限公司（miHoYo / HoYoverse）没有任何形式的关联、合作或官方授权。</value>
+    <value>Phần mềm này là một công cụ hỗ trợ trải nghiệm bên thứ ba hoàn toàn độc lập, không có bất kỳ hình thức liên kết, hợp tác hay ủy quyền chính thức nào từ Công ty TNHH Công nghệ Mạng miHoYo Thượng Hải (miHoYo / HoYoverse).</value>
   </data>
   <data name="ViewGuide5_1Bullet2" xml:space="preserve">
-    <value>本软件不代表、不暗示获得任何游戏官方的认可、背书或推荐。</value>
+    <value>Phần mềm này không đại diện, không ngụ ý việc nhận được bất kỳ sự công nhận, chứng thực hoặc đề xuất chính thức nào từ trò chơi.</value>
   </data>
   <data name="ViewGuide5_1Bullet3" xml:space="preserve">
-    <value>因使用本软件引发的任何游戏内资产损失或连带后果，游戏官方及本软件开发者均不承担任何责任。</value>
+    <value>Đối với bất kỳ tổn thất tài sản trong trò chơi hoặc hậu quả liên đới nào phát sinh từ việc sử dụng phần mềm này, công ty trò chơi chính thức và nhà phát triển phần mềm này đều không chịu bất kỳ trách nhiệm nào.</value>
   </data>
   <data name="ViewGuide5_2Title" xml:space="preserve">
-    <value>【5.2 账号安全与封禁风险】</value>
+    <value>【5.2 Bảo mật Tài khoản và Rủi ro Bị Khóa】</value>
   </data>
   <data name="ViewGuide5_2Bullet1" xml:space="preserve">
-    <value>虽然本软件的大部分功能通过官方公开接口合法获取数据，但根据游戏官方政策，使用任何第三方工具均可能存在违规风险。</value>
+    <value>Mặc dù hầu hết các tính năng của phần mềm này lấy dữ liệu một cách hợp pháp thông qua các API công khai chính thức, nhưng theo chính sách chính thức của trò chơi, việc sử dụng bất kỳ công cụ bên thứ ba nào đều có thể tồn tại rủi ro vi phạm.</value>
   </data>
   <data name="ViewGuide5_2Bullet2" xml:space="preserve">
-    <value>开发者绝对无法保证使用本软件不会导致您的游戏账号受到警告、限制登录或永久封禁。</value>
+    <value>Nhà phát triển tuyệt đối không thể đảm bảo rằng việc sử dụng phần mềm này sẽ không khiến tài khoản trò chơi của bạn nhận cảnh báo, bị hạn chế đăng nhập hoặc bị cấm vĩnh viễn.</value>
   </data>
   <data name="ViewGuide5_2Bullet3" xml:space="preserve">
-    <value>您应当利用自身判断力评估使用本软件的风险，并对使用的所有后果承担 100% 的独立责任。</value>
+    <value>Bạn nên sử dụng phán đoán của riêng mình để đánh giá rủi ro khi sử dụng phần mềm này và tự chịu 100% trách nhiệm độc lập đối với mọi hậu quả phát sinh từ việc sử dụng.</value>
   </data>
   <data name="ViewGuide5_2Bullet4" xml:space="preserve">
-    <value>如发生账号封禁等处罚事件，开发者不承担任何形式的申诉协助义务，亦不提供任何经济赔偿或补偿。</value>
+    <value>Nếu xảy ra các sự cố hình phạt như khóa tài khoản, nhà phát triển sẽ không chịu bất kỳ nghĩa vụ hỗ trợ khiếu nại nào, cũng như không cung cấp bất kỳ khoản bồi thường hay đền bù tài chính nào.</value>
   </data>
   <data name="ViewGuide5_3Title" xml:space="preserve">
-    <value>【5.3 插件加载风险】</value>
+    <value>【5.3 Rủi ro từ Việc Tải Plugin】</value>
   </data>
   <data name="ViewGuide5_3Bullet1" xml:space="preserve">
-    <value>FPS 解锁与 Island 等功能通过插件加载技术实现，此类技术明确违反游戏官方《用户协议》及反作弊系统（如 mhyprot）的运行规则。</value>
+    <value>Mở khóa FPS và các chức năng như Island được thực hiện thông qua công nghệ nạp plugin. Những công nghệ như vậy vi phạm rõ ràng "Thỏa thuận Người dùng" chính thức của trò chơi và các quy tắc hoạt động của các hệ thống chống gian lận (như mhyprot).</value>
   </data>
   <data name="ViewGuide5_3Bullet2" xml:space="preserve">
-    <value>开启并使用此类功能即代表您"明知故犯"地主动违反游戏官方服务条款。</value>
+    <value>Việc bật và sử dụng các tính năng này nghĩa là bạn "biết luật mà vẫn phạm", chủ động vi phạm điều khoản dịch vụ chính thức của trò chơi.</value>
   </data>
   <data name="ViewGuide5_3Bullet3" xml:space="preserve">
-    <value>此功能随时可能被游戏反作弊机制精准检测，由此导致的账号连带处罚风险完全由您自行承担。</value>
+    <value>Tính năng này có thể bị cơ chế chống gian lận của trò chơi phát hiện chính xác bất cứ lúc nào, và mọi rủi ro về việc tài khoản bị trừng phạt do hành động này sẽ hoàn toàn do bạn tự gánh chịu.</value>
   </data>
   <data name="ViewGuide5_3Bullet4" xml:space="preserve">
-    <value>此功能极易被 Windows Defender 或其他杀毒软件识别为恶意威胁并拦截，此属技术层面的正常现象，并非软件包含病毒。</value>
+    <value>Tính năng này rất dễ bị Windows Defender hoặc các phần mềm diệt virus khác nhận dạng nhầm là mối đe dọa độc hại và tiến hành chặn đứng, đây là một hiện tượng bình thường về mặt kỹ thuật, không phải do phần mềm chứa virus.</value>
   </data>
   <data name="ViewGuide5_4Title" xml:space="preserve">
-    <value>【5.4 软件担保的绝对免责】</value>
+    <value>【5.4 Từ chối Tuyệt đối Bảo đảm Phần mềm】</value>
   </data>
   <data name="ViewGuide5_4Text" xml:space="preserve">
-    <value>在适用法律允许的最大范围内，本软件按"原样"（AS IS）且"可用"（AS AVAILABLE）的状态提供，开发者明确否认任何形式的明示或暗示担保，包括但不限于：</value>
+    <value>Trong phạm vi tối đa mà pháp luật hiện hành cho phép, phần mềm này được cung cấp ở trạng thái "nguyên trạng" (AS IS) và "như hiện có" (AS AVAILABLE), nhà phát triển từ chối rõ ràng mọi hình thức bảo đảm rõ ràng hoặc ngụ ý, bao gồm nhưng không giới hạn:</value>
   </data>
   <data name="ViewGuide5_4Bullet1" xml:space="preserve">
-    <value>对适销性、特定用途的适用性、可靠性及非侵权性的暗示担保。</value>
+    <value>Bảo đảm ngụ ý về khả năng thương mại, sự phù hợp với một mục đích cụ thể, độ tin cậy và việc không vi phạm quyền.</value>
   </data>
   <data name="ViewGuide5_4Bullet2" xml:space="preserve">
-    <value>对本软件完全无错误、不中断运行或绝对满足您特定期望的担保。</value>
+    <value>Bảo đảm rằng phần mềm này hoàn toàn không có lỗi, hoạt động không bị gián đoạn hoặc đáp ứng tuyệt đối những kỳ vọng cụ thể của bạn.</value>
   </data>
   <data name="ViewGuide5_4Bullet3" xml:space="preserve">
-    <value>对因下载、安装、使用本软件而导致的任何直接、间接、偶发、特殊或惩罚性的损害赔偿（包括但不限于设备损坏、数据丢失、利润损失）。</value>
+    <value>Bất kỳ khoản bồi thường thiệt hại trực tiếp, gián tiếp, ngẫu nhiên, đặc biệt hoặc mang tính trừng phạt nào (bao gồm nhưng không giới hạn ở hư hỏng thiết bị, mất mát dữ liệu, tổn thất lợi nhuận) phát sinh do việc tải xuống, cài đặt hoặc sử dụng phần mềm này.</value>
   </data>
   <data name="ViewGuide5_5Title" xml:space="preserve">
-    <value>【5.5 数据丢失与服务异常免责】</value>
+    <value>【5.5 Miễn trừ Trách nhiệm Mất Dữ liệu và Dịch vụ Bất thường】</value>
   </data>
   <data name="ViewGuide5_5Text" xml:space="preserve">
-    <value>虽然本软件尽力确保数据的完整性和功能性，但在适用法律允许的最大范围内，开发者不对以下情况导致的任何损失承担责任：</value>
+    <value>Mặc dù phần mềm này đã cố gắng đảm bảo tính toàn vẹn và các chức năng của dữ liệu, nhưng trong phạm vi tối đa mà pháp luật cho phép, nhà phát triển không chịu trách nhiệm cho bất kỳ mất mát nào do các tình huống sau:</value>
   </data>
   <data name="ViewGuide5_5Bullet1" xml:space="preserve">
-    <value>用户误操作（如误删、误格式化）导致的数据不可逆丢失。</value>
+    <value>Người dùng thao tác lỗi (như xóa nhầm, format nhầm) dẫn đến việc dữ liệu bị mất vĩnh viễn không thể khôi phục.</value>
   </data>
   <data name="ViewGuide5_5Bullet2" xml:space="preserve">
-    <value>操作系统崩溃、硬盘物理损坏或第三方恶意软件攻击造成的数据毁损。</value>
+    <value>Sự cố hệ điều hành, hư hỏng phần cứng ổ đĩa hoặc phần mềm độc hại của bên thứ ba tấn công làm hỏng dữ liệu.</value>
   </data>
   <data name="ViewGuide5_5Bullet3" xml:space="preserve">
-    <value>游戏官方 API 变更、接口加密机制强制升级导致的数据抓取永久或暂时性失效。</value>
+    <value>Thay đổi API của game, bắt buộc nâng cấp cơ chế mã hóa giao diện khiến việc thu thập dữ liệu bị vô hiệu hóa tạm thời hoặc vĩnh viễn.</value>
   </data>
   <data name="ViewGuide5_5Bullet4" xml:space="preserve">
-    <value>第三方服务（如 Enka.Network 限流、宕机）导致的功能异常。</value>
+    <value>Bất thường về chức năng do các dịch vụ của bên thứ ba (chẳng hạn như giới hạn tốc độ Enka.Network, sập máy chủ).</value>
   </data>
   <data name="ViewGuide5_5Bullet5" xml:space="preserve">
-    <value>开发者对上述第三方因素引发的问题不承担强制修复的义务。</value>
+    <value>Nhà phát triển không có nghĩa vụ buộc phải sửa chữa đối với các vấn đề phát sinh từ những yếu tố của bên thứ ba nêu trên.</value>
   </data>
   <data name="ViewGuide6Title" xml:space="preserve">
-    <value>第六章  用户行为规范</value>
+    <value>Chương VI. Quy định Hành vi Người dùng</value>
   </data>
   <data name="ViewGuide6_1Title" xml:space="preserve">
-    <value>【6.1 合法使用】</value>
+    <value>【6.1 Sử dụng Hợp pháp】</value>
   </data>
   <data name="ViewGuide6_1Bullet1" xml:space="preserve">
-    <value>您应当确保下载和使用本软件的行为完全符合您所在国家或地区的全部现行法律法规。</value>
+    <value>Bạn cần đảm bảo hành vi tải xuống và sử dụng phần mềm này tuân thủ đầy đủ tất cả các quy định pháp luật hiện hành của quốc gia hoặc khu vực bạn đang sống.</value>
   </data>
   <data name="ViewGuide6_1Bullet2" xml:space="preserve">
-    <value>严禁利用本软件从事任何涉嫌诈骗、侵权、破坏计算机信息系统等违法活动。</value>
+    <value>Nghiêm cấm sử dụng phần mềm này để tham gia bất kỳ hoạt động bất hợp pháp nào liên quan đến lừa đảo, xâm phạm, phá hoại hệ thống thông tin máy tính.</value>
   </data>
   <data name="ViewGuide6_1Bullet3" xml:space="preserve">
-    <value>不得利用本软件的高级功能恶意干扰游戏服务器的正常运营或破坏游戏公平性。</value>
+    <value>Không được lợi dụng các tính năng nâng cao của phần mềm này để ác ý can thiệp vào hoạt động bình thường của máy chủ trò chơi hoặc phá hoại tính công bằng của trò chơi.</value>
   </data>
   <data name="ViewGuide6_2Title" xml:space="preserve">
-    <value>【6.2 严禁行为】</value>
+    <value>【6.2 Các Hành vi Nghiêm cấm】</value>
   </data>
   <data name="ViewGuide6_2Bullet1" xml:space="preserve">
-    <value>以营利为目的，将本软件包装、倒卖或作为收费外挂的一部分进行商业分发。</value>
+    <value>Vì mục đích lợi nhuận, đóng gói, bán lại phần mềm này hoặc phân phối thương mại như một phần của phần mềm gian lận thu phí.</value>
   </data>
   <data name="ViewGuide6_2Bullet2" xml:space="preserve">
-    <value>对本软件的开源代码进行恶意篡改，植入计算机病毒、广告后门或木马程序后向公众散播。</value>
+    <value>Sửa đổi ác ý mã nguồn mở của phần mềm này, cấy virus máy tính, quảng cáo, backdoor hoặc trojan rồi phát tán ra công chúng.</value>
   </data>
   <data name="ViewGuide6_2Bullet3" xml:space="preserve">
-    <value>冒用本软件官方名义或开发者身份建立虚假社群进行钓鱼或欺诈。</value>
+    <value>Mạo danh tên chính thức của phần mềm này hoặc danh tính nhà phát triển để tạo các cộng đồng giả mạo nhằm lừa đảo hoặc trục lợi.</value>
   </data>
   <data name="ViewGuide6_2Bullet4" xml:space="preserve">
-    <value>利用本软件的账号记忆功能从事非法盗号、游戏账号地下交易等黑色产业链活动。</value>
+    <value>Sử dụng chức năng ghi nhớ tài khoản của phần mềm này để thực hiện các hoạt động thuộc chuỗi công nghiệp đen (black market) như đánh cắp tài khoản bất hợp pháp, giao dịch tài khoản trò chơi ngầm.</value>
   </data>
   <data name="ViewGuide6_2Bullet5" xml:space="preserve">
-    <value>利用工具脚本自动化、高频次地恶意请求 API 接口，对游戏官方或第三方服务器造成实质性攻击（如 DDoS）。</value>
+    <value>Sử dụng công cụ script tự động, liên tục gửi yêu cầu API với tần suất cao, gây ra các cuộc tấn công thực tế (như DDoS) nhằm vào máy chủ của trò chơi hoặc máy chủ của bên thứ ba.</value>
   </data>
   <data name="ViewGuide6_3Title" xml:space="preserve">
-    <value>【6.3 未成年人特别保护声明】</value>
+    <value>【6.3 Tuyên bố Bảo vệ Đặc biệt dành cho Người Chưa Thành Niên】</value>
   </data>
   <data name="ViewGuide6_3Bullet1" xml:space="preserve">
-    <value>若您是未满 18 周岁（或您所在地区法定成年年龄）的未成年人，请务必在您的父母或其他法定监护人陪同、指导下共同仔细阅读并同意本协议。</value>
+    <value>Nếu bạn là người chưa thành niên dưới 18 tuổi (hoặc độ tuổi trưởng thành hợp pháp tại quốc gia/khu vực của bạn), xin vui lòng chắc chắn rằng bạn đã cùng cha mẹ hoặc người giám hộ hợp pháp khác đọc kỹ và đồng ý với Thỏa thuận này dưới sự đồng hành và hướng dẫn của họ.</value>
   </data>
   <data name="ViewGuide6_3Bullet2" xml:space="preserve">
-    <value>未成年人使用本软件可能带来的沉迷游戏或账号违规风险，应由监护人加强监督与引导。</value>
+    <value>Việc sử dụng phần mềm này của người chưa thành niên có thể mang theo rủi ro nghiện game hoặc vi phạm tài khoản, người giám hộ nên tăng cường giám sát và chỉ dẫn.</value>
   </data>
   <data name="ViewGuide6_3Bullet3" xml:space="preserve">
-    <value>因监护人未尽到监护义务，导致未成年人使用本软件引发的一切不良后果及法律责任，均由法定监护人完全承担。</value>
+    <value>Bởi người giám hộ đã không thực hiện đầy đủ nghĩa vụ giám hộ, mọi hậu quả tiêu cực và trách nhiệm pháp lý phát sinh từ việc người chưa thành niên sử dụng phần mềm này sẽ hoàn toàn do người giám hộ hợp pháp gánh chịu.</value>
   </data>
   <data name="ViewGuide7Title" xml:space="preserve">
-    <value>第七章  其他条款</value>
+    <value>Chương VII. Các Điều khoản Khác</value>
   </data>
   <data name="ViewGuide7_1Title" xml:space="preserve">
-    <value>【7.1 协议的生效与更新】</value>
+    <value>【7.1 Hiệu lực và Cập nhật Thỏa thuận】</value>
   </data>
   <data name="ViewGuide7_1Bullet1" xml:space="preserve">
-    <value>开发者保留在必要时随时修改本协议的权利，修改后的最新协议将随新版本软件一同发布生效。</value>
+    <value>Nhà phát triển có quyền sửa đổi Thỏa thuận này bất cứ lúc nào khi cần thiết. Thỏa thuận mới nhất được sửa đổi sẽ có hiệu lực ngay khi phần mềm phiên bản mới được phát hành.</value>
   </data>
   <data name="ViewGuide7_1Bullet2" xml:space="preserve">
-    <value>在协议更新后，您继续运行或使用本软件的行为，即视为您已无条件接受并同意修改后的全部条款。</value>
+    <value>Sau khi Thỏa thuận được cập nhật, nếu bạn tiếp tục chạy hoặc sử dụng phần mềm này, điều đó có nghĩa là bạn đã vô điều kiện chấp nhận và đồng ý với tất cả các điều khoản đã được sửa đổi.</value>
   </data>
   <data name="ViewGuide7_1Bullet3" xml:space="preserve">
-    <value>如果您拒绝接受更新后的条款，您唯一的救济途径是立即卸载本软件并清空相关数据。</value>
+    <value>Nếu bạn từ chối chấp nhận các điều khoản cập nhật, cách giải quyết duy nhất của bạn là gỡ cài đặt ngay phần mềm này và xóa mọi dữ liệu liên quan.</value>
   </data>
   <data name="ViewGuide7_2Title" xml:space="preserve">
-    <value>【7.2 协议可分割性】</value>
+    <value>【7.2 Tính Tách rời của Thỏa thuận】</value>
   </data>
   <data name="ViewGuide7_2Bullet1" xml:space="preserve">
-    <value>如本协议中的任何条款被拥有管辖权的法院或机构认定为部分或全部无效、不合法或不可执行，该条款将被视为从本协议中独立剔除。</value>
+    <value>Nếu bất kỳ điều khoản nào trong Thỏa thuận này bị tòa án hoặc cơ quan có thẩm quyền xét xử cho là vô hiệu, bất hợp pháp hoặc không thể thi hành một phần hay toàn bộ, điều khoản đó sẽ bị coi là đã được loại bỏ độc lập khỏi Thỏa thuận này.</value>
   </data>
   <data name="ViewGuide7_2Bullet2" xml:space="preserve">
-    <value>上述无效条款的剔除绝不影响本协议其余所有条款的完全法律效力和可执行性。</value>
+    <value>Việc loại bỏ điều khoản vô hiệu nêu trên hoàn toàn không ảnh hưởng đến toàn bộ hiệu lực pháp lý và tính có thể thi hành của tất cả các điều khoản còn lại trong Thỏa thuận này.</value>
   </data>
   <data name="ViewGuide7_3Title" xml:space="preserve">
-    <value>【7.3 法律适用与争议解决（管辖权）】</value>
+    <value>【7.3 Áp dụng Pháp luật và Giải quyết Tranh chấp (Quyền Tài phán)】</value>
   </data>
   <data name="ViewGuide7_3Bullet1" xml:space="preserve">
-    <value>本协议的成立、生效、履行、解释及争议解决，均严格适用中华人民共和国大陆地区法律（排除冲突法的适用）。</value>
+    <value>Việc thiết lập, hiệu lực, thi hành, giải thích và giải quyết tranh chấp của Thỏa thuận này sẽ tuân thủ nghiêm ngặt luật pháp của nước Cộng hòa Nhân dân Trung Hoa (khu vực Đại lục), (loại trừ việc áp dụng luật xung đột).</value>
   </data>
   <data name="ViewGuide7_3Bullet2" xml:space="preserve">
-    <value>因本协议或使用本软件引发的任何纠纷或争议，双方应首先本着诚实信用原则进行友好协商。</value>
+    <value>Mọi tranh chấp hay tranh cãi phát sinh từ Thỏa thuận này hoặc từ việc sử dụng phần mềm này, trước tiên cả hai bên nên tiến hành thương lượng hữu nghị dựa trên nguyên tắc trung thực và thiện chí.</value>
   </data>
   <data name="ViewGuide7_3Bullet3" xml:space="preserve">
-    <value>若协商不成，任何一方均必须向【本软件核心开发者或主要项目维护团队所在地】有管辖权的人民法院提起诉讼，排除其他任何法院的管辖权。</value>
+    <value>Nếu không thể thương lượng được, bất kỳ bên nào cũng BẮT BUỘC phải đệ đơn kiện lên Tòa án Nhân dân có thẩm quyền tại 【Nơi đặt trụ sở của nhà phát triển nòng cốt của phần mềm này hoặc nhóm bảo trì dự án chính】, loại trừ quyền tài phán của bất kỳ tòa án nào khác.</value>
   </data>
   <data name="ViewGuide7_4Title" xml:space="preserve">
-    <value>【7.4 完整协议】</value>
+    <value>【7.4 Toàn bộ Thỏa thuận】</value>
   </data>
   <data name="ViewGuide7_4Text" xml:space="preserve">
-    <value>本协议及随附的隐私政策构成了您与开发者之间关于使用本软件的唯一、完整且最终的协议，并自动取代双方此前就此达成的任何口头、书面或电子形式的声明与共识。</value>
+    <value>Thỏa thuận này cùng với Chính sách Bảo mật đính kèm tạo thành thỏa thuận duy nhất, toàn vẹn và cuối cùng giữa bạn và nhà phát triển về việc sử dụng phần mềm này, và sẽ tự động thay thế mọi tuyên bố hay đồng thuận bằng miệng, bằng văn bản hoặc điện tử nào đã đạt được trước đó giữa hai bên về vấn đề này.</value>
   </data>
   <data name="ViewInventoryHeader" xml:space="preserve">
-    <value>背包物品</value>
+    <value>Vật phẩm Ba lô</value>
   </data>
   <data name="ViewInventoryTitle" xml:space="preserve">
-    <value>背包武器</value>
+    <value>Vũ khí Ba lô</value>
   </data>
   <data name="ViewInventoryInjectButton" xml:space="preserve">
-    <value>插件获取</value>
+    <value>Nạp Plugin</value>
   </data>
   <data name="ViewInventoryLoadButton" xml:space="preserve">
-    <value>读取数据</value>
+    <value>Đọc dữ liệu</value>
   </data>
   <data name="ViewInventoryDumpPathPlaceholder" xml:space="preserve">
-    <value>PacketDump 目录路径</value>
+    <value>Đường dẫn thư mục PacketDump</value>
   </data>
   <data name="ViewInventoryStatusReady" xml:space="preserve">
-    <value>点击“插件获取”开始</value>
+    <value>Nhấp "Nạp Plugin" để bắt đầu</value>
   </data>
   <data name="ViewInventoryEmptyHint" xml:space="preserve">
-    <value>尚未获取背包信息</value>
+    <value>Chưa có thông tin Ba lô</value>
   </data>
   <data name="ViewInventoryCaptureDescription" xml:space="preserve">
-    <value>自动启动游戏并加载 DLL 插件获取背包武器数据</value>
+    <value>Tự động chạy game và nạp plugin DLL để lấy dữ liệu vũ khí trong ba lô</value>
   </data>
   <data name="ViewInventoryWeaponLevel" xml:space="preserve">
-    <value>等级</value>
+    <value>Cấp</value>
   </data>
   <data name="ViewInventoryWeaponPromote" xml:space="preserve">
-    <value>突破等级</value>
+    <value>Cấp Đột phá</value>
   </data>
   <data name="ViewInventoryWeaponRefinement" xml:space="preserve">
-    <value>精炼等级</value>
+    <value>Cấp Tinh luyện</value>
   </data>
   <data name="ViewInventoryWeaponType" xml:space="preserve">
-    <value>武器类型</value>
+    <value>Loại Vũ khí</value>
   </data>
   <data name="ViewInventoryStatusFindingProcess" xml:space="preserve">
-    <value>正在查找游戏进程...</value>
+    <value>Đang tìm tiến trình game...</value>
   </data>
   <data name="ViewInventoryStatusNoProcess" xml:space="preserve">
-    <value>未找到游戏进程，请确保游戏已启动</value>
+    <value>Không tìm thấy tiến trình game, hãy chắc chắn là game đã chạy</value>
   </data>
   <data name="ViewInventoryStatusInjecting" xml:space="preserve">
-    <value>找到游戏进程，正在加载插件...</value>
+    <value>Đã tìm thấy tiến trình game, đang nạp plugin...</value>
   </data>
   <data name="ViewInventoryStatusNoDll" xml:space="preserve">
-    <value>找不到 PacketSniffer.dll，请将拦截 DLL 放到程序目录</value>
+    <value>Không tìm thấy PacketSniffer.dll, hãy đặt DLL đánh chặn vào thư mục ứng dụng</value>
   </data>
   <data name="ViewInventoryStatusInjectFailed" xml:space="preserve">
-    <value>插件加载失败，可能需要管理员权限</value>
+    <value>Nạp plugin thất bại, có thể cần quyền quản trị viên</value>
   </data>
   <data name="ViewInventoryStatusWaitingCapture" xml:space="preserve">
-    <value>插件加载成功，等待数据包捕获...</value>
+    <value>Đã nạp thành công plugin, đang chờ bắt gói dữ liệu...</value>
   </data>
   <data name="ViewInventoryStatusParsing" xml:space="preserve">
-    <value>正在解析背包数据...</value>
+    <value>Đang phân tích dữ liệu ba lô...</value>
   </data>
   <data name="ViewInventoryStatusNoData" xml:space="preserve">
-    <value>未找到武器数据，请确保已捕获 CmdId=24104 的数据包</value>
+    <value>Không tìm thấy dữ liệu vũ khí, hãy chắc chắn đã bắt được gói dữ liệu CmdId=24104</value>
   </data>
   <data name="ViewInventoryStatusDirNotExist" xml:space="preserve">
-    <value>数据目录不存在</value>
+    <value>Thư mục dữ liệu không tồn tại</value>
   </data>
   <data name="ViewInventoryStatusParseFailed" xml:space="preserve">
-    <value>解析失败</value>
+    <value>Phân tích thất bại</value>
   </data>
   <data name="ViewInventoryTotalCount" xml:space="preserve">
-    <value>武器总数:</value>
+    <value>Tổng số vũ khí:</value>
   </data>
   <data name="ViewInventoryTypeCount" xml:space="preserve">
-    <value>武器种类:</value>
+    <value>Loại vũ khí:</value>
   </data>
   <data name="ViewInventoryColumnRefinement" xml:space="preserve">
-    <value>精炼</value>
+    <value>Tinh Luyện</value>
   </data>
   <data name="ViewInventoryUnknownWeapon" xml:space="preserve">
-    <value>未知武器</value>
+    <value>Vũ khí không xác định</value>
   </data>
   <data name="ViewInventoryStatusDone" xml:space="preserve">
-    <value>解析完成: {0} 把武器，{1} 种</value>
+    <value>Phân tích hoàn tất: {0} vũ khí, {1} loại</value>
   </data>
   <data name="ViewInventoryRefreshButton" xml:space="preserve">
-    <value>刷新</value>
+    <value>Làm mới</value>
   </data>
   <data name="ServiceFeedbackReplyNotification" xml:space="preserve">
-    <value>您的反馈已收到回复：{0}</value>
+    <value>Phản hồi của bạn đã nhận được trả lời: {0}</value>
   </data>
   <data name="ViewNavigationThrottleTitle" xml:space="preserve">
-    <value>操作过快</value>
+    <value>Thao tác quá nhanh</value>
   </data>
   <data name="ViewNavigationThrottleMessage" xml:space="preserve">
-    <value>请稍后再切换页面</value>
+    <value>Xin vui lòng đợi một chút rồi hãy chuyển trang</value>
   </data>
   <data name="ServiceGameLaunchingCustomDllInjectFailed" xml:space="preserve">
-    <value>以下自定义 DLL 注入失败（架构不匹配、依赖缺失、被安全软件拦截等）：</value>
+    <value>Các Custom DLL sau đã tiêm thất bại (kiến trúc không khớp, thiếu dependency, bị phần mềm bảo vệ chặn v.v):</value>
   </data>
   <data name="ServiceGameLaunchingCannotGetLauncherPath" xml:space="preserve">
-    <value>无法获取启动器路径</value>
+    <value>Không thể lấy đường dẫn Launcher</value>
   </data>
   <data name="ServiceGameLaunchingUserCancelledElevation" xml:space="preserve">
-    <value>用户取消了管理员授权</value>
+    <value>Người dùng đã hủy cấp quyền Quản trị viên</value>
   </data>
   <data name="ServiceGameLaunchingStartInjectionProcessFailed" xml:space="preserve">
-    <value>启动注入进程失败</value>
+    <value>Khởi chạy quá trình tiêm thất bại</value>
   </data>
   <data name="ServiceGameLaunchingInjectionReasonInvalidArgs" xml:space="preserve">
-    <value>参数错误</value>
+    <value>Sai tham số</value>
   </data>
   <data name="ServiceGameLaunchingInjectionReasonCreateProcessFailed" xml:space="preserve">
-    <value>创建游戏进程失败</value>
+    <value>Tạo tiến trình game thất bại</value>
   </data>
   <data name="ServiceGameLaunchingInjectionReasonDllInjectFailed" xml:space="preserve">
-    <value>DLL注入失败</value>
+    <value>Tiêm DLL thất bại</value>
   </data>
   <data name="ServiceGameLaunchingInjectionReasonUnknown" xml:space="preserve">
-    <value>未知错误 ({0})</value>
+    <value>Lỗi không xác định ({0})</value>
   </data>
   <data name="ServiceGameLaunchingInjectionFailed" xml:space="preserve">
-    <value>注入失败: {0}</value>
+    <value>Tiêm thất bại: {0}</value>
   </data>
   <data name="ServiceGameLaunchingCannotGetProcessInfo" xml:space="preserve">
-    <value>无法获取游戏进程信息</value>
+    <value>Không thể lấy thông tin tiến trình game</value>
   </data>
   <data name="ServiceGameLaunchingInvalidProcessId" xml:space="preserve">
-    <value>无效的游戏进程ID</value>
+    <value>ID tiến trình game không hợp lệ</value>
   </data>
   <data name="ServiceGameLaunchingCannotConnectToProcess" xml:space="preserve">
-    <value>无法连接到游戏进程</value>
+    <value>Không thể kết nối đến tiến trình game</value>
   </data>
   <data name="ServiceYaeAchievementImportHint" xml:space="preserve">
-    <value>注意请不要进行任何操作：点击导入 → 自动启动游戏 → 读取成就 → 自动导出</value>
+    <value>Lưu ý không thao tác gì cả: Nhấp Nhập → Tự động bật game → Đọc thành tựu → Tự động xuất</value>
   </data>
   <data name="ServiceYaeInventoryImportHint" xml:space="preserve">
-    <value>注意请不要进行任何操作：点击导入 → 自动启动游戏 → 读取背包 → 自动导出</value>
+    <value>Lưu ý không thao tác gì cả: Nhấp Nhập → Tự động bật game → Đọc ba lô → Tự động xuất</value>
   </data>
   <data name="ServiceInventoryWeaponTypeSword" xml:space="preserve">
-    <value>单手剑</value>
+    <value>Kiếm Đơn</value>
   </data>
   <data name="ServiceInventoryWeaponTypeCatalyst" xml:space="preserve">
-    <value>法器</value>
+    <value>Pháp Khí</value>
   </data>
   <data name="ServiceInventoryWeaponTypeClaymore" xml:space="preserve">
-    <value>双手剑</value>
+    <value>Trọng Kiếm</value>
   </data>
   <data name="ServiceInventoryWeaponTypeBow" xml:space="preserve">
-    <value>弓</value>
+    <value>Cung</value>
   </data>
   <data name="ServiceInventoryWeaponTypePolearm" xml:space="preserve">
-    <value>长柄武器</value>
+    <value>Vũ Khí Cán Dài</value>
   </data>
   <data name="ServiceInventoryWeaponTypeUnknown" xml:space="preserve">
-    <value>未知</value>
+    <value>Không rõ</value>
   </data>
   <data name="ServiceInventoryWeaponUnknown" xml:space="preserve">
-    <value>未知武器({0})</value>
+    <value>Vũ khí không rõ ({0})</value>
   </data>
   <data name="ServiceInventoryPromoteText" xml:space="preserve">
-    <value>突破 {0}</value>
+    <value>Đột Phá {0}</value>
   </data>
   <data name="ServiceInventoryRefinementText" xml:space="preserve">
-    <value>精炼 {0}</value>
+    <value>Tinh Luyện {0}</value>
   </data>
   <data name="ViewInventoryStatusNoGamePath" xml:space="preserve">
-    <value>未配置游戏路径，请先在启动游戏页面设置</value>
+    <value>Chưa thiết lập đường dẫn game, vui lòng cấu hình tại trang Khởi Động Game</value>
   </data>
   <data name="ViewEmotionIconCopyButton" xml:space="preserve">
-    <value>复制</value>
+    <value>Sao chép</value>
   </data>
   <data name="ViewEmotionIconCloseButton" xml:space="preserve">
-    <value>关闭</value>
+    <value>Đóng</value>
   </data>
   <data name="ViewFeedbackPickImageTitle" xml:space="preserve">
-    <value>选择反馈图片</value>
+    <value>Chọn ảnh phản hồi</value>
   </data>
   <data name="ViewFeedbackPickImageFilter" xml:space="preserve">
-    <value>图片文件</value>
+    <value>Tập tin hình ảnh</value>
   </data>
   <data name="ViewFeedbackNoImageSelected" xml:space="preserve">
-    <value>未选择图片</value>
+    <value>Chưa chọn ảnh</value>
   </data>
   <data name="ViewFeedbackContentRequired" xml:space="preserve">
-    <value>请填写反馈内容</value>
+    <value>Vui lòng điền nội dung phản hồi</value>
   </data>
   <data name="ViewFeedbackSubmitSuccess" xml:space="preserve">
-    <value>感谢您的反馈，我们会认真阅读！</value>
+    <value>Cảm ơn phản hồi của bạn, chúng tôi sẽ đọc kỹ!</value>
   </data>
   <data name="ViewFeedbackSubmitFailed" xml:space="preserve">
-    <value>提交失败，请检查网络连接后重试</value>
+    <value>Gửi thất bại, vui lòng kiểm tra kết nối mạng rồi thử lại</value>
   </data>
 </root>

--- a/src/launcher/Resource/Localization/SH.vi-VN.resx
+++ b/src/launcher/Resource/Localization/SH.vi-VN.resx
@@ -1,0 +1,5747 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppDevNameAndVersion" xml:space="preserve">
+    <value>ky3 Launcher Dev {0}</value>
+  </data>
+  <data name="AppElevatedDevNameAndVersion" xml:space="preserve">
+    <value>ky3 Launcher Dev {0} [管理员]</value>
+  </data>
+  <data name="AppElevatedNameAndVersion" xml:space="preserve">
+    <value>ky3 Launcher {0} [管理员]</value>
+  </data>
+  <data name="AppName" xml:space="preserve">
+    <value>ky3 Launcher</value>
+  </data>
+  <data name="AppNameAndVersion" xml:space="preserve">
+    <value>ky3 Launcher {0}</value>
+  </data>
+  <data name="ContentDialogCancelCloseButtonText" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="ContentDialogCompletePrimaryButtonText" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="ContentDialogConfirmPrimaryButtonText" xml:space="preserve">
+    <value>确认</value>
+  </data>
+  <data name="ContentDialogSavePrimaryButtonText" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="ControlAutoSuggestBoxNotFoundValue" xml:space="preserve">
+    <value>未找到结果</value>
+  </data>
+  <data name="ControlAutoSuggestTokenBoxRemoveMenuItem" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ControlAutoSuggestTokenBoxSelectAllMenuItem" xml:space="preserve">
+    <value>选择全部</value>
+  </data>
+  <data name="ControlImageCachedImageInvalidResourceUri" xml:space="preserve">
+    <value>无效的 URI</value>
+  </data>
+  <data name="ControlPanelPanelSelectorDropdownGridName" xml:space="preserve">
+    <value>网格</value>
+  </data>
+  <data name="ControlPanelPanelSelectorDropdownListName" xml:space="preserve">
+    <value>列表</value>
+  </data>
+  <data name="CoreLifeCycleAppActivationNotifyIconCreateFailed" xml:space="preserve">
+    <value>通知区域图标创建失败</value>
+  </data>
+  <data name="CoreThreadingSemaphoreSlimDisposed" xml:space="preserve">
+    <value>信号量已经被释放，操作取消</value>
+  </data>
+  <data name="CoreWebView2HelperVersionUndetected" xml:space="preserve">
+    <value>未检测到 WebView2 运行时</value>
+  </data>
+  <data name="CoreWindowHotkeyCombinationRegisterFailed" xml:space="preserve">
+    <value>[{0}] 热键 [{1}] 注册失败</value>
+  </data>
+  <data name="CoreWindowThemeDark" xml:space="preserve">
+    <value>深色</value>
+  </data>
+  <data name="CoreWindowThemeLight" xml:space="preserve">
+    <value>浅色</value>
+  </data>
+  <data name="CoreWindowThemeSystem" xml:space="preserve">
+    <value>跟随系统</value>
+  </data>
+  <data name="CoreWindowingNotifyIconExitLabel" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="CoreWindowingNotifyIconLaunchGameLabel" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="CoreWindowingNotifyIconPromotedHint" xml:space="preserve">
+    <value>已进入后台运行</value>
+  </data>
+  <data name="CoreWindowingNotifyIconViewLabel" xml:space="preserve">
+    <value>窗口</value>
+  </data>
+  <data name="GuideWindowTitle" xml:space="preserve">
+    <value>欢迎使用-ky3 Launcher</value>
+  </data>
+  <data name="GuideWindowTitleAllCultures" xml:space="preserve">
+    <value>欢迎使用-ky3 Launcher+Welcome to ky3 Launcher+歡迎使用-ky3 Launcher</value>
+  </data>
+  <data name="MetadataSpecialNameMetaAvatarSexProInfoPronounBoyGirlD" xml:space="preserve">
+    <value>&lt;color=#1E90FF&gt;王子&lt;/color&gt;/&lt;color=#FFB6C1&gt;公主&lt;/color&gt;</value>
+  </data>
+  <data name="MetadataSpecialNameMetaAvatarSexProInfoPronounBoyGirlFirst" xml:space="preserve">
+    <value>&lt;color=#1E90FF&gt;我&lt;/color&gt;/&lt;color=#FFB6C1&gt;我&lt;/color&gt;</value>
+  </data>
+  <data name="MetadataSpecialNameNickname" xml:space="preserve">
+    <value>旅行者</value>
+  </data>
+  <data name="MetadataSpecialNamePlayerAvatarSexProInfoPronounHeShe" xml:space="preserve">
+    <value>&lt;color=#1E90FF&gt;他&lt;/color&gt;/&lt;color=#FFB6C1&gt;她&lt;/color&gt;</value>
+  </data>
+  <data name="MetadataSpecialNameRealNameId1" xml:space="preserve">
+    <value>流浪者</value>
+  </data>
+  <data name="MetadataSpecialNameServerTimeZone" xml:space="preserve">
+    <value>服务器时区</value>
+  </data>
+  <data name="ModelBindingAvatarPropertyWeaponAffix" xml:space="preserve">
+    <value>精炼 {0}</value>
+  </data>
+  <data name="ModelBindingCultivationDaysOfWeek14" xml:space="preserve">
+    <value>周一/周四/周日</value>
+  </data>
+  <data name="ModelBindingCultivationDaysOfWeek25" xml:space="preserve">
+    <value>周二/周五/周日</value>
+  </data>
+  <data name="ModelBindingCultivationDaysOfWeek36" xml:space="preserve">
+    <value>周三/周六/周日</value>
+  </data>
+  <data name="ModelBindingGachaTypedWishSummaryAveragePull" xml:space="preserve">
+    <value>{0:f2} 抽</value>
+  </data>
+  <data name="ModelBindingGachaTypedWishSummaryMaxOrangePull" xml:space="preserve">
+    <value>最非 {0} 抽</value>
+  </data>
+  <data name="ModelBindingGachaTypedWishSummaryMinOrangePull" xml:space="preserve">
+    <value>最欧 {0} 抽</value>
+  </data>
+  <data name="ModelBindingGachaWishBaseTotalCount" xml:space="preserve">
+    <value>{0} 抽</value>
+  </data>
+  <data name="ModelBindingLauncherComplexRankFloor" xml:space="preserve">
+    <value>第 {0} 层</value>
+  </data>
+  <data name="ModelBindingLauncherComplexRankLevel" xml:space="preserve">
+    <value>第 {0} 间</value>
+  </data>
+  <data name="ModelBindingLauncherTeamUpCount" xml:space="preserve">
+    <value>上场 {0} 次</value>
+  </data>
+  <data name="ModelBindingLaunchGameLaunchSchemeBilibili" xml:space="preserve">
+    <value>渠道服</value>
+  </data>
+  <data name="ModelBindingLaunchGameLaunchSchemeChinese" xml:space="preserve">
+    <value>官方服</value>
+  </data>
+  <data name="ModelBindingLaunchGameLaunchSchemeOversea" xml:space="preserve">
+    <value>国际服</value>
+  </data>
+  <data name="ModelBindingUserInitializationFailed" xml:space="preserve">
+    <value>网络异常</value>
+  </data>
+  <data name="ModelEntityDailyNoteNotRefreshed" xml:space="preserve">
+    <value>尚未刷新</value>
+  </data>
+  <data name="ModelEntityDailyNoteRefreshTime" xml:space="preserve">
+    <value>刷新于 {0:MM.dd HH:mm:ss}</value>
+  </data>
+  <data name="ModelEntityHardChallengeSchedule" xml:space="preserve">
+    <value>第 {0} 期：{1}</value>
+  </data>
+  <data name="ModelEntityPrimitiveCultivateTypeAvatarAndSkill" xml:space="preserve">
+    <value>角色</value>
+  </data>
+  <data name="ModelEntityPrimitiveCultivateTypeFurniture" xml:space="preserve">
+    <value>家具</value>
+  </data>
+  <data name="ModelEntityPrimitiveCultivateTypeWeapon" xml:space="preserve">
+    <value>武器</value>
+  </data>
+  <data name="ModelEntitySpiralAbyssSchedule" xml:space="preserve">
+    <value>第 {0} 期</value>
+  </data>
+  <data name="ModelInterchangeUIGFItemTypeAvatar" xml:space="preserve">
+    <value>角色</value>
+    <comment>Need EXACT same string in official API</comment>
+  </data>
+  <data name="ModelInterchangeUIGFItemTypeWeapon" xml:space="preserve">
+    <value>武器</value>
+    <comment>Need EXACT same string in official API</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeFatui" xml:space="preserve">
+    <value>愚人众</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeFontaine" xml:space="preserve">
+    <value>枫丹</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeInazuma" xml:space="preserve">
+    <value>稻妻</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeLiyue" xml:space="preserve">
+    <value>璃月</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeMondstadt" xml:space="preserve">
+    <value>蒙德</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeNatlan" xml:space="preserve">
+    <value>纳塔</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeNodkrai" xml:space="preserve">
+    <value>挪德卡莱</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeOmniScourge" xml:space="preserve">
+    <value>寰宇劫灭</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeRanger" xml:space="preserve">
+    <value>游侠</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeSnezhnaya" xml:space="preserve">
+    <value>至冬</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicAssociationTypeSumeru" xml:space="preserve">
+    <value>须弥</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicBodyTypeBoy" xml:space="preserve">
+    <value>少男</value>
+  </data>
+  <data name="ModelIntrinsicBodyTypeGirl" xml:space="preserve">
+    <value>少女</value>
+  </data>
+  <data name="ModelIntrinsicBodyTypeLady" xml:space="preserve">
+    <value>成女</value>
+  </data>
+  <data name="ModelIntrinsicBodyTypeLoli" xml:space="preserve">
+    <value>萝莉</value>
+  </data>
+  <data name="ModelIntrinsicBodyTypeMale" xml:space="preserve">
+    <value>成男</value>
+  </data>
+  <data name="ModelIntrinsicElementNameElec" xml:space="preserve">
+    <value>雷</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameFire" xml:space="preserve">
+    <value>火</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameGrass" xml:space="preserve">
+    <value>草</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameIce" xml:space="preserve">
+    <value>冰</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameRock" xml:space="preserve">
+    <value>岩</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameWater" xml:space="preserve">
+    <value>水</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicElementNameWind" xml:space="preserve">
+    <value>风</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelAdvancing" xml:space="preserve">
+    <value>进阶</value>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelDire" xml:space="preserve">
+    <value>绝境</value>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelFearless" xml:space="preserve">
+    <value>无畏</value>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelHard" xml:space="preserve">
+    <value>困难</value>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelMenacing" xml:space="preserve">
+    <value>险恶</value>
+  </data>
+  <data name="ModelIntrinsicHardChallengeDifficultyLevelNormal" xml:space="preserve">
+    <value>普通</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityBlue" xml:space="preserve">
+    <value>三星</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityGreen" xml:space="preserve">
+    <value>二星</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityOrange" xml:space="preserve">
+    <value>五星</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityPurple" xml:space="preserve">
+    <value>四星</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityRed" xml:space="preserve">
+    <value>限定五星</value>
+  </data>
+  <data name="ModelIntrinsicItemQualityWhite" xml:space="preserve">
+    <value>一星</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeNovice" xml:space="preserve">
+    <value>新手祈愿</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeStandard" xml:space="preserve">
+    <value>常驻祈愿</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeAvatarEvent" xml:space="preserve">
+    <value>角色活动祈愿</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeWeaponEvent" xml:space="preserve">
+    <value>武器活动祈愿</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeAvatarEvent2" xml:space="preserve">
+    <value>角色活动祈愿-2</value>
+  </data>
+  <data name="ModelIntrinsicGachaTypeChronicled" xml:space="preserve">
+    <value>集录祈愿</value>
+  </data>
+  <data name="ModelIntrinsicRoleCombatDifficultyLevelEasy" xml:space="preserve">
+    <value>轻简模式</value>
+  </data>
+  <data name="ModelIntrinsicRoleCombatDifficultyLevelHard" xml:space="preserve">
+    <value>困难模式</value>
+  </data>
+  <data name="ModelIntrinsicRoleCombatDifficultyLevelLunar" xml:space="preserve">
+    <value>月谕模式</value>
+  </data>
+  <data name="ModelIntrinsicRoleCombatDifficultyLevelNormal" xml:space="preserve">
+    <value>普通模式</value>
+  </data>
+  <data name="ModelIntrinsicRoleCombatDifficultyLevelVisionary" xml:space="preserve">
+    <value>卓越模式</value>
+  </data>
+  <data name="ModelIntrinsicWeaponTypeBow" xml:space="preserve">
+    <value>弓</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicWeaponTypeCatalyst" xml:space="preserve">
+    <value>法器</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicWeaponTypeClaymore" xml:space="preserve">
+    <value>双手剑</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicWeaponTypePole" xml:space="preserve">
+    <value>长柄武器</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelIntrinsicWeaponTypeSwordOneHand" xml:space="preserve">
+    <value>单手剑</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataAvatarPlayerName" xml:space="preserve">
+    <value>旅行者</value>
+  </data>
+  <data name="ModelMetadataFetterInfoBirthday" xml:space="preserve">
+    <value>{0} 月 {1} 日</value>
+  </data>
+  <data name="ModelMetadataMaterialCharacterAndWeaponEnhancementMaterial" xml:space="preserve">
+    <value>角色与武器培养素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialCharacterAscensionMaterial" xml:space="preserve">
+    <value>角色突破素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialCharacterEXPMaterial" xml:space="preserve">
+    <value>角色经验素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialCharacterLevelUpMaterial" xml:space="preserve">
+    <value>角色培养素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialCharacterTalentMaterial" xml:space="preserve">
+    <value>角色天赋素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialWeaponAscensionMaterial" xml:space="preserve">
+    <value>武器突破素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataMaterialWeaponEnhancementMaterial" xml:space="preserve">
+    <value>武器强化素材</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ModelMetadataTowerGoalTypeDefeatMonsters" xml:space="preserve">
+    <value>击败怪物</value>
+  </data>
+  <data name="ModelMetadataTowerGoalTypeDefendTarget" xml:space="preserve">
+    <value>守护目标</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeAdditional" xml:space="preserve">
+    <value>附加：增援怪物</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeDefault" xml:space="preserve">
+    <value>本间怪物</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupA" xml:space="preserve">
+    <value>A组：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupAWave1" xml:space="preserve">
+    <value>A组第一波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupAWave2" xml:space="preserve">
+    <value>A组第二波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupAWave3" xml:space="preserve">
+    <value>A组第三波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupB" xml:space="preserve">
+    <value>B组：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupBWave1" xml:space="preserve">
+    <value>B组第一波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupBWave2" xml:space="preserve">
+    <value>B组第二波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupBWave3" xml:space="preserve">
+    <value>B组第三波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupC" xml:space="preserve">
+    <value>C组：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupCWave1" xml:space="preserve">
+    <value>C组第一波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupCWave2" xml:space="preserve">
+    <value>C组第二波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupCWave3" xml:space="preserve">
+    <value>C组第三波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupD" xml:space="preserve">
+    <value>D组：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupDWave1" xml:space="preserve">
+    <value>D组第一波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupDWave2" xml:space="preserve">
+    <value>D组第二波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeGroupDWave3" xml:space="preserve">
+    <value>D组第三波：不同的组同时在场，各自分波独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeIndependent" xml:space="preserve">
+    <value>与其他怪物独立</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeSuppressed" xml:space="preserve">
+    <value>暂时没有分波信息</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave1" xml:space="preserve">
+    <value>第一波：击败所有怪物，下一波才会出现</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave1Additional" xml:space="preserve">
+    <value>第一波附加：增援第一波怪物</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave2" xml:space="preserve">
+    <value>第二波：击败所有怪物，下一波才会出现</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave3" xml:space="preserve">
+    <value>第三波：击败所有怪物，下一波才会出现</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave4" xml:space="preserve">
+    <value>第四波：击败所有怪物，下一波才会出现</value>
+  </data>
+  <data name="ModelMetadataTowerWaveTypeWave99999" xml:space="preserve">
+    <value>维持场上 4 个盗宝团怪物，击杀后立即替换，总数 12 个</value>
+  </data>
+  <data name="ModelNameValueDefaultDescription" xml:space="preserve">
+    <value>请更新角色橱窗数据</value>
+  </data>
+  <data name="ModelNameValueDefaultName" xml:space="preserve">
+    <value>暂无数据</value>
+  </data>
+  <data name="ModelWeaponAffix" xml:space="preserve">
+    <value>精炼 {0} 阶</value>
+  </data>
+  <data name="MustSelectUserAndUid" xml:space="preserve">
+    <value>必须登录 米游社 / HoYoLAB 并选择一个用户与角色</value>
+  </data>
+  <data name="ServerCdnServiceInsufficientTime" xml:space="preserve">
+    <value>未开通云 CDN 或已到期</value>
+  </data>
+  <data name="ServerGachaLogServiceDeleteEntrySucceed" xml:space="preserve">
+    <value>删除了 UID：{0} 的 {1} 条祈愿记录</value>
+  </data>
+  <data name="ServerGachaLogServiceInsufficientRecordSlot" xml:space="preserve">
+    <value>云保存的祈愿记录存档数已达当前账号上限</value>
+  </data>
+  <data name="ServerGachaLogServiceInsufficientTime" xml:space="preserve">
+    <value>未开通祈愿记录上传服务或已到期</value>
+  </data>
+  <data name="ServerGachaLogServiceInvalidGachaLogData" xml:space="preserve">
+    <value>祈愿数据存在无效的物品，无法保存至云</value>
+  </data>
+  <data name="ServerGachaLogServiceServerDatabaseError" xml:space="preserve">
+    <value>数据异常，无法保存至云端，请勿跨账号上传或尝试删除云端数据后重试</value>
+  </data>
+  <data name="ServerGachaLogServiceUploadEntrySucceed" xml:space="preserve">
+    <value>上传了 UID：{0} 的 {1} 条祈愿记录，存储了 {2} 条</value>
+  </data>
+  <data name="ServerPassportDeviceIdEmpty" xml:space="preserve">
+    <value>设备 ID 不能为空</value>
+  </data>
+  <data name="ServerPassportLoginRequired" xml:space="preserve">
+    <value>请先登录或注册账号</value>
+  </data>
+  <data name="ServerPassportLoginSucceed" xml:space="preserve">
+    <value>登录成功</value>
+  </data>
+  <data name="ServerPassportPasswordTooShort" xml:space="preserve">
+    <value>密码长度不能小于 8 位</value>
+  </data>
+  <data name="ServerPassportRefreshTokenEmpty" xml:space="preserve">
+    <value>刷新令牌不能为空</value>
+  </data>
+  <data name="ServerPassportRefreshTokenInvalid" xml:space="preserve">
+    <value>刷新令牌无效或已过期</value>
+  </data>
+  <data name="ServerPassportRegisterSucceed" xml:space="preserve">
+    <value>注册成功</value>
+  </data>
+  <data name="ServerPassportResetPasswordSucceed" xml:space="preserve">
+    <value>新密码设置成功</value>
+  </data>
+  <data name="ServerPassportResetPasswordTheSamePassword" xml:space="preserve">
+    <value>新密码不能与旧密码相同</value>
+  </data>
+  <data name="ServerPassportServiceEmailHasNotRegistered" xml:space="preserve">
+    <value>当前邮箱尚未注册</value>
+  </data>
+  <data name="ServerPassportServiceEmailHasRegistered" xml:space="preserve">
+    <value>当前邮箱已被注册</value>
+  </data>
+  <data name="ServerPassportServiceInternalException" xml:space="preserve">
+    <value>注册失败，服务器异常，请尽快联系开发者解决</value>
+  </data>
+  <data name="ServerPassportServiceUnregisterPasswordIncorrect" xml:space="preserve">
+    <value>密码错误，注销失败</value>
+  </data>
+  <data name="ServerPassportServiceUnregisterUserNotFound" xml:space="preserve">
+    <value>用户不存在，注销失败</value>
+  </data>
+  <data name="ServerPassportTokenRevokeFailed" xml:space="preserve">
+    <value>令牌撤销失败</value>
+  </data>
+  <data name="ServerPassportTokenRevokeSuccess" xml:space="preserve">
+    <value>令牌撤销成功</value>
+  </data>
+  <data name="ServerPassportUnregisterSucceed" xml:space="preserve">
+    <value>用户注销成功</value>
+  </data>
+  <data name="ServerPassportUserInfoNotExist" xml:space="preserve">
+    <value>用户不存在，获取用户信息失败</value>
+  </data>
+  <data name="ServerPassportUserNameOrPasswordIncorrect" xml:space="preserve">
+    <value>用户名或密码错误</value>
+  </data>
+  <data name="ServerPassportVerifyFailed" xml:space="preserve">
+    <value>验证失败</value>
+  </data>
+  <data name="ServerPassportVerifyRequestNotCurrentUser" xml:space="preserve">
+    <value>验证请求失败，不是当前登录的账号</value>
+  </data>
+  <data name="ServerPassportVerifyRequestSuccess" xml:space="preserve">
+    <value>验证码已发送至邮箱</value>
+  </data>
+  <data name="ServerPassportVerifyRequestUserAlreadyExisted" xml:space="preserve">
+    <value>验证请求失败，当前邮箱已被注册</value>
+  </data>
+  <data name="ServerPassportVerifyRequestUserNotExisted" xml:space="preserve">
+    <value>验证请求失败，当前邮箱未注册</value>
+  </data>
+  <data name="ServerPassportVerifyTooFrequent" xml:space="preserve">
+    <value>验证请求过快，请 1 分钟后再试</value>
+  </data>
+  <data name="ServerRecordBannedUid" xml:space="preserve">
+    <value>上传深渊记录失败，当前 UID 已被数据库封禁</value>
+  </data>
+  <data name="ServerRecordComputingStatistics" xml:space="preserve">
+    <value>上传深渊记录失败，正在计算统计数据</value>
+  </data>
+  <data name="ServerRecordComputingStatistics2" xml:space="preserve">
+    <value>获取数据失败，正在计算统计数据</value>
+  </data>
+  <data name="ServerRecordInternalException" xml:space="preserve">
+    <value>上传深渊记录失败，服务器异常，请尽快联系开发者解决</value>
+  </data>
+  <data name="ServerRecordInvalidData" xml:space="preserve">
+    <value>上传深渊记录失败，存在无效的数据</value>
+  </data>
+  <data name="ServerRecordInvalidUid" xml:space="preserve">
+    <value>无效的 UID</value>
+  </data>
+  <data name="ServerRecordNotCurrentSchedule" xml:space="preserve">
+    <value>上传深渊记录失败，不是本期数据</value>
+  </data>
+  <data name="ServerRecordPreviousRequestNotCompleted" xml:space="preserve">
+    <value>上传深渊记录失败，当前 UID 的记录仍在处理中，请勿重复操作</value>
+  </data>
+  <data name="ServerRecordUploadSuccessAndGachaLogServiceTimeExtended" xml:space="preserve">
+    <value>上传深渊记录成功，获赠祈愿记录上传服务时长</value>
+  </data>
+  <data name="ServerRecordUploadSuccessButNoPassport" xml:space="preserve">
+    <value>上传深渊记录成功，但未登录通行证，无法获赠祈愿记录上传服务时长</value>
+  </data>
+  <data name="ServerRecordUploadSuccessButNoSuchUser" xml:space="preserve">
+    <value>上传深渊记录成功，但无法找到用户，无法获赠祈愿记录上传服务时长</value>
+  </data>
+  <data name="ServerRecordUploadSuccessButNotFirstTimeAtCurrentSchedule" xml:space="preserve">
+    <value>上传深渊记录成功，但不是本期首次提交，无法获赠祈愿记录上传服务时长</value>
+  </data>
+  <data name="ServiceAchievementImportResult" xml:space="preserve">
+    <value>新增：{0} 个成就 | 更新：{1} 个成就 | 删除：{2} 个成就</value>
+  </data>
+  <data name="ServiceAchievementUIAFImportPickerFilterText" xml:space="preserve">
+    <value>UIAF JSON 文件</value>
+  </data>
+  <data name="ServiceAchievementUIAFImportPickerTitile" xml:space="preserve">
+    <value>打开 UIAF JSON 文件</value>
+  </data>
+  <data name="ServiceAchievementUserdataCorruptedAchievementIdNotUnique" xml:space="preserve">
+    <value>单个成就存档内发现多个相同的成就 Id</value>
+  </data>
+  <data name="ServiceAppOptionsCalendarServerTimeZoneAmerica" xml:space="preserve">
+    <value>美服 UTC-05</value>
+  </data>
+  <data name="ServiceAppOptionsCalendarServerTimeZoneCommon" xml:space="preserve">
+    <value>其他 UTC+08</value>
+  </data>
+  <data name="ServiceAppOptionsCalendarServerTimeZoneEurope" xml:space="preserve">
+    <value>欧服 UTC+01</value>
+  </data>
+  <data name="ServiceAvatarInfoPropertyAtk" xml:space="preserve">
+    <value>攻击力</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyBaseAtk" xml:space="preserve">
+    <value>基础攻击力</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyBaseDef" xml:space="preserve">
+    <value>基础防御力</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyBaseHp" xml:space="preserve">
+    <value>基础生命值</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyCDmg" xml:space="preserve">
+    <value>暴击伤害</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyCE" xml:space="preserve">
+    <value>元素充能效率</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyCR" xml:space="preserve">
+    <value>暴击率</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBElec" xml:space="preserve">
+    <value>雷元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBFire" xml:space="preserve">
+    <value>火元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBGrass" xml:space="preserve">
+    <value>草元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBIce" xml:space="preserve">
+    <value>冰元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBPhyiscal" xml:space="preserve">
+    <value>物理伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBRock" xml:space="preserve">
+    <value>岩元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBWater" xml:space="preserve">
+    <value>水元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDBWind" xml:space="preserve">
+    <value>风元素伤害加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyDef" xml:space="preserve">
+    <value>防御力</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyEM" xml:space="preserve">
+    <value>元素精通</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyHB" xml:space="preserve">
+    <value>治疗加成</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyHDB" xml:space="preserve">
+    <value>受治疗加成</value>
+  </data>
+  <data name="ServiceAvatarInfoPropertyHp" xml:space="preserve">
+    <value>生命值</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESElec" xml:space="preserve">
+    <value>雷元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESFire" xml:space="preserve">
+    <value>火元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESGrass" xml:space="preserve">
+    <value>草元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESIce" xml:space="preserve">
+    <value>冰元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESPhysical" xml:space="preserve">
+    <value>物理抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESRock" xml:space="preserve">
+    <value>岩元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESWater" xml:space="preserve">
+    <value>水元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertyRESWind" xml:space="preserve">
+    <value>风元素抗性</value>
+    <comment>Need EXACT same string in game</comment>
+  </data>
+  <data name="ServiceAvatarInfoPropertySkillCDReduce" xml:space="preserve">
+    <value>冷却缩减</value>
+  </data>
+  <data name="ServiceBackgroundActivityDefaultDescription" xml:space="preserve">
+    <value>准备中...</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustInitialization" xml:space="preserve">
+    <value>插件组件初始化</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustInitializationDescription" xml:space="preserve">
+    <value>仅在必要时执行</value>
+  </data>
+  <data name="ServiceBackgroundActivityMetadataInitialization" xml:space="preserve">
+    <value>游戏元数据</value>
+  </data>
+  <data name="ServiceBackgroundActivityMetadataInitializationDescription" xml:space="preserve">
+    <value>加载中</value>
+  </data>
+  <data name="ServiceBackgroundImageTypeLauncher" xml:space="preserve">
+    <value>官方启动器壁纸</value>
+  </data>
+<data name="ServiceBackgroundImageTypeCustom" xml:space="preserve">
+    <value>自定义图片或视频</value>
+  </data>
+  <data name="ServiceBackgroundImageTypeNone" xml:space="preserve">
+    <value>无背景图片</value>
+  </data>
+  <data name="ServiceCloseButtonBehaviorTypeExit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="ServiceCloseButtonBehaviorTypeMinimize" xml:space="preserve">
+    <value>最小化到通知区域图标</value>
+  </data>
+  <data name="ServiceDailyNoteNotificationSendExceptionTitle" xml:space="preserve">
+    <value>应用通知发送失败</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierActionLaunchGameButton" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierActionLaunchGameDismiss" xml:space="preserve">
+    <value>我知道了</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierDailyTask" xml:space="preserve">
+    <value>每日委托</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierDailyTaskHint" xml:space="preserve">
+    <value>奖励未领取</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierExpedition" xml:space="preserve">
+    <value>探索派遣</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierExpeditionAdaptiveHint" xml:space="preserve">
+    <value>已完成</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierExpeditionHint" xml:space="preserve">
+    <value>探索派遣已完成</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierHomeCoin" xml:space="preserve">
+    <value>洞天宝钱</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierHomeCoinCurrent" xml:space="preserve">
+    <value>当前洞天宝钱：{0}</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierMultiValueReached" xml:space="preserve">
+    <value>多个提醒项达到设定值</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierResin" xml:space="preserve">
+    <value>原粹树脂</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierResinCurrent" xml:space="preserve">
+    <value>当前原粹树脂：{0}</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierTitle" xml:space="preserve">
+    <value>实时便笺提醒</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierTransformer" xml:space="preserve">
+    <value>参量质变仪</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierTransformerAdaptiveHint" xml:space="preserve">
+    <value>准备完成</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierTransformerHint" xml:space="preserve">
+    <value>参量质变仪已准备完成</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierWeekActiveProgress" xml:space="preserve">
+    <value>砺行修远</value>
+  </data>
+  <data name="ServiceDailyNoteNotifierWeekActiveProgressHint" xml:space="preserve">
+    <value>本周砺行修远已完成</value>
+  </data>
+  <data name="ServiceGachaLogFactoryAvatarWishName" xml:space="preserve">
+    <value>角色活动</value>
+  </data>
+  <data name="ServiceGachaLogFactoryChronicledWishName" xml:space="preserve">
+    <value>集录祈愿</value>
+  </data>
+  <data name="ServiceGachaLogFactoryPermanentWishName" xml:space="preserve">
+    <value>奔行世间</value>
+  </data>
+  <data name="ServiceGachaLogFactoryWeaponWishName" xml:space="preserve">
+    <value>神铸赋形</value>
+  </data>
+  <data name="ServiceGachaLogLauncherCloudEndIdFetchFailed" xml:space="preserve">
+    <value>获取云端祈愿记录失败</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderAuthkeyRequestFailed" xml:space="preserve">
+    <value>请求验证密钥失败</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderCachePathInvalid" xml:space="preserve">
+    <value>未正确提供原神路径，或当前设置的路径不正确</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderCachePathNotFound" xml:space="preserve">
+    <value>找不到原神内置浏览器缓存路径：
+{0}</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderCacheUrlNotFound" xml:space="preserve">
+    <value>未找到可用的 URL</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderLogFileUrlNotFound" xml:space="preserve">
+    <value>无法从游戏日志中自动获取祈愿链接，请确保已在游戏内打开过祈愿历史记录</value>
+  </data>
+<data name="ServiceGachaLogUrlProviderLogFileUrlCopied" xml:space="preserve">
+    <value>祈愿链接已复制到剪贴板（{0}）</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderLogFileServerCN" xml:space="preserve">
+    <value>国服</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderLogFileServerOversea" xml:space="preserve">
+    <value>国际服</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderCopyWebCacheUnauthorizedAccess" xml:space="preserve">
+    <value>复制网页缓存到临时文件夹时发生问题，权限不足</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderManualInputInvalid" xml:space="preserve">
+    <value>提供的 URL 无效</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderStokenUnsupported" xml:space="preserve">
+    <value>HoYoLab 账号不支持使用 SToken 刷新祈愿记录</value>
+  </data>
+  <data name="ServiceGachaLogUrlProviderUrlLanguageNotMatchCurrentLocale" xml:space="preserve">
+    <value>URL 中的语言：{0} 与的语言：{1} 不匹配，请切换到对应语言重试</value>
+  </data>
+  <data name="ServiceGachaStatisticsFactoryItemIdInvalid" xml:space="preserve">
+    <value>不支持的 Item Id：{0}</value>
+  </data>
+  <data name="ServiceGameAccountBilibiliNotSupported" xml:space="preserve">
+    <value>Bilibili 渠道服不支持账号功能</value>
+  </data>
+  <data name="ServiceGameAccountDetectInputNameAlreadyExists" xml:space="preserve">
+    <value>名称为 {0} 的账号已存在</value>
+  </data>
+  <data name="ServiceGameAccountRegistryMultipleAccountDetected" xml:space="preserve">
+    <value>检测到多个账号的登录信息，请在游戏登录界面删除多余的账号并进入游戏后重试</value>
+  </data>
+  <data name="ServiceGameAccountRegistryNoAccountDetected" xml:space="preserve">
+    <value>未检测到登录信息，请进入游戏后重试</value>
+  </data>
+  <data name="ServiceGameAccountRegistryTryGetFailed" xml:space="preserve">
+    <value>此设备的 MAC 地址发生变化，请重新登录游戏后再尝试</value>
+  </data>
+  <data name="ServiceGameDetectGameAccountMultiMatched" xml:space="preserve">
+    <value>存在多个匹配账号，请删除重复的账号</value>
+  </data>
+  <data name="ServiceGameEnsureGameResourceInsufficientDirectoryPermissions" xml:space="preserve">
+    <value>文件系统权限不足，无法转换服务器</value>
+  </data>
+  <data name="ServiceGameEnsureGameResourceQueryResourceInformation" xml:space="preserve">
+    <value>下载游戏资源索引</value>
+  </data>
+  <data name="ServiceGameIslandFileSystemGetGameVersionFailed" xml:space="preserve">
+    <value>获取本地游戏版本失败，无法获取插件配置信息</value>
+  </data>
+  <data name="ServiceGameIslandTargetVersionFileNotExists" xml:space="preserve">
+    <value>尚未支持当前游戏版本</value>
+  </data>
+  <data name="ServiceGameLaunchExecutionCurrentSchemeNull" xml:space="preserve">
+    <value>本地游戏配置文件损坏，请修复后重试</value>
+  </data>
+  <data name="ServiceGameLaunchExecutionGameIsRunning" xml:space="preserve">
+    <value>游戏进程运行中</value>
+  </data>
+  <data name="ServiceGameLaunchExecutionGameResourceQueryIndexFailed" xml:space="preserve">
+    <value>下载游戏资源索引失败: {0}</value>
+  </data>
+  <data name="ServiceGameLaunchExecutionGameRunningKillFailed" xml:space="preserve">
+    <value>结束进程失败</value>
+  </data>
+  <data name="ServiceGameLaunchPhaseProcessExited" xml:space="preserve">
+    <value>游戏进程已退出</value>
+  </data>
+  <data name="ServiceGameLaunchPhaseProcessStarted" xml:space="preserve">
+    <value>游戏进程已启动</value>
+  </data>
+  <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
+    <value>等待游戏进程退出</value>
+  </data>
+  <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
+    <value>目标服务器与当前游戏资源匹配，无需转换</value>
+  </data>
+  <data name="ServiceGameLaunchingHandlerEmbeddedYaeClientNotElevated" xml:space="preserve">
+    <value>使用 Embedded Yae 前，需要以管理员权限运行</value>
+  </data>
+  <data name="ServiceGameLaunchingHandlerEmbeddedYaeErrorSystemIntegrityPolicyViolation" xml:space="preserve">
+    <value>插件加载失败，可能是由于 Windows Defender 应用和浏览器控制 &gt; 智能应用控制策略阻止了操作，请尝试关闭。</value>
+  </data>
+  <data name="ServiceGameLaunchingHandlerEmbeddedYaeIslandNotEnabled" xml:space="preserve">
+    <value>使用 Embedded Yae 前，需要您了解相关风险并在「启动游戏」页面开启插件功能</value>
+  </data>
+  <data name="ServiceGameLaunchingHandlerGameProcessStartRepositorySyncFailed" xml:space="preserve">
+    <value>在获取必要的启动游戏组件时发生错误</value>
+  </data>
+  <data name="ServiceGameLocatorFileOpenPickerCommitText" xml:space="preserve">
+    <value>选择游戏本体</value>
+  </data>
+  <data name="ServiceGameLocatorPickerFilterText" xml:space="preserve">
+    <value>游戏本体</value>
+  </data>
+  <data name="ServiceGameLocatorUnityLogCannotOpenRead" xml:space="preserve">
+    <value>游戏运行中，无法读取 Unity 日志文件</value>
+  </data>
+  <data name="ServiceGameLocatorUnityLogFileNotFound" xml:space="preserve">
+    <value>找不到 Unity 日志文件</value>
+  </data>
+  <data name="ServiceGameLocatorUnityLogGamePathNotFound" xml:space="preserve">
+    <value>在 Unity 日志文件中找不到游戏路径</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedAssetOperationDiskCorrupted" xml:space="preserve">
+    <value>检测到硬盘错误，请运行 chkdsk 修复</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedAssetOperationNoSuchDevice" xml:space="preserve">
+    <value>检测到硬盘丢失，请检查硬件连接情况</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedConfirmMessage" xml:space="preserve">
+    <value>资源包体大小: {0}
+所需空间: {1}
+可用空间: {2}</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedConfirmStartInstallTitle" xml:space="preserve">
+    <value>确认开始安装游戏</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedConfirmStartPredownloadTitle" xml:space="preserve">
+    <value>确认开始预下载</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedConfirmStartUpdateTitle" xml:space="preserve">
+    <value>确认开始更新游戏</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedDecodeManifestFailed" xml:space="preserve">
+    <value>清单数据解析失败</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedDriverNoAvailableFreeSpace" xml:space="preserve">
+    <value>磁盘空间不足</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedInstalling" xml:space="preserve">
+    <value>正在安装游戏</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedPredownloading" xml:space="preserve">
+    <value>正在预下载资源</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedRepairing" xml:space="preserve">
+    <value>正在修复游戏</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedUpdating" xml:space="preserve">
+    <value>正在更新游戏</value>
+  </data>
+  <data name="ServiceGamePackageAdvancedVerifyingIntegrity" xml:space="preserve">
+    <value>正在验证游戏完整性</value>
+  </data>
+  <data name="ServiceGamePackageConvertMoveFileBackup" xml:space="preserve">
+    <value>备份：{0}</value>
+  </data>
+  <data name="ServiceGamePackageConvertMoveFileRename" xml:space="preserve">
+    <value>重命名：{0} 到：{1}</value>
+  </data>
+  <data name="ServiceGamePackageConvertMoveFileRestore" xml:space="preserve">
+    <value>替换：{0}</value>
+  </data>
+  <data name="ServiceGamePackageRenameDataFolderFailed" xml:space="preserve">
+    <value>重命名数据文件夹名称失败</value>
+  </data>
+  <data name="ServiceGamePathLocateFailed" xml:space="preserve">
+    <value>无法找到游戏路径，请前往设置修改</value>
+  </data>
+  <data name="ServiceGameSetMultiChannelConfigFileNotFound" xml:space="preserve">
+    <value>无法读取游戏配置文件 {0}，可能是文件不存在</value>
+  </data>
+  <data name="ServiceGameSetMultiChannelUnauthorizedAccess" xml:space="preserve">
+    <value>无法读取或保存配置文件，请以管理员模式重试</value>
+  </data>
+  <data name="ServiceGitRepositoryOperationCompleted" xml:space="preserve">
+    <value>操作完成</value>
+  </data>
+  <data name="ServiceGitRepositoryOperationFailed" xml:space="preserve">
+    <value>操作失败</value>
+  </data>
+  <data name="ServiceLauncherUserGachaLogExpiredAt" xml:space="preserve">
+    <value>祈愿记录上传服务有效期至</value>
+  </data>
+  <data name="ServiceInventoryRefreshByEmbeddedYaeErrorMessage" xml:space="preserve">
+    <value>请使用其他方法同步背包物品</value>
+  </data>
+  <data name="ServiceMetadataDownloadSourceFilesFailed" xml:space="preserve">
+    <value>一个或多个元数据文件下载失败：{0}</value>
+  </data>
+  <data name="ServiceMetadataFileNotFound" xml:space="preserve">
+    <value>无法找到缓存的元数据文件</value>
+  </data>
+  <data name="ServiceMetadataNotInitialized" xml:space="preserve">
+    <value>元数据服务尚未初始化，或初始化失败</value>
+  </data>
+  <data name="ServiceMetadataParseFailed" xml:space="preserve">
+    <value>元数据校验文件解析失败</value>
+  </data>
+  <data name="ServiceMetadataVersionNotSupported" xml:space="preserve">
+    <value>你的版本过低，请尽快升级</value>
+  </data>
+  <data name="ServicePackageAdvancedExecuteOperationCanceledTitle" xml:space="preserve">
+    <value>游戏资源操作已取消</value>
+  </data>
+  <data name="ServicePackageAdvancedExecuteOperationFailedTitle" xml:space="preserve">
+    <value>游戏资源操作失败</value>
+  </data>
+  <data name="ServiceReSignInClaimRewardFailed" xml:space="preserve">
+    <value>补签失败，{0}</value>
+  </data>
+  <data name="ServiceReSignInSuccessReward" xml:space="preserve">
+    <value>补签成功，{0}×{1}</value>
+  </data>
+  <data name="ServiceSignInClaimRewardFailed" xml:space="preserve">
+    <value>签到失败，{0}</value>
+  </data>
+  <data name="ServiceSignInInfoRequestFailed" xml:space="preserve">
+    <value>获取签到次数失败</value>
+  </data>
+  <data name="ServiceSignInRewardListRequestFailed" xml:space="preserve">
+    <value>获取奖励列表失败</value>
+  </data>
+  <data name="ServiceSignInRiskVerificationFailed" xml:space="preserve">
+    <value>验证失败，请前往米游社原神签到页面自行领取奖励</value>
+  </data>
+  <data name="ServiceSignInSuccessReward" xml:space="preserve">
+    <value>签到成功，{0}×{1}</value>
+  </data>
+  <data name="ServiceUIGFImportInvalidItem" xml:space="preserve">
+    <value>不支持的物品, Id: {0}</value>
+  </data>
+  <data name="ServiceUserProcessCookieNoMid" xml:space="preserve">
+    <value>输入的 Cookie 必须包含 Mid</value>
+  </data>
+  <data name="ServiceUserProcessCookieNoSToken" xml:space="preserve">
+    <value>输入的 Cookie 必须包含 SToken</value>
+  </data>
+  <data name="ServiceUserProcessCookieRequestUserInfoFailed" xml:space="preserve">
+    <value>输入的 Cookie 无法获取用户信息</value>
+  </data>
+  <data name="ServiceUserProcessInputCookieDialogTitle" xml:space="preserve">
+    <value>获取用户信息中，请稍候...</value>
+  </data>
+  <data name="ServiceUserUserInfoContainsNoGameRole" xml:space="preserve">
+    <value>此账号尚未绑定原神游戏角色</value>
+  </data>
+  <data name="ServiceYaeEmbeddedYaeErrorTitle" xml:space="preserve">
+    <value>Embedded Yae 错误</value>
+  </data>
+  <data name="ServiceYaeGetGameVersionFailed" xml:space="preserve">
+    <value>获取游戏版本失败</value>
+  </data>
+  <data name="ServiceYaeWaitForGameResponseMessage" xml:space="preserve">
+    <value>正在等待游戏数据</value>
+  </data>
+  <data name="ServiceThirdPartyToolNoExecutableFound" xml:space="preserve">
+    <value>未找到可执行文件</value>
+  </data>
+  <data name="ServiceThirdPartyToolFileNotFound" xml:space="preserve">
+    <value>文件不存在：{0}</value>
+  </data>
+  <data name="UIViewMainTitleBarRestartToUpdateAction" xml:space="preserve">
+    <value>重启以更新</value>
+  </data>
+  <data name="UIViewMainTitleBarBackgroundActivityAction" xml:space="preserve">
+    <value>后台任务</value>
+  </data>
+  <data name="UIViewMainTitleBarRedeemCodeAction" xml:space="preserve">
+    <value>奖励兑换码</value>
+  </data>
+  <data name="UIViewMainRedeemCodeCNHeader" xml:space="preserve">
+    <value>CN:</value>
+  </data>
+  <data name="UIViewMainRedeemCodeOSHeader" xml:space="preserve">
+    <value>OS:</value>
+  </data>
+  <data name="UIViewMainRedeemCodeCopy" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="UIViewMainRedeemCodeValidUntil" xml:space="preserve">
+    <value>有效期至 {0}</value>
+  </data>
+  <data name="UIViewMainRedeemCodeCopySucceed" xml:space="preserve">
+    <value>已复制兑换码: {0}</value>
+  </data>
+  <data name="UIViewPageAvatarPropertyRecommendedAppendProperties" xml:space="preserve">
+    <value>追加属性推荐</value>
+  </data>
+  <data name="UIViewPageAvatarPropertyRecommendedCircletProperties" xml:space="preserve">
+    <value>理之冠主属性推荐</value>
+  </data>
+  <data name="UIViewPageAvatarPropertyRecommendedGobletProperties" xml:space="preserve">
+    <value>空之杯主属性推荐</value>
+  </data>
+  <data name="UIViewPageAvatarPropertyRecommendedSandProperties" xml:space="preserve">
+    <value>时之沙主属性推荐</value>
+  </data>
+  <data name="UIXamlControlCachedImageCopyImage" xml:space="preserve">
+    <value>复制图像</value>
+  </data>
+  <data name="UIXamlViewSpecializedSophonProgressDefault" xml:space="preserve">
+    <value>正在获取清单数据</value>
+  </data>
+  <data name="UIXamlViewWindowWebView2GeetestHeader" xml:space="preserve">
+    <value>请完成验证</value>
+  </data>
+  <data name="ViewAchievementHeader" xml:space="preserve">
+    <value>成就管理</value>
+  </data>
+  <data name="ViewAnnouncementHeader" xml:space="preserve">
+    <value>主页</value>
+  </data>
+  <data name="ViewAvatarPropertyHeader" xml:space="preserve">
+    <value>我的角色</value>
+  </data>
+  <data name="ViewAvatarPropertySyncDataButtonLabel" xml:space="preserve">
+    <value>同步角色信息</value>
+  </data>
+  <data name="ViewCardAchievementStatisticsTitle" xml:space="preserve">
+    <value>成就统计</value>
+  </data>
+  <data name="ViewCardCalendarAllMaterialsHint" xml:space="preserve">
+    <value>全部材料副本均可挑战</value>
+  </data>
+  <data name="ViewCardCalendarNoBirthdayAvatarHint" xml:space="preserve">
+    <value>当天没有角色过生日</value>
+  </data>
+  <data name="ViewCardGachaStatisticsTitle" xml:space="preserve">
+    <value>保底计数</value>
+  </data>
+  <data name="ViewCardLaunchGameSelectAccountPlaceholder" xml:space="preserve">
+    <value>选择账号或直接启动</value>
+  </data>
+  <data name="ViewCardSignInClaimReSignInAction" xml:space="preserve">
+    <value>补签</value>
+  </data>
+  <data name="ViewCardSignInClaimSignInAction" xml:space="preserve">
+    <value>签到</value>
+  </data>
+  <data name="ViewControlBaseValueSliderLevel" xml:space="preserve">
+    <value>等级</value>
+  </data>
+  <data name="ViewControlBaseValueSliderPromoted" xml:space="preserve">
+    <value>突破后</value>
+  </data>
+  <data name="ViewControlElevationText" xml:space="preserve">
+    <value>需要管理员权限</value>
+  </data>
+  <data name="ViewControlLoadingText" xml:space="preserve">
+    <value>加载中，请稍候</value>
+  </data>
+  <data name="ViewControlStatisticsCardBlueText" xml:space="preserve">
+    <value>三星</value>
+  </data>
+  <data name="ViewControlStatisticsCardGuaranteeText" xml:space="preserve">
+    <value>保底</value>
+  </data>
+  <data name="ViewControlStatisticsCardOrangeAveragePullText" xml:space="preserve">
+    <value>五星平均抽数</value>
+  </data>
+  <data name="ViewControlStatisticsCardOrangeText" xml:space="preserve">
+    <value>五星</value>
+  </data>
+  <data name="ViewControlStatisticsCardPullText" xml:space="preserve">
+    <value>抽</value>
+  </data>
+  <data name="ViewControlStatisticsCardPurpleText" xml:space="preserve">
+    <value>四星</value>
+  </data>
+  <data name="ViewControlStatisticsCardToLastOrangeText" xml:space="preserve">
+    <value>距上个五星</value>
+  </data>
+  <data name="ViewControlStatisticsCardToLastPurpleText" xml:space="preserve">
+    <value>距上个四星</value>
+  </data>
+  <data name="ViewControlStatisticsCardUpAveragePullText" xml:space="preserve">
+    <value>UP 平均抽数</value>
+  </data>
+  <data name="ViewControlStatisticsCardUpText" xml:space="preserve">
+    <value>UP</value>
+  </data>
+  <data name="ViewControlStatisticsCardNotUpText" xml:space="preserve">
+    <value>歪</value>
+  </data>
+  <data name="ViewControlStatisticsSegmentedItemContentPrediction" xml:space="preserve">
+    <value>预测</value>
+  </data>
+  <data name="ViewControlStatisticsSegmentedItemContentProportion" xml:space="preserve">
+    <value>比例</value>
+  </data>
+  <data name="ViewControlStatisticsSegmentedItemContentStatistics" xml:space="preserve">
+    <value>统计</value>
+  </data>
+  <data name="ViewControlWebViewerCoreWebView2ProfileQueryInterfaceFailed" xml:space="preserve">
+    <value>当前 WebView2 版本不支持管理配置，继续使用可能会导致异常，请尽快升级</value>
+  </data>
+  <data name="ViewCultivationHeader" xml:space="preserve">
+    <value>养成计划</value>
+  </data>
+  <data name="ViewDailyNoteHeader" xml:space="preserve">
+    <value>实时便笺</value>
+  </data>
+  <data name="ViewDataHeader" xml:space="preserve">
+    <value>数据</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveCreateInputPlaceholder" xml:space="preserve">
+    <value>在此处输入</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveCreateTitle" xml:space="preserve">
+    <value>设置成就存档的名称</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveImportStrategy" xml:space="preserve">
+    <value>导入模式</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveImportStrategyAggressive" xml:space="preserve">
+    <value>添加新数据，更新已完成项</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveImportStrategyLazy" xml:space="preserve">
+    <value>添加新数据，跳过已完成项</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveImportStrategyOverwrite" xml:space="preserve">
+    <value>删除老数据，添加新的数据</value>
+  </data>
+  <data name="ViewDialogAchievementArchiveImportTitle" xml:space="preserve">
+    <value>为当前存档导入成就</value>
+  </data>
+  <data name="ViewDialogAvatarPropertyMultiAvatarCultivateSelectTitle" xml:space="preserve">
+    <value>选择要添加到当前培养计划的角色</value>
+  </data>
+  <data name="ViewDialogCultivateWeaponSelectTitle" xml:space="preserve">
+    <value>选择要添加到当前培养计划的武器</value>
+  </data>
+  <data name="ViewDialogCultivateWeaponLevelTitle" xml:space="preserve">
+    <value>设置武器等级</value>
+  </data>
+  <data name="ViewDialogCultivateBatchAvatarLevelTarget" xml:space="preserve">
+    <value>角色目标等级</value>
+  </data>
+  <data name="ViewDialogCultivateBatchSkillATarget" xml:space="preserve">
+    <value>普通攻击目标等级</value>
+  </data>
+  <data name="ViewDialogCultivateBatchSkillETarget" xml:space="preserve">
+    <value>元素战技目标等级</value>
+  </data>
+  <data name="ViewDialogCultivateBatchSkillQTarget" xml:space="preserve">
+    <value>元素爆发目标等级</value>
+  </data>
+  <data name="ViewDialogCultivateBatchWeaponLevelTarget" xml:space="preserve">
+    <value>武器目标等级</value>
+  </data>
+  <data name="ViewDialogCultivateProjectInputPlaceholder" xml:space="preserve">
+    <value>在此处输入计划名称</value>
+  </data>
+  <data name="ViewDialogCultivateLevelTitle" xml:space="preserve">
+    <value>添加或更新到当前养成计划</value>
+  </data>
+  <data name="ViewDialogCultivateLevelAvatarLevel" xml:space="preserve">
+    <value>角色等级</value>
+  </data>
+  <data name="ViewDialogCultivateLevelFrom" xml:space="preserve">
+    <value>当前</value>
+  </data>
+  <data name="ViewDialogCultivateLevelTo" xml:space="preserve">
+    <value>目标</value>
+  </data>
+  <data name="ViewDialogCultivateLevelSkillA" xml:space="preserve">
+    <value>普通攻击</value>
+  </data>
+  <data name="ViewDialogCultivateLevelSkillE" xml:space="preserve">
+    <value>元素战技</value>
+  </data>
+  <data name="ViewDialogCultivateLevelSkillQ" xml:space="preserve">
+    <value>元素爆发</value>
+  </data>
+  <data name="ViewDialogCultivateProjectTitle" xml:space="preserve">
+    <value>创建新的养成计划</value>
+  </data>
+  <data name="ViewDialogCultivatePromotionDeltaBatchTitle" xml:space="preserve">
+    <value>批量添加或更新到当前养成计划</value>
+  </data>
+  <data name="ViewDialogCultivatePromotionDeltaPromoted" xml:space="preserve">
+    <value>已突破</value>
+  </data>
+  <data name="ViewDialogCultivatePromotionDeltaTitle" xml:space="preserve">
+    <value>添加或更新到当前养成计划</value>
+  </data>
+  <data name="ViewDialogCultivationConsumptionSaveStrategyCreateNewEntry" xml:space="preserve">
+    <value>总是创建新的养成目标物品</value>
+  </data>
+  <data name="ViewDialogCultivationConsumptionSaveStrategyHeader" xml:space="preserve">
+    <value>保存方式</value>
+  </data>
+  <data name="ViewDialogCultivationConsumptionSaveStrategyOverwriteExisting" xml:space="preserve">
+    <value>覆盖存在的养成目标物品</value>
+  </data>
+  <data name="ViewDialogCultivationConsumptionSaveStrategyPreserveExisting" xml:space="preserve">
+    <value>保留存在的养成目标物品</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationDailyTaskNotify" xml:space="preserve">
+    <value>每日委托上线提醒</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationExpeditionNotify" xml:space="preserve">
+    <value>探索派遣完成提醒</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationHomeCoinNotifyThreshold" xml:space="preserve">
+    <value>洞天宝钱提醒阈值</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationResinNotifyThreshold" xml:space="preserve">
+    <value>原粹树脂提醒阈值</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationTitle" xml:space="preserve">
+    <value>实时便笺通知设置</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationTransformerNotify" xml:space="preserve">
+    <value>参量质变仪提醒</value>
+  </data>
+  <data name="ViewDialogDailyNoteNotificationWeekActiveProgressNotify" xml:space="preserve">
+    <value>砺行修远完成提醒</value>
+  </data>
+  <data name="ViewDialogDailyNoteWebhookUrlInputPlaceholder" xml:space="preserve">
+    <value>请输入 URL</value>
+  </data>
+  <data name="ViewDialogDailyNoteWebhookUrlTitle" xml:space="preserve">
+    <value>实时便笺 Webhook URL</value>
+  </data>
+  <data name="ViewDialogExportUIGFSubtitle" xml:space="preserve">
+    <value>选择要导出记录的 UID</value>
+  </data>
+  <data name="ViewDialogExportUIGFTitle" xml:space="preserve">
+    <value>导出 UIGF 文件</value>
+  </data>
+  <data name="ViewDialogFeedbackEnableLoopbackContent" xml:space="preserve">
+    <value>解除限制后需要使用其他工具恢复限制</value>
+  </data>
+  <data name="ViewDialogFeedbackEnableLoopbackTitle" xml:space="preserve">
+    <value>是否解除 Loopback 限制</value>
+  </data>
+  <data name="ViewDialogGachaLogRefreshProgressAuthkeyTimeout" xml:space="preserve">
+    <value>祈愿记录 URL 已失效，请重新获取</value>
+  </data>
+  <data name="ViewDialogGachaLogRefreshProgressDescription" xml:space="preserve">
+    <value>正在获取 {0}</value>
+  </data>
+  <data name="ViewDialogGachaLogRefreshProgressTitle" xml:space="preserve">
+    <value>获取祈愿物品中</value>
+  </data>
+  <data name="ViewDialogGachaLogUrlInputPlaceholder" xml:space="preserve">
+    <value>请输入 URL</value>
+  </data>
+  <data name="ViewDialogGachaLogUrlTitle" xml:space="preserve">
+    <value>手动输入祈愿记录 URL</value>
+  </data>
+  <data name="ViewDialogGameInstallLaunchScheme" xml:space="preserve">
+    <value>游戏服务器</value>
+  </data>
+  <data name="ViewDialogGameInstallPathHddHint" xml:space="preserve">
+    <value>当前选择目录为HDD，建议使用SSD</value>
+  </data>
+  <data name="ViewDialogGameInstallPickGameDirectory" xml:space="preserve">
+    <value>设置游戏安装目录</value>
+  </data>
+  <data name="ViewDialogGameInstallTitle" xml:space="preserve">
+    <value>安装游戏</value>
+  </data>
+  <data name="ViewDialogGameInstallVoiceChinese" xml:space="preserve">
+    <value>汉语</value>
+  </data>
+  <data name="ViewDialogGameInstallVoiceEnglish" xml:space="preserve">
+    <value>英语</value>
+  </data>
+  <data name="ViewDialogGameInstallVoiceJapanese" xml:space="preserve">
+    <value>日语</value>
+  </data>
+  <data name="ViewDialogGameInstallVoiceKorean" xml:space="preserve">
+    <value>韩语</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlCompositInputHint" xml:space="preserve">
+    <value>请输入请求接口的 URL 复合模板</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlReturnDataDescription1" xml:space="preserve">
+    <value>接口需要返回形如上方所示的 JSON 数据，多余的数据会被忽略</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlReturnDataDescription2" xml:space="preserve">
+    <value>"code" 为 0 时，指示验证成功，其他的值均视为验证失败</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlReturnDataHeader" xml:space="preserve">
+    <value>返回数据</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlSampleDescription1" xml:space="preserve">
+    <value>{0} 将在实际请求时替换为 gt</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlSampleDescription2" xml:space="preserve">
+    <value>{1} 将在实际请求时替换为 challenge</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlSampleDescription3" xml:space="preserve">
+    <value>将会通过 GET 方式对接口发送请求</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlSampleHeader" xml:space="preserve">
+    <value>示例</value>
+  </data>
+  <data name="ViewDialogGeetestCustomUrlTitle" xml:space="preserve">
+    <value>配置无感验证接口</value>
+  </data>
+  <data name="ViewDialogLauncherPassportLoginTitle" xml:space="preserve">
+    <value>登录通行证</value>
+  </data>
+  <data name="ViewDialogLauncherPassportRegisterTitle" xml:space="preserve">
+    <value>注册通行证</value>
+  </data>
+  <data name="ViewDialogLauncherPassportResetPasswordTitle" xml:space="preserve">
+    <value>重置通行证密码</value>
+  </data>
+  <data name="ViewDialogLauncherPassportResetUserNameTitle" xml:space="preserve">
+    <value>重置通行证邮箱</value>
+  </data>
+  <data name="ViewDialogLauncherPassportUnregisterTitle" xml:space="preserve">
+    <value>注销通行证账号</value>
+  </data>
+  <data name="ViewDialogLauncherPassportUseRedeemCodeTitle" xml:space="preserve">
+    <value>使用云兑换码</value>
+  </data>
+  <data name="ViewDialogImportExportApp" xml:space="preserve">
+    <value>导出 App</value>
+  </data>
+  <data name="ViewDialogImportExportAppVersion" xml:space="preserve">
+    <value>导出 App 版本</value>
+  </data>
+  <data name="ViewDialogImportExportTime" xml:space="preserve">
+    <value>导出时间</value>
+  </data>
+  <data name="ViewDialogImportUIAFExportListCount" xml:space="preserve">
+    <value>成就个数</value>
+  </data>
+  <data name="ViewDialogImportUIAFExportUIAFVersion" xml:space="preserve">
+    <value>UIAF 版本</value>
+  </data>
+  <data name="ViewDialogImportUIGFExportUIGFVersion" xml:space="preserve">
+    <value>UIGF 版本</value>
+  </data>
+  <data name="ViewDialogImportUIGFSubtitle" xml:space="preserve">
+    <value>选择要导入记录的 UID</value>
+  </data>
+  <data name="ViewDialogImportUIGFTitle" xml:space="preserve">
+    <value>导入 UIGF 文件</value>
+  </data>
+  <data name="ViewDialogLaunchGameAccountInputPlaceholder" xml:space="preserve">
+    <value>在此处输入名称</value>
+  </data>
+  <data name="ViewDialogLaunchGameAccountTitle" xml:space="preserve">
+    <value>为账号命名</value>
+  </data>
+  <data name="ViewDialogLaunchGameConfigurationFixDialogHint" xml:space="preserve">
+    <value>请选择当前游戏路径对应的游戏服务器</value>
+  </data>
+  <data name="ViewDialogLaunchGameConfigurationFixDialogTitle" xml:space="preserve">
+    <value>修复配置文件</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameDirectoryCreationFailed" xml:space="preserve">
+    <value>选择的安装路径不存在且无法创建</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameDirectoryExistsFileSystemEntry" xml:space="preserve">
+    <value>选择的安装路径存在文件或文件夹</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameDirectoryInvalid" xml:space="preserve">
+    <value>选择的安装路径无效</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameDirectoryIsSSDCheckFailed" xml:space="preserve">
+    <value>在检测路径所在驱动器的类型时发生了未知的错误，数据下载与写入将会受到限制。如果你确定此设备为固态硬盘，请与我们联系。</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameNoAudioPackageSelected" xml:space="preserve">
+    <value>未选择语音包</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGameNoSchemeSelected" xml:space="preserve">
+    <value>未选择游戏区服</value>
+  </data>
+  <data name="ViewDialogLaunchGameInstallGamePickDirectoryTitle" xml:space="preserve">
+    <value>选择安装路径</value>
+  </data>
+  <data name="ViewDialogLaunchGamePackageConvertHint" xml:space="preserve">
+    <value>转换可能需要花费一段时间，请勿关闭</value>
+  </data>
+  <data name="ViewDialogLaunchGamePackageConvertTitle" xml:space="preserve">
+    <value>正在转换客户端</value>
+  </data>
+  <data name="ViewDialogThirdPartyToolDescription" xml:space="preserve">
+    <value>工具描述：</value>
+  </data>
+  <data name="ViewDialogThirdPartyToolLaunch" xml:space="preserve">
+    <value>启动</value>
+  </data>
+  <data name="ViewDialogQRCodeTitle" xml:space="preserve">
+    <value>使用米游社扫描二维码</value>
+  </data>
+  <data name="ViewDialogReconfirmHint" xml:space="preserve">
+    <value>为了确保功能的启用者有独立的判断能力，我们将不定期更新这些功能的启用条件，如果您是一位内容创造者，在创作相关的内容时请不要向你的受众介绍具体的启用方法。</value>
+  </data>
+  <data name="ViewDialogReconfirmTextHeader" xml:space="preserve">
+    <value>为防止你在无意间启用，请输入正在启用的功能开关的&lt;b&gt;标题名称&lt;/b&gt;</value>
+  </data>
+  <data name="ViewDialogReconfirmTitle" xml:space="preserve">
+    <value>你正在启用一个危险功能</value>
+  </data>
+  <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginHint" xml:space="preserve">
+    <value>当前未登录账号，上传深渊数据无法获赠云时长</value>
+  </data>
+  <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginPrimaryButtonText" xml:space="preserve">
+    <value>前往登录</value>
+  </data>
+  <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginSecondaryButtonText" xml:space="preserve">
+    <value>继续上传</value>
+  </data>
+  <data name="ViewDialogSpiralAbyssUploadRecordHomaNotLoginTitle" xml:space="preserve">
+    <value>上传深渊数据</value>
+  </data>
+  <data name="ViewDialogUserAccountPasswordAccountHint" xml:space="preserve">
+    <value>请输入账号</value>
+  </data>
+  <data name="ViewDialogUserAccountPasswordPasswordHint" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="ViewDialogUserAccountPasswordTitle" xml:space="preserve">
+    <value>账号密码登录</value>
+  </data>
+  <data name="ViewDialogUserAccountVerificationCaptchaPlaceholder" xml:space="preserve">
+    <value>验证码</value>
+  </data>
+  <data name="ViewDialogUserAccountVerificationEmailCaptchaSent" xml:space="preserve">
+    <value>验证码已发送</value>
+  </data>
+  <data name="ViewDialogUserAccountVerificationTitle" xml:space="preserve">
+    <value>请输入邮箱验证码</value>
+  </data>
+  <data name="ViewDialogUserDocumentAction" xml:space="preserve">
+    <value>立即前往</value>
+  </data>
+  <data name="ViewDialogUserDocumentDescription" xml:space="preserve">
+    <value>进入文档页面并按指示操作</value>
+  </data>
+  <data name="ViewDialogUserDocumentHeader" xml:space="preserve">
+    <value>操作文档</value>
+  </data>
+  <data name="ViewDialogUserInputPlaceholder" xml:space="preserve">
+    <value>在此处输入包含 SToken 的 Cookie</value>
+  </data>
+  <data name="ViewDialogUserMobileCaptchaCaptchaHint" xml:space="preserve">
+    <value>请输入收到的验证码</value>
+  </data>
+  <data name="ViewDialogUserMobileCaptchaMobileHint" xml:space="preserve">
+    <value>请输入手机号码</value>
+  </data>
+  <data name="ViewDialogUserMobileCaptchaSendCaptchaAction" xml:space="preserve">
+    <value>发送</value>
+  </data>
+  <data name="ViewDialogUserMobileCaptchaTitle" xml:space="preserve">
+    <value>手机验证码登录</value>
+  </data>
+  <data name="ViewDialogUserTitle" xml:space="preserve">
+    <value>设置 Cookie</value>
+  </data>
+  <data name="ViewExceptionWindowCommentDescription" xml:space="preserve">
+    <value>步骤明确，条理清晰的描述将有助于我们更快的定位问题</value>
+  </data>
+  <data name="ViewExceptionWindowCommentHeader" xml:space="preserve">
+    <value>崩溃发生前您执行了哪些操作？</value>
+  </data>
+  <data name="ViewExceptionWindowStacktraceHeader" xml:space="preserve">
+    <value>调用堆栈</value>
+  </data>
+  <data name="ViewFeedbackHeader" xml:space="preserve">
+    <value>反馈中心</value>
+  </data>
+  <data name="ViewGachaLogHeader" xml:space="preserve">
+    <value>祈愿记录</value>
+  </data>
+  <data name="ViewWishCountdownHeader" xml:space="preserve">
+    <value>UP 计时</value>
+  </data>
+  <data name="ViewGuideStepAgreementIHaveReadText" xml:space="preserve">
+    <value>我已阅读并同意</value>
+  </data>
+  <data name="ViewGuideStepAgreementPrivacyPolicy" xml:space="preserve">
+    <value>用户数据与隐私权益</value>
+  </data>
+  <data name="ViewGuideStepAgreementTermOfService" xml:space="preserve">
+    <value>用户使用协议与法律声明</value>
+  </data>
+  <data name="ViewGuideStepCommonSettingHint" xml:space="preserve">
+    <value>稍后可以在设置中修改</value>
+  </data>
+  <data name="ViewGuideStepDataFolderHeader" xml:space="preserve">
+    <value>数据文件夹用于存储所有由用户操作产生的数据、自定义壁纸、元数据、切换服务器缓存、更新缓存等文件</value>
+  </data>
+  <data name="ViewGuideStepDataFolderHint" xml:space="preserve">
+    <value>* 默认的文件夹会在卸载时一同删除，稍后可以在设置中修改</value>
+  </data>
+  <data name="ViewGuideStepCacheFolderHeader" xml:space="preserve">
+    <value>缓存文件夹用于存储图片缓存、背景缓存、静态资源等临时文件</value>
+  </data>
+  <data name="ViewPageSettingSetCacheFolderHeader" xml:space="preserve">
+    <value>更改缓存目录</value>
+  </data>
+  <data name="ViewGuideStepEnvironmentAfterInstallDescription" xml:space="preserve">
+    <value>安装完成后重启以查看是否正常生效</value>
+  </data>
+  <data name="ViewGuideStepEnvironmentFontDescription1" xml:space="preserve">
+    <value>如果上方的图标中存在乱码或方块字，请前往</value>
+  </data>
+  <data name="ViewGuideStepEnvironmentFontDescription2" xml:space="preserve">
+    <value>下载并自行安装图标字体</value>
+  </data>
+  <data name="ViewGuideStepEnvironmentWebView2Description1" xml:space="preserve">
+    <value>若未检测到 WebView2 运行时信息，可以前往</value>
+  </data>
+  <data name="ViewGuideStepEnvironmentWebView2Description2" xml:space="preserve">
+    <value>下载并自行安装运行时</value>
+  </data>
+  <data name="ViewHardChallengeHeader" xml:space="preserve">
+    <value>幽境危战</value>
+  </data>
+  <data name="ViewLauncherPassportHeader" xml:space="preserve">
+    <value>通行证</value>
+  </data>
+  <data name="ViewInfoBarPanelClearAllContent" xml:space="preserve">
+    <value>清除所有通知</value>
+  </data>
+  <data name="ViewInfoBarPanelContractContent" xml:space="preserve">
+    <value>收起</value>
+  </data>
+  <data name="ViewInfoBarPanelTitle" xml:space="preserve">
+    <value>所有通知</value>
+  </data>
+  <data name="ViewInfoBarToggleTitle" xml:space="preserve">
+    <value>有新的通知</value>
+  </data>
+  <data name="ViewLaunchGameHeader" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="ViewListViewDragElevatedHint" xml:space="preserve">
+    <value>管理员模式下无法拖动排序</value>
+  </data>
+  <data name="ViewModelAchievementArchiveAdded" xml:space="preserve">
+    <value>存档 [{0}] 添加成功</value>
+  </data>
+  <data name="ViewModelAchievementArchiveAlreadyExists" xml:space="preserve">
+    <value>不能添加名称重复的存档 [{0}]</value>
+  </data>
+  <data name="ViewModelAchievementArchiveInvalidName" xml:space="preserve">
+    <value>不能添加名称无效的存档</value>
+  </data>
+  <data name="ViewModelAchievementCopyAchievementIdSuccess" xml:space="preserve">
+    <value>复制成就 ID 成功</value>
+  </data>
+  <data name="ViewModelAchievementExportFileType" xml:space="preserve">
+    <value>UIAF 文件</value>
+  </data>
+  <data name="ViewModelAchievementImportProgress" xml:space="preserve">
+    <value>导入成就中</value>
+  </data>
+  <data name="ViewModelAchievementImportWarningMessage" xml:space="preserve">
+    <value>数据的 UIAF 版本过低，无法导入</value>
+  </data>
+  <data name="ViewModelAchievementRemoveArchiveContent" xml:space="preserve">
+    <value>该操作是不可逆的，该存档和其内的所有成就状态会丢失</value>
+  </data>
+  <data name="ViewModelAchievementRemoveArchiveTitle" xml:space="preserve">
+    <value>确定要删除存档 {0} 吗？</value>
+  </data>
+  <data name="ViewModelAchievementSearchInHoYoLAB" xml:space="preserve">
+    <value>前往HoYoLAB搜索</value>
+  </data>
+  <data name="ViewModelAchievementSearchInMiyoushe" xml:space="preserve">
+    <value>前往米游社搜索</value>
+  </data>
+  <data name="ViewModelAchievementSearchQuery" xml:space="preserve">
+    <value>{0} 成就</value>
+  </data>
+  <data name="ViewModelAchievementUIAFExportPickerTitle" xml:space="preserve">
+    <value>导出 UIAF JSON 文件到指定路径</value>
+  </data>
+  <data name="ViewModelAvatarPropertyBatchCultivateNoSelectedAvatar" xml:space="preserve">
+    <value>未选中任意角色</value>
+  </data>
+  <data name="ViewModelAvatarPropertyBatchCultivateProgressTitle" xml:space="preserve">
+    <value>获取培养材料中，请稍候...</value>
+  </data>
+  <data name="ViewModelAvatarPropertyCalculateWeaponNull" xml:space="preserve">
+    <value>当前角色无法计算，请同步信息后再试</value>
+  </data>
+  <data name="ViewModelAvatarPropertyFetch" xml:space="preserve">
+    <value>获取数据中</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindActivatedConstellationCount" xml:space="preserve">
+    <value>命之座解锁层数顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindCurAttack" xml:space="preserve">
+    <value>攻击力顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindCurDefense" xml:space="preserve">
+    <value>防御力顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindDefault" xml:space="preserve">
+    <value>默认顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindElementMastery" xml:space="preserve">
+    <value>元素精通顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindFetterLevel" xml:space="preserve">
+    <value>好感度顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindLevelNumber" xml:space="preserve">
+    <value>等级顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindMaxHp" xml:space="preserve">
+    <value>生命值上限顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertySortDescriptionKindQuality" xml:space="preserve">
+    <value>品质顺序</value>
+  </data>
+  <data name="ViewModelAvatarPropertyTotalAvatarCountHint" xml:space="preserve">
+    <value>共 {0} 位角色</value>
+  </data>
+  <data name="ViewModelAvatatPropertyExportTextError" xml:space="preserve">
+    <value>复制角色详情失败</value>
+  </data>
+  <data name="ViewModelAvatatPropertyExportTextSuccess" xml:space="preserve">
+    <value>复制角色详情成功</value>
+  </data>
+  <data name="ViewModelComplexReliquarySetViewEmptyName" xml:space="preserve">
+    <value>无圣遗物或散件</value>
+  </data>
+  <data name="ViewModelCultivationAddWarning" xml:space="preserve">
+    <value>养成计划添加失败</value>
+  </data>
+  <data name="ViewModelCultivationBatchAddCompleted" xml:space="preserve">
+    <value>操作完成：添加 / 更新：{0} 个，跳过 {1} 个</value>
+  </data>
+  <data name="ViewModelCultivationBatchAddIncompleted" xml:space="preserve">
+    <value>操作未全部完成：添加 / 更新：{0} 个，跳过 {1} 个</value>
+  </data>
+  <data name="ViewModelCultivationClearInventoryContent" xml:space="preserve">
+    <value>此操作不可逆，此计划的背包物品将会丢失</value>
+  </data>
+  <data name="ViewModelCultivationClearInventoryProgress" xml:space="preserve">
+    <value>正在清空背包物品</value>
+  </data>
+  <data name="ViewModelCultivationClearInventoryTitle" xml:space="preserve">
+    <value>确认要清空当前计划下的所有背包物品吗？</value>
+  </data>
+  <data name="ViewModelCultivationConsumptionSaveNoItemHint" xml:space="preserve">
+    <value>选定的等级不需要养成材料</value>
+  </data>
+  <data name="ViewModelCultivationConsumptionSaveSkippedHint" xml:space="preserve">
+    <value>已存在该物品的养成项目</value>
+  </data>
+  <data name="ViewModelCultivationEntryAddNoConsumptionWarning" xml:space="preserve">
+    <value>未消耗任何材料</value>
+  </data>
+  <data name="ViewModelCultivationEntryAddSuccess" xml:space="preserve">
+    <value>已成功添加至当前养成计划</value>
+  </data>
+  <data name="ViewModelCultivationEntryAddWarning" xml:space="preserve">
+    <value>请先前往养成计划页面创建计划并选中</value>
+  </data>
+  <data name="ViewModelCultivationEntryViewDescriptionDefault" xml:space="preserve">
+    <value>重新添加物品以查看养成描述</value>
+  </data>
+  <data name="ViewModelCultivationEntryViewPromoteOnlyHint" xml:space="preserve">
+    <value>仅突破</value>
+  </data>
+  <data name="ViewModelCultivationProjectAdded" xml:space="preserve">
+    <value>添加成功</value>
+  </data>
+  <data name="ViewModelCultivationProjectAlreadyExists" xml:space="preserve">
+    <value>不能添加名称重复的计划</value>
+  </data>
+  <data name="ViewModelCultivationProjectInvalidName" xml:space="preserve">
+    <value>不能添加名称无效的计划</value>
+  </data>
+  <data name="ViewModelCultivationRefreshInventoryProgress" xml:space="preserve">
+    <value>正在同步背包物品</value>
+  </data>
+  <data name="ViewModelCultivationRemoveProjectContent" xml:space="preserve">
+    <value>此操作不可逆，此计划的养成物品与背包材料将会丢失</value>
+  </data>
+  <data name="ViewModelCultivationRemoveProjectTitle" xml:space="preserve">
+    <value>确认要删除当前计划吗？</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsBlossomOfRevelationTitle" xml:space="preserve">
+    <value>启示之花</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsBlossomOfWealthTitle" xml:space="preserve">
+    <value>藏金之花</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsItemRemainDays" xml:space="preserve">
+    <value>还需 {0} 天</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsNormalBossTitle" xml:space="preserve">
+    <value>世界 BOSS</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsTalentAscensionTitle" xml:space="preserve">
+    <value>角色天赋素材</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsWeaponAscensionTitle" xml:space="preserve">
+    <value>武器突破素材</value>
+  </data>
+  <data name="ViewModelCultivationResinStatisticsWeeklyBossTitle" xml:space="preserve">
+    <value>周常 BOSS</value>
+  </data>
+  <data name="ViewModelDailyNoteConfigWebhookUrlComplete" xml:space="preserve">
+    <value>实时便笺 Webhook URL 配置成功</value>
+  </data>
+  <data name="ViewModelDailyNoteRefreshTime30" xml:space="preserve">
+    <value>30 分钟 | 3.75 树脂</value>
+  </data>
+  <data name="ViewModelDailyNoteRefreshTime4" xml:space="preserve">
+    <value>4 分钟 | 0.5 树脂</value>
+  </data>
+  <data name="ViewModelDailyNoteRefreshTime40" xml:space="preserve">
+    <value>40 分钟 | 5 树脂</value>
+  </data>
+  <data name="ViewModelDailyNoteRefreshTime60" xml:space="preserve">
+    <value>60 分钟 | 7.5 树脂</value>
+  </data>
+  <data name="ViewModelDailyNoteRefreshTime8" xml:space="preserve">
+    <value>8 分钟 | 1 树脂</value>
+  </data>
+  <data name="ViewModelDailyNoteRequestProgressTitle" xml:space="preserve">
+    <value>正在获取实时便笺信息，请稍候</value>
+  </data>
+  <data name="ViewModelExportSuccessMessage" xml:space="preserve">
+    <value>成功保存到指定位置</value>
+  </data>
+  <data name="ViewModelExportSuccessTitle" xml:space="preserve">
+    <value>导出成功</value>
+  </data>
+  <data name="ViewModelExportWarningMessage" xml:space="preserve">
+    <value>写入文件时遇到问题</value>
+  </data>
+  <data name="ViewModelExportWarningTitle" xml:space="preserve">
+    <value>导出失败</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownCurrentWish" xml:space="preserve">
+    <value>当前卡池</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownCurrentWishDelta" xml:space="preserve">
+    <value>距离 UP 结束还有 {0} 天</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownHistoryCount" xml:space="preserve">
+    <value>累计 UP 次数：{0}</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownLastTime" xml:space="preserve">
+    <value>上次 UP 时间: {0:yyyy.MM.dd}</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownLastTimeDelta" xml:space="preserve">
+    <value>距离上次 UP 已有 {0} 天</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownOrderDown" xml:space="preserve">
+    <value>下半</value>
+  </data>
+  <data name="ViewModelGachaLogCountdownOrderUp" xml:space="preserve">
+    <value>上半</value>
+  </data>
+  <data name="ViewModelGachaLogExportFileType" xml:space="preserve">
+    <value>UIGF JSON 文件</value>
+  </data>
+  <data name="ViewModelGachaLogExportFormatTitle" xml:space="preserve">
+    <value>选择导出格式</value>
+  </data>
+  <data name="ViewModelGachaLogExportFormatDescription" xml:space="preserve">
+    <value>UIGF v4.0 适用于大部分新版工具，UIGF v2.3 适用于部分旧版工具（如 Starward）</value>
+  </data>
+  <data name="ViewModelGachaLogPredictedPullLeftToOrange" xml:space="preserve">
+    <value>{1:P3} 概率 {0} 抽后获得五星物品</value>
+  </data>
+  <data name="ViewModelGachaLogProbabilityOfNextPullIsOrange" xml:space="preserve">
+    <value>{0:P3} 概率下一抽获得五星物品</value>
+  </data>
+  <data name="ViewModelGachaLogRefreshFail" xml:space="preserve">
+    <value>获取祈愿记录失败</value>
+  </data>
+  <data name="ViewModelGachaLogRefreshOperationCancel" xml:space="preserve">
+    <value>祈愿记录刷新操作被异常取消</value>
+  </data>
+  <data name="ViewModelGachaLogRemoveArchiveDescription" xml:space="preserve">
+    <value>该操作是不可逆的，该存档和其内的所有祈愿数据会丢失</value>
+  </data>
+  <data name="ViewModelGachaLogRemoveArchiveTitle" xml:space="preserve">
+    <value>确定要删除存档 {0} 吗？</value>
+  </data>
+  <data name="ViewModelGachaLogRetrieveFromLauncherCloudProgress" xml:space="preserve">
+    <value>从云服务同步祈愿记录</value>
+  </data>
+  <data name="ViewModelGachaLogUIGFExportPickerTitle" xml:space="preserve">
+    <value>导出 UIGF JSON 文件到指定路径</value>
+  </data>
+  <data name="ViewModelGachaLogUIGFImportSuccess" xml:space="preserve">
+    <value>成功导入 {0} 条祈愿记录</value>
+  </data>
+  <data name="ViewModelGachaLogUIGFExportSuccess" xml:space="preserve">
+    <value>成功导出 UID:{0} 的祈愿记录</value>
+  </data>
+  <data name="ViewModelGachaLogUploadToLauncherCloudProgress" xml:space="preserve">
+    <value>正在上传到云服务</value>
+  </data>
+  <data name="ViewModelGachaUIGFImportPickerTitile" xml:space="preserve">
+    <value>导入 UIGF JSON 文件</value>
+  </data>
+  <data name="ViewModelGameConfigurationCreateFailed" xml:space="preserve">
+    <value>生成配置文件失败</value>
+  </data>
+  <data name="ViewModelGameConfigurationCreateFailedGamePathLocked" xml:space="preserve">
+    <value>游戏路径被锁定，请稍后再试</value>
+  </data>
+  <data name="ViewModelGameConfigurationCreateFailedGamePathNullOrEmpty" xml:space="preserve">
+    <value>游戏路径为空，请先设置游戏路径</value>
+  </data>
+  <data name="ViewModelGamePackageGetGameBranchFailed" xml:space="preserve">
+    <value>获取游戏版本配置失败</value>
+  </data>
+  <data name="ViewModelGamePackageLocalLaunchScheme" xml:space="preserve">
+    <value>本地游戏配置 [{0}]</value>
+  </data>
+  <data name="ViewModelGamePackageLocalVersion" xml:space="preserve">
+    <value>本地版本: {0}</value>
+  </data>
+  <data name="ViewModelGamePackageOperationAborted" xml:space="preserve">
+    <value>任务已中断，{0}</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCanceled" xml:space="preserve">
+    <value>已取消</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCancelling" xml:space="preserve">
+    <value>正在取消</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCompleteInstall" xml:space="preserve">
+    <value>安装完成</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCompletePredownload" xml:space="preserve">
+    <value>预下载完成</value>
+  </data>
+  <data name="ViewModelGamePackagePredownloadMergeTitle" xml:space="preserve">
+    <value>预下载完成</value>
+  </data>
+  <data name="ViewModelGamePackagePredownloadMergeContent" xml:space="preserve">
+    <value>资源预下载已完成，是否立即合并更新？合并期间游戏将无法启动。</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCompleteRepair" xml:space="preserve">
+    <value>修复完成</value>
+  </data>
+  <data name="ViewModelGamePackageOperationCompleteUpdate" xml:space="preserve">
+    <value>更新完成</value>
+  </data>
+  <data name="ViewModelGamePackageOperationSkipRepair" xml:space="preserve">
+    <value>游戏完整，无需修复</value>
+  </data>
+  <data name="ViewModelGamePackagePreVersion" xml:space="preserve">
+    <value>{0} 版本预下载已开启</value>
+  </data>
+  <data name="ViewModelGamePackageRemoteVersion" xml:space="preserve">
+    <value>最新版本: {0}</value>
+  </data>
+  <data name="ViewModelGuideActionComplete" xml:space="preserve">
+    <value>完成</value>
+  </data>
+  <data name="ViewModelGuideActionNext" xml:space="preserve">
+    <value>下一步</value>
+  </data>
+  <data name="ViewGuideScrollHint" xml:space="preserve">
+    <value>请滚动至底部阅读完整协议</value>
+  </data>
+  <data name="ViewModelHardChallengeSeconds" xml:space="preserve">
+    <value>{0} 秒</value>
+  </data>
+  <data name="ViewModelHardChalllengeDataEntryMultiPlayerName" xml:space="preserve">
+    <value>联机挑战</value>
+  </data>
+  <data name="ViewModelHardChalllengeDataEntrySinglePlayerName" xml:space="preserve">
+    <value>单人挑战</value>
+  </data>
+  <data name="ViewModelLauncherPassportEmailNotValidHint" xml:space="preserve">
+    <value>请输入正确的邮箱</value>
+  </data>
+  <data name="ViewModelLauncherPassportPasswordTooShortHint" xml:space="preserve">
+    <value>密码长度不能小于 8 位</value>
+  </data>
+  <data name="ViewModelImportByEmbeddedYaeErrorMessage" xml:space="preserve">
+    <value>请使用其他方法导入成就</value>
+  </data>
+  <data name="ViewModelImportFromClipboardErrorTitle" xml:space="preserve">
+    <value>剪贴板中没有有效的成就数据</value>
+  </data>
+  <data name="ViewModelImportFromClipboardErrorMessage" xml:space="preserve">
+    <value>请先从其他成就工具导出 UIAF 格式的数据并复制到剪贴板后再试</value>
+  </data>
+  <data name="ViewModelImportWarningMessage" xml:space="preserve">
+    <value>数据格式不正确</value>
+  </data>
+  <data name="ViewModelImportWarningMessage2" xml:space="preserve">
+    <value>请先创建一个成就存档</value>
+  </data>
+  <data name="ViewModelImportWarningTitle" xml:space="preserve">
+    <value>导入失败</value>
+  </data>
+  <data name="ViewModelLaunchGameAccountAndServerNotMatch" xml:space="preserve">
+    <value>当前选中用户和游戏服务器不匹配，请重新选择</value>
+  </data>
+  <data name="ViewModelLaunchGameConfigurationFailed" xml:space="preserve">
+    <value>读取游戏配置文件时遇到问题：{0}</value>
+  </data>
+  <data name="ViewModelLaunchGameConfigurationFileNotFound" xml:space="preserve">
+    <value>无法读取游戏配置文件: {0}，可能是文件不存在或权限不足</value>
+  </data>
+  <data name="ViewModelLaunchGameContentCorrupted" xml:space="preserve">
+    <value>当前选中的游戏目录 {0} 已损坏，请手动删除文件夹后重新安装游戏</value>
+  </data>
+  <data name="ViewModelLaunchGameCreateAuthTicketFailed" xml:space="preserve">
+    <value>使用 米游社 / HoYoLAB 用户登录失败，请重新登录</value>
+  </data>
+  <data name="ViewModelLaunchGameDeviceNotFound" xml:space="preserve">
+    <value>无效的游戏路径，请检查硬件连接</value>
+  </data>
+  <data name="ViewModelLaunchGameDisplayGamePath" xml:space="preserve">
+    <value>当前游戏路径：'{0}'</value>
+  </data>
+  <data name="ViewModelLaunchGameEnsureGameResourceFail" xml:space="preserve">
+    <value>切换服务器失败</value>
+  </data>
+  <data name="ViewModelLaunchGameFixConfigurationFileButtonText" xml:space="preserve">
+    <value>修复配置文件</value>
+  </data>
+  <data name="ViewModelLaunchGameFixConfigurationFileFailed" xml:space="preserve">
+    <value>修复失败</value>
+  </data>
+  <data name="ViewModelLaunchGameFixConfigurationFileSucceed" xml:space="preserve">
+    <value>修复成功</value>
+  </data>
+  <data name="ViewModelLaunchGameGamePathNullOrEmpty" xml:space="preserve">
+    <value>尚未设置游戏目录</value>
+  </data>
+  <data name="ViewModelLaunchGameIdentifyMonitorsAction" xml:space="preserve">
+    <value>识别显示器</value>
+  </data>
+  <data name="ViewModelLaunchGameGamePathNotSet" xml:space="preserve">
+    <value>尚未设置游戏路径，请先在设置中配置游戏目录</value>
+  </data>
+  <data name="ViewModelLaunchGameSchemeNotSelected" xml:space="preserve">
+    <value>尚未选择任何服务器</value>
+  </data>
+  <data name="ViewModelLaunchGameSetGamePathButtonText" xml:space="preserve">
+    <value>设置游戏目录</value>
+  </data>
+  <data name="ViewModelLaunchGameSwitchGameAccountFail" xml:space="preserve">
+    <value>切换账号失败</value>
+  </data>
+  <data name="ViewModelNotifyIconRestartAsElevatedErrorHint" xml:space="preserve">
+    <value>在重启时遇到问题，请手动重启</value>
+  </data>
+  <data name="ViewModelOverlayCatalogHotKeyDisplayName" xml:space="preserve">
+    <value>热键提示</value>
+  </data>
+  <data name="ViewModelOverlayCatalogIslandSwitchName" xml:space="preserve">
+    <value>快捷开关</value>
+  </data>
+  <data name="ViewModelRoleCombatHeraldry" xml:space="preserve">
+    <value>已抵达{0}</value>
+  </data>
+  <data name="ViewModelRoleCombatRound" xml:space="preserve">
+    <value>第 {0} 幕</value>
+  </data>
+  <data name="ViewModelRoleCombatRoundAndTarot" xml:space="preserve">
+    <value>第 {0} 幕 圣牌 {1}</value>
+  </data>
+  <data name="ViewModelRoleCombatTarot" xml:space="preserve">
+    <value>圣牌挑战 {0}</value>
+  </data>
+  <data name="ViewModelSettingActionComplete" xml:space="preserve">
+    <value>操作完成</value>
+  </data>
+  <data name="ViewModelSettingAlreadyUpdated" xml:space="preserve">
+    <value>当前已是最新版本</value>
+  </data>
+  <data name="ViewModelSettingCheckUpdateFailed" xml:space="preserve">
+    <value>检查更新时发生错误</value>
+  </data>
+  <data name="ViewModelSettingClearWebCacheFail" xml:space="preserve">
+    <value>清除失败，文件目录权限不足，请使用管理员模式重试</value>
+  </data>
+  <data name="ViewModelSettingClearWebCachePathInvalid" xml:space="preserve">
+    <value>清除失败，找不到目录：{0}</value>
+  </data>
+  <data name="ViewModelSettingClearWebCacheSuccess" xml:space="preserve">
+    <value>清除完成</value>
+  </data>
+  <data name="ViewModelSettingCopyDeviceIdSuccess" xml:space="preserve">
+    <value>复制成功</value>
+  </data>
+  <data name="ViewModelSettingCreateDesktopShortcutFailed" xml:space="preserve">
+    <value>创建桌面快捷方式失败</value>
+  </data>
+  <data name="ViewModelSettingFolderSizeDescription" xml:space="preserve">
+    <value>已使用磁盘空间：{0}</value>
+  </data>
+  <data name="ViewModelSettingGeetestCustomUrlSucceed" xml:space="preserve">
+    <value>无感验证复合 URL 配置成功</value>
+  </data>
+  <data name="ViewModelSettingSetDataFolderSuccess" xml:space="preserve">
+    <value>设置数据目录成功，重启以应用更改</value>
+  </data>
+  <data name="ViewModelSettingStorageRestartFailed" xml:space="preserve">
+    <value>重启失败，请手动重启应用</value>
+  </data>
+  <data name="ViewModelSettingStorageSetDataFolderDescription" xml:space="preserve">
+    <value>选择的文件夹不为空，将会覆盖已存在的文件</value>
+  </data>
+  <data name="ViewModelSettingStorageSetDataFolderDescription2" xml:space="preserve">
+    <value>不是有效的数据文件夹位置，请重新选择</value>
+  </data>
+  <data name="ViewModelSettingStorageSetDataFolderDescription3" xml:space="preserve">
+    <value>选择的文件夹'{0}'不为空，将会覆盖已存在的文件</value>
+  </data>
+  <data name="ViewModelSettingStorageSetDataFolderTitle" xml:space="preserve">
+    <value>复制数据文件</value>
+  </data>
+  <data name="ViewModelSettingUpdateAvailable" xml:space="preserve">
+    <value>更新可用: {0}</value>
+  </data>
+  <data name="ViewModelSettingPatchDownloading" xml:space="preserve">
+    <value>正在下载增量补丁...</value>
+  </data>
+  <data name="ViewModelSettingPatchDownloadingProgress" xml:space="preserve">
+    <value>正在下载增量补丁 {0}%</value>
+  </data>
+  <data name="ViewModelSettingPatchVerifyFailed" xml:space="preserve">
+    <value>补丁校验失败</value>
+  </data>
+  <data name="ViewModelSettingPatchReadyRestarting" xml:space="preserve">
+    <value>补丁已就绪，正在重启安装...</value>
+  </data>
+  <data name="ViewModelSettingPatchUpdaterMissing" xml:space="preserve">
+    <value>updater.exe 不存在，无法应用更新</value>
+  </data>
+  <data name="ViewModelMainUpdatePatchNotAvailable" xml:space="preserve">
+    <value>检测到新版本，但增量补丁暂未就绪，请稍后重试</value>
+  </data>
+  <data name="ViewModelMainUpdateMandatoryTitle" xml:space="preserve">
+    <value>发现新版本</value>
+  </data>
+    <data name="ViewModelMainUpdateMandatoryContent" xml:space="preserve">
+    <value>检测到新版本 {0}，是否立即更新？</value>
+  </data>
+  <data name="ViewModelMainUpdateCompletedTitle" xml:space="preserve">
+    <value>更新完成</value>
+  </data>
+  <data name="ViewModelMainUpdateCompletedContent" xml:space="preserve">
+    <value>已更新到 v{0}</value>
+  </data>
+  <data name="ViewModelMainUpdateNowButton" xml:space="preserve">
+    <value>立即更新</value>
+  </data>
+  <data name="ViewModelMainUpdateLaterButton" xml:space="preserve">
+    <value>稍后更新</value>
+  </data>
+  <data name="ViewModelMainUpdateDownloadFailed" xml:space="preserve">
+    <value>更新下载失败，请检查网络连接后重新启动</value>
+  </data>
+  <data name="ViewModelMainUpdateRestartFailed" xml:space="preserve">
+    <value>更新程序启动失败，请稍后重试或手动重启启动器</value>
+  </data>
+  <data name="ViewModelMainUpdateDownloading" xml:space="preserve">
+    <value>正在下载更新...</value>
+  </data>
+  <data name="ViewModelMainUpdateVerifying" xml:space="preserve">
+    <value>正在校验文件...</value>
+  </data>
+  <data name="ViewModelMainUpdateExtracting" xml:space="preserve">
+    <value>正在解压更新...</value>
+  </data>
+  <data name="ViewModelSignInReSignInDialogContent" xml:space="preserve">
+    <value>需消耗 {0} 米游币，{1} 米游币可用</value>
+  </data>
+  <data name="ViewModelSignInReSignInDialogContentOversea" xml:space="preserve">
+    <value>需消耗 {0} 张补签卡，{1} 张补签卡可用</value>
+  </data>
+  <data name="ViewModelSignInReSignInDialogTitle" xml:space="preserve">
+    <value>确定要补签吗？</value>
+  </data>
+  <data name="ViewModelSignInReSignInNotEnoughCoinMessage" xml:space="preserve">
+    <value>米游币不足</value>
+  </data>
+  <data name="ViewModelSignInTotalSignInDaysHint" xml:space="preserve">
+    <value>{0} 累计签到 {1} 天</value>
+  </data>
+  <data name="ViewModelTitleDataFolderHasReparsepoint" xml:space="preserve">
+    <value>当前数据目录 '{0}' 包含了一个或多个重新分析点（Reparse points），可能会导致部分依赖数据文件夹的功能无法正常工作，请前往设置更改路径</value>
+  </data>
+  <data name="ViewModelUIGFExportError" xml:space="preserve">
+    <value>导出失败</value>
+  </data>
+  <data name="ViewModelUIGFExportSuccess" xml:space="preserve">
+    <value>导出成功</value>
+  </data>
+  <data name="ViewModelUIGFImportDuplicatedHk4eEntry" xml:space="preserve">
+    <value>导入的 UIGF 文件中包含 UID 重复的祈愿记录项</value>
+  </data>
+  <data name="ViewModelUIGFImportError" xml:space="preserve">
+    <value>导入失败</value>
+  </data>
+  <data name="ViewModelUIGFImportNoHk4eEntry" xml:space="preserve">
+    <value>导入的 UIGF 文件中不包含祈愿数据</value>
+  </data>
+  <data name="ViewModelUIGFImportNoSelectedEntry" xml:space="preserve">
+    <value>请选择至少一个 UID 以导入数据</value>
+  </data>
+  <data name="ViewModelUIGFImportSuccess" xml:space="preserve">
+    <value>导入成功</value>
+  </data>
+  <data name="ViewModelUIGFImportingProgressTitle" xml:space="preserve">
+    <value>导入中</value>
+  </data>
+  <data name="ViewModelUserAdded" xml:space="preserve">
+    <value>用户 [{0}] 添加成功</value>
+  </data>
+  <data name="ViewModelUserCookieCopied" xml:space="preserve">
+    <value>用户 [{0}] 的 Cookie 复制成功</value>
+  </data>
+  <data name="ViewModelUserEmptyGameRole" xml:space="preserve">
+    <value>此账号尚未绑定原神游戏角色</value>
+  </data>
+  <data name="ViewModelUserIncomplete" xml:space="preserve">
+    <value>此 Cookie 不完整，操作失败</value>
+  </data>
+  <data name="ViewModelUserInvalid" xml:space="preserve">
+    <value>此 Cookie 无效，操作失败</value>
+  </data>
+  <data name="ViewModelUserRemoved" xml:space="preserve">
+    <value>用户 [{0}] 成功移除</value>
+  </data>
+  <data name="ViewModelUserUpdated" xml:space="preserve">
+    <value>用户 [{0}] 的 Cookie 更新成功</value>
+  </data>
+  <data name="ViewModelViewDisposedOperationCancel" xml:space="preserve">
+    <value>页面资源已经被释放，操作取消</value>
+  </data>
+  <data name="ViewModelWikiAvatarStrategyNotFound" xml:space="preserve">
+    <value>暂无该角色的攻略信息</value>
+  </data>
+  <data name="ViewModelYaeProcessNotElevatedDescription" xml:space="preserve">
+    <value>Embedded Yae 需要管理员权限以启动并加载到游戏</value>
+  </data>
+  <data name="ViewModelYaeProcessNotElevatedTitle" xml:space="preserve">
+    <value>进程权限不足</value>
+  </data>
+  <data name="ViewOverlayDisableShowDamageTextToolTip" xml:space="preserve">
+    <value>移除战斗伤害跳字</value>
+  </data>
+  <data name="ViewOverlayLaunchGameHideQuestBannerToolTip" xml:space="preserve">
+    <value>移除地图界面任务提示</value>
+  </data>
+  <data name="ViewPageAchievementAddArchive" xml:space="preserve">
+    <value>创建新存档</value>
+  </data>
+  <data name="ViewPageAchievementAddArchiveHint" xml:space="preserve">
+    <value>创建新存档以继续</value>
+  </data>
+  <data name="ViewPageAchievementExportLabel" xml:space="preserve">
+    <value>导出</value>
+  </data>
+  <data name="ViewPageAchievementFilterDailyQuestItems" xml:space="preserve">
+    <value>仅委托成就</value>
+  </data>
+  <data name="ViewPageAchievementImportFromClipboard" xml:space="preserve">
+    <value>从剪贴板导入</value>
+  </data>
+  <data name="ViewPageAchievementImportFromEmbeddedYae" xml:space="preserve">
+    <value>通过 Embedded Yae 从游戏内导入</value>
+  </data>
+  <data name="ViewPageAchievementImportFromFile" xml:space="preserve">
+    <value>从 UIAF 文件导入</value>
+  </data>
+  <data name="ViewPageAchievementImportLabel" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="ViewPageAchievementRemoveArchive" xml:space="preserve">
+    <value>删除当前存档</value>
+  </data>
+  <data name="ViewPageAchievementSearchPlaceholder" xml:space="preserve">
+    <value>搜索成就名称，描述，版本或编号</value>
+  </data>
+  <data name="ViewPageAchievementSortIncompletedItemsFirst" xml:space="preserve">
+    <value>优先未完成</value>
+  </data>
+  <data name="ViewPageAnnouncementRedeemCodeCopySucceed" xml:space="preserve">
+    <value>兑换码复制成功</value>
+  </data>
+  <data name="ViewPageAnnouncementRedeemCodeLabel" xml:space="preserve">
+    <value>前瞻直播兑换码</value>
+  </data>
+  <data name="ViewPageAnnouncementViewDetails" xml:space="preserve">
+    <value>查看详情</value>
+  </data>
+  <data name="ViewPageAvatarPropertyCalculateAll" xml:space="preserve">
+    <value>所有角色与武器</value>
+  </data>
+  <data name="ViewPageAvatarPropertyCalculateCurrent" xml:space="preserve">
+    <value>当前角色与武器</value>
+  </data>
+  <data name="ViewPageAvatarPropertyCalculatePart" xml:space="preserve">
+    <value>部分角色与武器</value>
+  </data>
+  <data name="ViewPageAvatarPropertyDefaultDescription" xml:space="preserve">
+    <value>尚未获取任何角色信息</value>
+  </data>
+  <data name="ViewPageAvatarPropertyExportToTextLabel" xml:space="preserve">
+    <value>导出文本到剪贴板</value>
+  </data>
+  <data name="ViewPageAvatarPropertyHeader" xml:space="preserve">
+    <value>角色属性</value>
+  </data>
+  <data name="ViewPageAvatarPropertyRefreshAction" xml:space="preserve">
+    <value>同步</value>
+  </data>
+  <data name="ViewPageAvatarPropertyRefreshFromHoyolabGameRecord" xml:space="preserve">
+    <value>从米游社原神战绩同步</value>
+  </data>
+  <data name="ViewPageCultivateCalculate" xml:space="preserve">
+    <value>养成计算</value>
+  </data>
+  <data name="ViewPageCultivationAddProject" xml:space="preserve">
+    <value>新建计划</value>
+  </data>
+  <data name="ViewPageCultivationAddProjectAction" xml:space="preserve">
+    <value>新建</value>
+  </data>
+  <data name="ViewPageCultivationAddProjectContinue" xml:space="preserve">
+    <value>新建养成计划以继续</value>
+  </data>
+  <data name="ViewPageCultivationAddProjectDescription" xml:space="preserve">
+    <value>稍后可以前往其他页面添加养成计划项</value>
+  </data>
+  <data name="ViewPageCultivationAvatarPropertyDescription" xml:space="preserve">
+    <value>添加我的角色与武器到养成计划</value>
+  </data>
+  <data name="ViewPageCultivationClearInventory" xml:space="preserve">
+    <value>清空背包物品</value>
+  </data>
+  <data name="ViewPageCultivationCultivateEntry" xml:space="preserve">
+    <value>养成物品</value>
+  </data>
+  <data name="ViewPageCultivationInventoryItem" xml:space="preserve">
+    <value>背包物品</value>
+  </data>
+  <data name="ViewPageCultivationMaterialList" xml:space="preserve">
+    <value>材料清单</value>
+  </data>
+  <data name="ViewPageCultivationMaterialListIncompleteFirstLabel" xml:space="preserve">
+    <value>未集齐优先</value>
+  </data>
+  <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
+    <value>树脂预估</value>
+  </data>
+  <data name="ViewPageCultivationMaterialListWorldLevelTitle" xml:space="preserve">
+    <value>世界等级</value>
+  </data>
+  <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
+    <value>材料统计</value>
+  </data>
+  <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
+    <value>前往</value>
+  </data>
+  <data name="ViewPageCultivationRefreshInventory" xml:space="preserve">
+    <value>同步背包物品</value>
+  </data>
+  <data name="ViewPageCultivationRefreshInventoryByCalculator" xml:space="preserve">
+    <value>通过养成计算器同步</value>
+  </data>
+  <data name="ViewPageCultivationRefreshInventoryByEmbeddedYae" xml:space="preserve">
+    <value>通过 Embedded Yae 同步</value>
+  </data>
+  <data name="ViewPageCultivationRemoveEntry" xml:space="preserve">
+    <value>删除清单</value>
+  </data>
+  <data name="ViewPageCultivationRemoveProject" xml:space="preserve">
+    <value>删除当前计划</value>
+  </data>
+  <data name="ViewPageCultivationResinEstimation" xml:space="preserve">
+    <value>树脂预估</value>
+  </data>
+  <data name="ViewPageCultivationResinWorldLevel" xml:space="preserve">
+    <value>世界等级</value>
+  </data>
+  <data name="ViewPageCultivationResinBlossomOfWealth" xml:space="preserve">
+    <value>藏金之花</value>
+  </data>
+  <data name="ViewPageCultivationResinTalentDomain" xml:space="preserve">
+    <value>角色天赋素材</value>
+  </data>
+  <data name="ViewPageCultivationResinWorldBoss" xml:space="preserve">
+    <value>世界 BOSS</value>
+  </data>
+  <data name="ViewPageCultivationResinWeeklyBoss" xml:space="preserve">
+    <value>周常 BOSS</value>
+  </data>
+  <data name="ViewPageCultivationWikiAvatarDescription" xml:space="preserve">
+    <value>添加任意角色到养成计划</value>
+  </data>
+  <data name="ViewPageCultivationWikiWeaponDescription" xml:space="preserve">
+    <value>添加任意武器到养成计划</value>
+  </data>
+  <data name="ViewPageCultivationMyAvatarHeader" xml:space="preserve">
+    <value>我的角色</value>
+  </data>
+  <data name="ViewPageCultivationMyAvatarDescription" xml:space="preserve">
+    <value>从米游社同步角色与武器到养成计划</value>
+  </data>
+  <data name="ViewPageCultivationSyncAllAvatarsAndWeapons" xml:space="preserve">
+    <value>同步所有角色与武器</value>
+  </data>
+  <data name="ViewPageCultivationSyncAllAvatars" xml:space="preserve">
+    <value>所有角色</value>
+  </data>
+  <data name="ViewPageCultivationSyncAllWeapons" xml:space="preserve">
+    <value>所有武器</value>
+  </data>
+  <data name="ViewPageCultivationMyAvatars" xml:space="preserve">
+    <value>我的角色</value>
+  </data>
+  <data name="ViewPageCultivationSyncInventoryToAllProjects" xml:space="preserve">
+    <value>背包同步影响所有计划</value>
+  </data>
+  <data name="ViewPageCultivationFilterEntries" xml:space="preserve">
+    <value>筛选养成物品</value>
+  </data>
+  <data name="ViewPageDailyNoteAddEntry" xml:space="preserve">
+    <value>添加实时便笺</value>
+  </data>
+  <data name="ViewPageDailyNoteAttendanceStatusInfo" xml:space="preserve">
+    <value>历练点获取详情</value>
+  </data>
+  <data name="ViewPageDailyNoteConfigWebhookDescription" xml:space="preserve">
+    <value>在实时便笺刷新后推送到指定的 Webhook</value>
+  </data>
+  <data name="ViewPageDailyNoteConfigWebhookHeader" xml:space="preserve">
+    <value>配置 Webhook</value>
+  </data>
+  <data name="ViewPageDailyNoteDataInteropHeader" xml:space="preserve">
+    <value>数据互操作</value>
+  </data>
+  <data name="ViewPageDailyNoteNotificationHeader" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="ViewPageDailyNoteNotificationSetting" xml:space="preserve">
+    <value>通知设置</value>
+  </data>
+  <data name="ViewPageDailyNoteNotificationUnavailableHint" xml:space="preserve">
+    <value>的通知权限已被关闭</value>
+  </data>
+  <data name="ViewPageDailyNoteRefresh" xml:space="preserve">
+    <value>立即刷新</value>
+  </data>
+  <data name="ViewPageDailyNoteRefreshTime" xml:space="preserve">
+    <value>刷新间隔时间</value>
+  </data>
+  <data name="ViewPageDailyNoteReminderDescription" xml:space="preserve">
+    <value>防止通知自动收入操作中心</value>
+  </data>
+  <data name="ViewPageDailyNoteReminderHeader" xml:space="preserve">
+    <value>提醒通知</value>
+  </data>
+  <data name="ViewPageDailyNoteRemoveToolTip" xml:space="preserve">
+    <value>移除角色</value>
+  </data>
+  <data name="ViewPageDailyNoteResinDiscountUsed" xml:space="preserve">
+    <value>本周已消耗减半次数</value>
+  </data>
+  <data name="ViewPageDailyNoteSettingAutoRefresh" xml:space="preserve">
+    <value>自动刷新</value>
+  </data>
+  <data name="ViewPageDailyNoteSettingAutoRefreshDescription" xml:space="preserve">
+    <value>间隔选定的时间后刷新添加的实时便笺</value>
+  </data>
+  <data name="ViewPageDailyNoteSettingRefreshHeader" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="ViewPageDailyNoteSettingRefreshNotifyIconFailedToCreateHint" xml:space="preserve">
+    <value>通知区域图标创建失败，关闭窗口后自动刷新将不会执行</value>
+  </data>
+  <data name="ViewPageDailyNoteSilentModeDescription" xml:space="preserve">
+    <value>在我游玩原神时不通知我</value>
+  </data>
+  <data name="ViewPageDailyNoteSilentModeHeader" xml:space="preserve">
+    <value>免打扰模式</value>
+  </data>
+  <data name="ViewPageDailyNoteStartGameToolTip" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="ViewPageDailyNoteStoredAttendance" xml:space="preserve">
+    <value>长效历练点</value>
+  </data>
+  <data name="ViewPageDailyNoteVerify" xml:space="preserve">
+    <value>验证当前用户与角色</value>
+  </data>
+  <data name="ViewPageDailyNoteWeekActiveProgress" xml:space="preserve">
+    <value>砺行修远</value>
+  </data>
+  <data name="ViewPageFeedbackAutoSuggestBoxPlaceholder" xml:space="preserve">
+    <value>搜索问题与建议</value>
+  </data>
+  <data name="ViewPageFeedbackCommonLinksHeader" xml:space="preserve">
+    <value>常用链接</value>
+  </data>
+  <data name="ViewPageFeedbackCurrentProxyHeader" xml:space="preserve">
+    <value>当前代理</value>
+  </data>
+  <data name="ViewPageFeedbackCurrentProxyNoProxyDescription" xml:space="preserve">
+    <value>无代理</value>
+  </data>
+  <data name="ViewPageFeedbackEnableLoopbackEnabledDescription" xml:space="preserve">
+    <value>已解除</value>
+  </data>
+  <data name="ViewPageFeedbackEnableLoopbackHeader" xml:space="preserve">
+    <value>解除 Loopback 限制</value>
+  </data>
+  <data name="ViewPageFeedbackEngageWithUsDescription" xml:space="preserve">
+    <value>与我们密切联系</value>
+  </data>
+  <data name="ViewPageFeedbackFeatureGuideHeader" xml:space="preserve">
+    <value>功能指南</value>
+  </data>
+  <data name="ViewPageFeedbackGithubIssuesDescription" xml:space="preserve">
+    <value>我们总是优先处理 GitHub 上的问题</value>
+  </data>
+  <data name="ViewPageFeedbackSearchResultPlaceholderTitle" xml:space="preserve">
+    <value>暂无搜索结果</value>
+  </data>
+  <data name="ViewPageFeedbackServerStatusDescription" xml:space="preserve">
+    <value>服务可用性监控</value>
+  </data>
+  <data name="ViewPageFeedbackServerStatusHeader" xml:space="preserve">
+    <value>服务</value>
+  </data>
+  <data name="ViewPageGachaLogAggressiveRefresh" xml:space="preserve">
+    <value>全量刷新</value>
+  </data>
+  <data name="ViewPageGachaLogHint" xml:space="preserve">
+    <value>尚未获取任何祈愿记录</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloud" xml:space="preserve">
+    <value>云</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudAfdianPurchaseDescription" xml:space="preserve">
+    <value>前往爱发电购买相关服务</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudAfdianPurchaseHeader" xml:space="preserve">
+    <value>购买 / 续费云服务</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudDelete" xml:space="preserve">
+    <value>删除此 UID 的云端存档</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudDeveloperHint" xml:space="preserve">
+    <value>开发者账号无视服务到期时间</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudNoEntryHint" xml:space="preserve">
+    <value>无云端记录</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudNotAllowed" xml:space="preserve">
+    <value>云服务时长不足</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudRetrieve" xml:space="preserve">
+    <value>下载此 UID 的云端存档</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudSpiralAbyssActivityDescription" xml:space="preserve">
+    <value>每期深渊首次上传可免费获得 3 天时长</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudSpiralAbyssActivityHeader" xml:space="preserve">
+    <value>上传深渊记录</value>
+  </data>
+  <data name="ViewPageGachaLogLauncherCloudUpload" xml:space="preserve">
+    <value>上传当前的祈愿存档</value>
+  </data>
+  <data name="ViewPageGachaLogImportAction" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="ViewPageGachaLogImportDescription" xml:space="preserve">
+    <value>导入来自其它 App 的数据</value>
+  </data>
+  <data name="ViewPageGachaLogImportExportAction" xml:space="preserve">
+    <value>导入/导出记录</value>
+  </data>
+  <data name="ViewPageGachaLogImportHeader" xml:space="preserve">
+    <value>导入 UIGF Json</value>
+  </data>
+  <data name="ViewPageGachaLogInputAction" xml:space="preserve">
+    <value>输入</value>
+  </data>
+  <data name="ViewPageGachaLogOrangeAvatarCountdown" xml:space="preserve">
+    <value>五星角色</value>
+  </data>
+  <data name="ViewPageGachaLogOrangeWeaponCountdown" xml:space="preserve">
+    <value>五星武器</value>
+  </data>
+  <data name="ViewPageGachaLogPivotAvatar" xml:space="preserve">
+    <value>角色</value>
+  </data>
+  <data name="ViewPageGachaLogPivotCountdown" xml:space="preserve">
+    <value>计时</value>
+  </data>
+  <data name="ViewPageGachaLogPivotHistory" xml:space="preserve">
+    <value>历史</value>
+  </data>
+  <data name="ViewPageGachaLogPivotOverview" xml:space="preserve">
+    <value>总览</value>
+  </data>
+  <data name="ViewPageGachaLogPivotWeapon" xml:space="preserve">
+    <value>武器</value>
+  </data>
+  <data name="ViewPageGachaLogPurpleAvatarCountdown" xml:space="preserve">
+    <value>四星角色</value>
+  </data>
+  <data name="ViewPageGachaLogPurpleWeaponCountdown" xml:space="preserve">
+    <value>四星武器</value>
+  </data>
+  <data name="ViewPageGachaLogCountdownSearchPlaceholder" xml:space="preserve">
+    <value>搜索角色/武器</value>
+  </data>
+  <data name="ViewPageGachaLogRecoverFromLauncherCloudDescription" xml:space="preserve">
+    <value>从云恢复祈愿记录</value>
+  </data>
+  <data name="ViewPageGachaLogRefresh" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshAction" xml:space="preserve">
+    <value>获取</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshByManualInput" xml:space="preserve">
+    <value>手动输入 URL</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshByManualInputDescription" xml:space="preserve">
+    <value>使用由你提供的 URL 刷新祈愿记录</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshBySToken" xml:space="preserve">
+    <value>SToken 刷新</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshBySTokenDescription" xml:space="preserve">
+    <value>使用当前用户的 Cookie 信息刷新祈愿记录</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshByWebCache" xml:space="preserve">
+    <value>网页缓存刷新</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshByWebCacheDescription" xml:space="preserve">
+    <value>使用游戏内浏览器的网页缓存刷新祈愿记录</value>
+  </data>
+<data name="ViewPageGachaLogRefreshByLogFile" xml:space="preserve">
+    <value>获取抽卡链接</value>
+  </data>
+  <data name="ViewPageGachaLogRefreshByLogFileDescription" xml:space="preserve">
+    <value>自动从游戏日志定位缓存获取祈愿链接并复制到剪贴板</value>
+  </data>
+  <data name="ViewPageGachaLogRemoveArchiveAction" xml:space="preserve">
+    <value>删除当前存档</value>
+  </data>
+  <data name="ViewPageGachaLogSelectArchivePlaceholder" xml:space="preserve">
+    <value>选择存档</value>
+  </data>
+  <data name="ViewPageGachaLogLazyRefresh" xml:space="preserve">
+    <value>懒加载</value>
+  </data>
+  <data name="ViewPageGachaLogExportAction" xml:space="preserve">
+    <value>导出</value>
+  </data>
+  <data name="ViewPageGachaLogAvatarWishOrangeHistory" xml:space="preserve">
+    <value>角色活动祈愿 · 五星历史</value>
+  </data>
+  <data name="ViewPageGachaLogWeaponWishOrangeHistory" xml:space="preserve">
+    <value>武器活动祈愿 · 五星历史</value>
+  </data>
+  <data name="ViewPageHardChallengeNotEngaged" xml:space="preserve">
+    <value>您暂未参与本次关卡哦</value>
+  </data>
+  <data name="ViewPageHardChallengeTime" xml:space="preserve">
+    <value>战斗用时</value>
+  </data>
+  <data name="ViewPageHomeGreetingTextCommon1" xml:space="preserve">
+    <value>已经为你启动了 {0} 次游戏</value>
+  </data>
+  <data name="ViewPageHomeGreetingTextCommon2" xml:space="preserve">
+    <value>你已经启动了 Manjusaka {0} 次</value>
+  </data>
+  <data name="ViewPageHomeGreetingTextDefault" xml:space="preserve">
+    <value>旅行者，欢迎来到提瓦特大陆！</value>
+  </data>
+  <data name="ViewPageHomeGreetingTextEasterEgg" xml:space="preserve">
+    <value>你说的对，但是《》是由 DGP Studio 自主研发的一款...</value>
+  </data>
+  <data name="ViewPageHomeGreetingTextEpic1" xml:space="preserve">
+    <value>呐，旅行者，这是你来到提瓦特大陆的第 {0} 天哦</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverview" xml:space="preserve">
+    <value>详情</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewAvatarAppearanceRank" xml:space="preserve">
+    <value>角色出场</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewAvatarConstellation" xml:space="preserve">
+    <value>角色持有</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewAvatarUsageRank" xml:space="preserve">
+    <value>角色使用</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation0" xml:space="preserve">
+    <value>0 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation1" xml:space="preserve">
+    <value>1 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation2" xml:space="preserve">
+    <value>2 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation3" xml:space="preserve">
+    <value>3 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation4" xml:space="preserve">
+    <value>4 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation5" xml:space="preserve">
+    <value>5 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellation6" xml:space="preserve">
+    <value>6 命</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellationAvatar" xml:space="preserve">
+    <value>角色</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewConstellationHolding" xml:space="preserve">
+    <value>持有</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewDataCollect" xml:space="preserve">
+    <value>数据收集统计</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewRecordTotal" xml:space="preserve">
+    <value>上传记录总数</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewRefreshTime" xml:space="preserve">
+    <value>数据刷新时间</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyss" xml:space="preserve">
+    <value>深渊数据统计</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssBattleAverage" xml:space="preserve">
+    <value>平均战斗次数</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssFullStar" xml:space="preserve">
+    <value>满星深渊记录</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssPassed" xml:space="preserve">
+    <value>通关深渊记录</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssStarAverage" xml:space="preserve">
+    <value>平均获取渊星</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewSpiralAbyssTotal" xml:space="preserve">
+    <value>总计深渊记录</value>
+  </data>
+  <data name="ViewPageLauncherDatabaseOverviewTeamAppearance" xml:space="preserve">
+    <value>队伍出场</value>
+  </data>
+  <data name="ViewPageLauncherPassportCDNCloudDescription" xml:space="preserve">
+    <value>获得时长后您将能够在版本更新时选择中国国内的 CDN 镜像，以获得更好的更新体验。</value>
+  </data>
+  <data name="ViewPageLauncherPassportCDNCloudHeader" xml:space="preserve">
+    <value>云 CDN 服务</value>
+  </data>
+  <data name="ViewPageLauncherPassportGachaLogCloudDescription" xml:space="preserve">
+    <value>获得时长后您将能够通过我们的服务器下载/上传/删除最多 5 个 UID 的祈愿记录。深境螺旋页面中，每期挑战首次上传记录时会获得免费的时长！</value>
+  </data>
+  <data name="ViewPageLauncherPassportGachaLogCloudHeader" xml:space="preserve">
+    <value>云祈愿记录服务</value>
+  </data>
+  <data name="ViewPageLauncherPassportNewUserNameHint" xml:space="preserve">
+    <value>请输入新邮箱</value>
+  </data>
+  <data name="ViewPageLauncherPassportPasswordHint" xml:space="preserve">
+    <value>请输入密码</value>
+  </data>
+  <data name="ViewPageLauncherPassportPasswordRequirementHint" xml:space="preserve">
+    <value>至少需要 8 个字符</value>
+  </data>
+  <data name="ViewPageLauncherPassportRedeemCodeHint" xml:space="preserve">
+    <value>请输入兑换码</value>
+  </data>
+  <data name="ViewPageLauncherPassportSponsorAction" xml:space="preserve">
+    <value>赞助</value>
+  </data>
+  <data name="ViewPageLauncherPassportUnregisterHint" xml:space="preserve">
+    <value>注销账号的数据将永远丢失，无法恢复</value>
+  </data>
+  <data name="ViewPageLauncherPassportUserNameHint" xml:space="preserve">
+    <value>请输入邮箱</value>
+  </data>
+  <data name="ViewPageLauncherPassportVerifyCodeAction" xml:space="preserve">
+    <value>获取验证码</value>
+  </data>
+  <data name="ViewPageLauncherPassportVerifyCodeHint" xml:space="preserve">
+    <value>请输入验证码</value>
+  </data>
+  <data name="ViewPageLaunchGameAction" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceAspectRatioDescription" xml:space="preserve">
+    <value>快速切换到指定的分辨率，启动游戏以保存当前分辨率</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceAspectRatioHeader" xml:space="preserve">
+    <value>分辨率</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceAspectRatioPlaceHolder" xml:space="preserve">
+    <value>快捷设置分辨率</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceBorderlessDescription" xml:space="preserve">
+    <value>将窗口创建为弹出窗口，不带框架</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceExclusiveDescription" xml:space="preserve">
+    <value>与游戏内浏览器不兼容，切屏等操作也能使游戏闪退</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceFullscreenDescription" xml:space="preserve">
+    <value>覆盖默认的全屏状态</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearancePlatformTypeDescription" xml:space="preserve">
+    <value>选择平台类型，不同的类型会影响游戏如何呈现 UI</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceScreenHeightDescription" xml:space="preserve">
+    <value>覆盖默认屏幕高度</value>
+  </data>
+  <data name="ViewPageLaunchGameAppearanceScreenWidthDescription" xml:space="preserve">
+    <value>覆盖默认屏幕宽度</value>
+  </data>
+  <data name="ViewPageLaunchGameArgumentsDescription" xml:space="preserve">
+    <value>在游戏启动时修改其默认行为</value>
+  </data>
+  <data name="ViewPageLaunchGameArgumentsHeader" xml:space="preserve">
+    <value>启动参数</value>
+  </data>
+  <data name="ViewPageLaunchGameBetterGIDescription" xml:space="preserve">
+    <value>在游戏启动后尝试启动并使用 BetterGI 进行自动化任务</value>
+  </data>
+  <data name="ViewPageLaunchGameBetterGIHeader" xml:space="preserve">
+    <value>自动化任务</value>
+  </data>
+  <data name="ViewPageLaunchGameDangerousDescriptionHint" xml:space="preserve">
+    <value>本软件及插件功能属于《米哈游用户协议》第十条第二款规定的“插件、外挂或非经合法授权的第三方工具/服务”，您需要自行承担因使用内容而引起的所有风险，本软件无法且不会对您因前述风险而导致的任何损失或损害承担责任。
+出于安全因素考虑，我们有权不经向您特别通知而对软件及相关功能进行更新，或者对软件的部分功能效果进行改变或限制。</value>
+  </data>
+  <data name="ViewPageLaunchGameDisableFogDescription" xml:space="preserve">
+    <value>移除光照渲染中的迷雾</value>
+  </data>
+  <data name="ViewPageLaunchGameDisableFogHeader" xml:space="preserve">
+    <value>移除迷雾</value>
+  </data>
+  <data name="ViewPageLaunchGameDisableFogOff" xml:space="preserve">
+    <value>保留</value>
+  </data>
+  <data name="ViewPageLaunchGameDisableFogOn" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="ViewPageLaunchGameElevationDescription" xml:space="preserve">
+    <value>游戏文件管理/切换游戏服务器需要管理员权限</value>
+  </data>
+  <data name="ViewPageLaunchGameEventCameraMoveHotSwitchHeader" xml:space="preserve">
+    <value>移除元素爆发镜头特写</value>
+  </data>
+  <data name="ViewPageLaunchGameFixLowFovSceneDescription" xml:space="preserve">
+    <value>修正角色/队伍配置/祈愿/纪行等特殊界面的视野</value>
+  </data>
+  <data name="ViewPageLaunchGameFixLowFovSceneHeader" xml:space="preserve">
+    <value>特殊界面修正</value>
+  </data>
+  <data name="ViewPageLaunchGameFixLowFovSceneTeachingTipSubtitle" xml:space="preserve">
+    <value>启用「调整视野」后，所有场景下的迷雾显示将会遵循「移除迷雾」开关的状态。若同时启用了「特殊界面修正」，则会在原始视野小于等于 30 时，强制禁用迷雾渲染。这会让你看到正常的祈愿/纪行/角色等界面，但是在进入部分剧情时也会强制禁用迷雾。这不属于软件 BUG，不要向我们反馈。</value>
+  </data>
+  <data name="ViewPageLaunchGameFixLowFovSceneTeachingTipTitle" xml:space="preserve">
+    <value>视野与迷雾</value>
+  </data>
+  <data name="ViewPageLaunchGameHideQuestBannerHotSwitchDescription" xml:space="preserve">
+    <value>强制移除地图界面左上角的任务提示</value>
+  </data>
+  <data name="ViewPageLaunchGameHideQuestBannerHotSwitchHeader" xml:space="preserve">
+    <value>关闭地图横幅</value>
+  </data>
+  <data name="ViewPageLaunchGameHotSwitchDescription" xml:space="preserve">
+    <value>游戏启动后可以实时切换</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionDescription" xml:space="preserve">
+    <value>请您仔细甄别这些功能的危害性再选择开启这些功能</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionHeader" xml:space="preserve">
+    <value>插件</value>
+  </data>
+  <data name="ViewPageLaunchGameThirdPartyTools" xml:space="preserve">
+    <value>第三方插件工具：</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandConnected" xml:space="preserve">
+    <value>已连接到游戏，更改设置将会动态反映到游戏中</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandOptionsHeader" xml:space="preserve">
+    <value>插件选项</value>
+  </data>
+  
+  <data name="ViewPageLaunchGameAutomationOptionsHeader" xml:space="preserve">
+    <value>自动化选项</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandRedirectCombineEntryDescription" xml:space="preserve">
+    <value>在物品详情中点击可合成数量时直接打开合成页面而不是地图</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandRedirectCombineEntryHeader" xml:space="preserve">
+    <value>重定向合成</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandResinListItemAllowCondensedResinHeader" xml:space="preserve">
+    <value>使用浓缩树脂领取奖励</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandResinListItemAllowFragileResinHeader" xml:space="preserve">
+    <value>使用脆弱树脂领取奖励</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandResinListItemAllowOriginalResinHeader" xml:space="preserve">
+    <value>使用原粹树脂领取奖励</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandResinListItemAllowPrimogemHeader" xml:space="preserve">
+    <value>使用原石领取奖励</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandResinListItemAllowTransientResinHeader" xml:space="preserve">
+    <value>使用须臾树脂领取奖励</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandUsingTouchScreenHeader" xml:space="preserve">
+    <value>使用触摸输入</value>
+  </data>
+  <data name="ViewPageLaunchGameKillGameProcessAction" xml:space="preserve">
+    <value>结束进程</value>
+  </data>
+  <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
+    <value>在指定的显示器上运行</value>
+  </data>
+  <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
+    <value>游戏选项</value>
+  </data>
+  <data name="ViewPageLaunchGameOverlayDescription" xml:space="preserve">
+    <value>需要在设置中启用通知区域图标，可能需要启用无边框窗口选项来正确显示</value>
+  </data>
+  <data name="ViewPageLaunchGameOverlayHeader" xml:space="preserve">
+    <value>悬浮窗</value>
+  </data>
+  <data name="ViewPageLaunchGameOverlayHideDescription" xml:space="preserve">
+    <value>设置悬浮窗（与游戏一同启动）的显示/隐藏快捷键</value>
+  </data>
+  <data name="ViewPageLaunchGameOverlayHideHeader" xml:space="preserve">
+    <value>显示/隐藏悬浮窗</value>
+  </data>
+  <data name="ViewPageLaunchGamePackageOperationInstall" xml:space="preserve">
+    <value>安装游戏</value>
+  </data>
+  <data name="ViewPageLaunchGamePackageOperationPredownload" xml:space="preserve">
+    <value>预下载</value>
+  </data>
+  <data name="ViewPageLaunchGamePackageOperationPredownloadCompleteBadgeContent" xml:space="preserve">
+    <value>已完成预下载</value>
+  </data>
+  <data name="ViewPageLaunchGamePackagePredownloadUnavailable" xml:space="preserve">
+    <value>当前没有要预下载的资源哦</value>
+  </data>
+  <data name="ViewPageLaunchGamePackageOperationUpdate" xml:space="preserve">
+    <value>更新游戏</value>
+  </data>
+  <data name="ViewPageLaunchGamePackageOperationVerify" xml:space="preserve">
+    <value>修复游戏</value>
+  </data>
+  <data name="ViewPageLaunchGamePlayTimeDescription" xml:space="preserve">
+    <value>在游戏启动后尝试启动并使用 Starward 进行游戏时长统计</value>
+  </data>
+  <data name="ViewPageLaunchGamePlayTimeHeader" xml:space="preserve">
+    <value>时长统计</value>
+  </data>
+  <data name="ViewPageLaunchGameRemoveOpenTeamProgressDescription" xml:space="preserve">
+    <value>移除打开队伍配置界面时显示的进度条</value>
+  </data>
+  <data name="ViewPageLaunchGameRemoveOpenTeamProgressHeader" xml:space="preserve">
+    <value>移除队伍配置进度条</value>
+  </data>
+  <data name="ViewPageLaunchGameSelectGamePath" xml:space="preserve">
+    <value>选择游戏路径</value>
+  </data>
+  <data name="ViewPageLaunchGameSelectGamePathHint" xml:space="preserve">
+    <value>在下方列表中选中以切换到该路径</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountDescription" xml:space="preserve">
+    <value>在游戏内切换账号，网络环境发生变化后需要重新手动检测</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountDetectAction" xml:space="preserve">
+    <value>检测</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountExpired" xml:space="preserve">
+    <value>MAC 地址不匹配，可能需要在游戏中重新登录</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountHeader" xml:space="preserve">
+    <value>检测账号</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountRemoveToolTip" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchAccountRenameToolTip" xml:space="preserve">
+    <value>重命名</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchSchemeAction" xml:space="preserve">
+    <value>转换</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchSchemeDescription" xml:space="preserve">
+    <value>切换游戏服务器（国服 / 渠道服 / 国际服）</value>
+  </data>
+  <data name="ViewPageLaunchGameSwitchSchemeHeader" xml:space="preserve">
+    <value>服务器</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFovDescription" xml:space="preserve">
+    <value>调整相机视野，默认 45</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFovHeader" xml:space="preserve">
+    <value>调整视野</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFovHotSwitchHeader" xml:space="preserve">
+    <value>视野热开关</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFpsHeader" xml:space="preserve">
+    <value>目标帧率</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFpsHotSwitchHeader" xml:space="preserve">
+    <value>帧率热开关</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFpsTeachingTipSubtitle" xml:space="preserve">
+    <value>若在启用此功能后帧率无法超过 60/显示器帧率 但其他功能正常，那么这一定不是软件 BUG，不要向我们反馈。请自行检查 游戏设置/显卡驱动设置/显示器设置 中是否未关闭（包括但不限于）垂直同步，最大帧率限制，智能插帧等功能。</value>
+  </data>
+  <data name="ViewPageLaunchGameTargetFpsTeachingTipTitle" xml:space="preserve">
+    <value>无法解锁帧率上限？</value>
+  </data>
+  <data name="ViewPageLaunchGameUnlockFpsDescription" xml:space="preserve">
+    <value>请在游戏内关闭「垂直同步」选项，需要高性能的显卡以支持更高的帧率</value>
+  </data>
+  <data name="ViewPageLaunchGameUseHoyolabAccountDescription" xml:space="preserve">
+    <value>使用当前选中的 米游社 / HoYoLAB 用户登录</value>
+  </data>
+  <data name="ViewPageLaunchGameUseHoyolabAccountHeader" xml:space="preserve">
+    <value>使用 米游社 / HoYoLAB 用户登录</value>
+  </data>
+  <data name="ViewPageLaunchGameWindowsHDRDescription" xml:space="preserve">
+    <value>充分利用支持高动态范围的显示器获得更亮、更生动、更精细的画面</value>
+  </data>
+  <data name="ViewPageLaunchGameWindowsHDRHeader" xml:space="preserve">
+    <value>Windows HDR（启动游戏自动开启，退出游戏自动关闭）</value>
+  </data>
+  <data name="ViewPageOpenScreenshotFolderAction" xml:space="preserve">
+    <value>打开截图文件夹</value>
+  </data>
+  <data name="ViewPageResetGamePathAction" xml:space="preserve">
+    <value>选择游戏路径</value>
+  </data>
+  <data name="ViewPageRoleCombatAvatarSupportHint" xml:space="preserve">
+    <value>助演</value>
+  </data>
+  <data name="ViewPageRoleCombatAvatarTrialHint" xml:space="preserve">
+    <value>试用</value>
+  </data>
+  <data name="ViewPageRoleCombatBackupAvatars" xml:space="preserve">
+    <value>待命角色</value>
+  </data>
+  <data name="ViewPageRoleCombatChoiceCardsHeader" xml:space="preserve">
+    <value>神秘收获</value>
+  </data>
+  <data name="ViewPageRoleCombatCoinNumber" xml:space="preserve">
+    <value>消耗「幻剧之花」</value>
+  </data>
+  <data name="ViewPageRoleCombatInitialAvatarsHeader" xml:space="preserve">
+    <value>开幕角色</value>
+  </data>
+  <data name="ViewPageRoleCombatMaxRound" xml:space="preserve">
+    <value>最佳记录</value>
+  </data>
+  <data name="ViewPageRoleCombatMedalRound" xml:space="preserve">
+    <value>挑战星章</value>
+  </data>
+  <data name="ViewPageRoleCombatNotEngagedHeader" xml:space="preserve">
+    <value>暂无演出数据</value>
+  </data>
+  <data name="ViewPageRoleCombatShortest" xml:space="preserve">
+    <value>最快演出</value>
+  </data>
+  <data name="ViewPageRoleCombatSpecialAvatarsHeader" xml:space="preserve">
+    <value>特邀角色</value>
+  </data>
+  <data name="ViewPageRoleCombatSplendourBuffsHeader" xml:space="preserve">
+    <value>辉彩祝福</value>
+  </data>
+  <data name="ViewPageRoleCombatStatAvatarBonus" xml:space="preserve">
+    <value>场外声援</value>
+  </data>
+  <data name="ViewPageRoleCombatStatRent" xml:space="preserve">
+    <value>助演次数</value>
+  </data>
+  <data name="ViewPageRoleCombatTotalBattleTime" xml:space="preserve">
+    <value>演出总时长</value>
+  </data>
+  <data name="ViewPageSettingAppearanceCloseButtonBehaviorDescription" xml:space="preserve">
+    <value>更改关闭按钮的行为</value>
+  </data>
+  <data name="ViewPageSettingAppearanceCloseButtonBehaviorHeader" xml:space="preserve">
+    <value>关闭按钮行为</value>
+  </data>
+  <data name="ViewPageSettingRememberWindowPlacementHeader" xml:space="preserve">
+    <value>记住窗口大小和位置</value>
+  </data>
+  <data name="ViewPageSettingRememberWindowPlacementDescription" xml:space="preserve">
+    <value>下次启动时恢复上次关闭时的窗口大小和位置</value>
+  </data>
+  <data name="ViewPageSettingApperanceFirstDayOfWeekDescription" xml:space="preserve">
+    <value>选择适合你的一周中的首日</value>
+  </data>
+  <data name="ViewPageSettingApperanceFirstDayOfWeekHeader" xml:space="preserve">
+    <value>一周中的首日</value>
+  </data>
+  <data name="ViewPageSettingApperanceHeader" xml:space="preserve">
+    <value>外观</value>
+  </data>
+  <data name="ViewPageSettingApperanceLanguageDescription" xml:space="preserve">
+    <value>设置呈现语言</value>
+  </data>
+  <data name="ViewPageSettingApperanceLanguageHeader" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="ViewPageSettingBackdropMaterialDescription" xml:space="preserve">
+    <value>更改窗体的背景材质</value>
+  </data>
+  <data name="ViewPageSettingBackdropMaterialHeader" xml:space="preserve">
+    <value>背景材质</value>
+  </data>
+  <data name="ViewPageSettingBackgroundImageDescription" xml:space="preserve">
+    <value>更改主页的背景图片来源</value>
+  </data>
+<data name="ViewPageSettingBackgroundImageCustomNone" xml:space="preserve">
+    <value>未选择文件</value>
+  </data>
+<data name="ViewPageSettingBackgroundImageCustomHint" xml:space="preserve">
+    <value>请先选择“自定义图片或视频”选项</value>
+  </data>
+<data name="ViewPageSettingBackgroundImageCustomBrowse" xml:space="preserve">
+    <value>浏览</value>
+  </data>
+  <data name="ViewPageSettingBackgroundImageCustomClear" xml:space="preserve">
+    <value>清除</value>
+  </data>
+  <data name="ViewPageSettingBackgroundSwitchIntervalHeader" xml:space="preserve">
+    <value>背景自动切换间隔</value>
+  </data>
+  <data name="ViewPageSettingBackgroundSwitchIntervalDescription" xml:space="preserve">
+    <value>设置官方启动器背景图片自动切换的时间间隔</value>
+  </data>
+  <data name="ViewPageSettingBackgroundSwitchIntervalUnit" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="ViewPageSettingBackgroundShowDynamicHeader" xml:space="preserve">
+    <value>显示动态背景</value>
+  </data>
+  <data name="ViewPageSettingBackgroundShowDynamicDescription" xml:space="preserve">
+    <value>在官方启动器背景中显示包含视频的动态背景</value>
+  </data>
+  <data name="ViewPageSettingBackgroundShowStaticHeader" xml:space="preserve">
+    <value>显示静态背景</value>
+  </data>
+  <data name="ViewPageSettingBackgroundShowStaticDescription" xml:space="preserve">
+    <value>在官方启动器背景中显示仅有图片的静态背景</value>
+  </data>
+  <data name="ViewPageSettingHomePageCardVisibleHeader" xml:space="preserve">
+    <value>显示主页卡片</value>
+  </data>
+  <data name="ViewPageSettingHomePageCardVisibleDescription" xml:space="preserve">
+    <value>控制主页活动公告卡片的显示</value>
+  </data>
+  <data name="ViewPageSettingHomePageIndicatorVisibleHeader" xml:space="preserve">
+    <value>显示背景指示器</value>
+  </data>
+  <data name="ViewPageSettingHomePageIndicatorVisibleDescription" xml:space="preserve">
+    <value>控制主页底部背景切换指示点和暂停按钮的显示</value>
+  </data>
+  <data name="ViewPageSettingBackgroundImageHeader" xml:space="preserve">
+    <value>主页背景图片</value>
+  </data>
+  <data name="ViewPageSettingCacheFolderHeader" xml:space="preserve">
+    <value>缓存 文件夹</value>
+  </data>
+  <data name="ViewPageSettingCheckUpdateHeader" xml:space="preserve">
+    <value>检查更新</value>
+  </data>
+  <data name="ViewPageSettingCloseButtonBehaviorNotifyIconFailedToCreateWarning" xml:space="preserve">
+    <value>通知区域图标创建失败，无法调整关闭按钮行为</value>
+  </data>
+
+  <data name="ViewPageSettingCopyDeviceIdAction" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="ViewPageSettingCreateDesktopShortcutAction" xml:space="preserve">
+    <value>创建</value>
+  </data>
+  <data name="ViewPageSettingCreateDesktopShortcutHeader" xml:space="preserve">
+    <value>在桌面上创建新的快捷方式</value>
+  </data>
+  <data name="ViewPageSettingDataFolderHeader" xml:space="preserve">
+    <value>数据 文件夹</value>
+  </data>
+  <data name="ViewPageSettingInstallFolderHeader" xml:space="preserve">
+    <value>安装 文件夹</value>
+  </data>
+  <data name="ViewPageSettingDeleteCacheAction" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ViewPageSettingDeleteCacheDescription" xml:space="preserve">
+    <value>若祈愿记录缓存刷新频繁提示验证密钥过期，可以尝试此操作</value>
+  </data>
+  <data name="ViewPageSettingDeleteCacheHeader" xml:space="preserve">
+    <value>删除游戏内网页缓存</value>
+  </data>
+  <data name="ViewPageSettingDeviceIdHeader" xml:space="preserve">
+    <value>设备 ID</value>
+  </data>
+  <data name="ViewPageSettingDeviceIpDescription" xml:space="preserve">
+    <value>IP：{0} 归属服务器：{1}</value>
+  </data>
+  <data name="ViewPageSettingDeviceIpHeader" xml:space="preserve">
+    <value>设备 IP</value>
+  </data>
+  <data name="ViewPageSettingElevatedModeHeader" xml:space="preserve">
+    <value>管理员模式</value>
+  </data>
+  <data name="ViewPageSettingElevatedModeRestartAction" xml:space="preserve">
+    <value>以管理员身份重启</value>
+  </data>
+  <data name="ViewPageSettingEmptyHistoryVisibleDescription" xml:space="preserve">
+    <value>在祈愿记录页面显示或隐藏无记录的历史祈愿活动</value>
+  </data>
+  <data name="ViewPageSettingEmptyHistoryVisibleHeader" xml:space="preserve">
+    <value>无记录的历史祈愿活动</value>
+  </data>
+  <data name="ViewPageSettingEmptyHistoryVisibleOff" xml:space="preserve">
+    <value>隐藏</value>
+  </data>
+  <data name="ViewPageSettingEmptyHistoryVisibleOn" xml:space="preserve">
+    <value>显示</value>
+  </data>
+  <data name="ViewPageSettingFeedbackNavigate" xml:space="preserve">
+    <value>前往反馈</value>
+  </data>
+  <data name="ViewModelSettingFeedbackTitle" xml:space="preserve">
+    <value>反馈</value>
+  </data>
+  <data name="ViewModelSettingFeedbackDescription" xml:space="preserve">
+    <value>请选择反馈方式</value>
+  </data>
+  <data name="ViewModelSettingFeedbackDeveloperServer" xml:space="preserve">
+    <value>开发者服务器</value>
+  </data>
+  <data name="ViewPageSettingGitHubNavigate" xml:space="preserve">
+<value>开源仓库</value>
+  </data>
+  <data name="ViewPageSettingGachaLogHeader" xml:space="preserve">
+    <value>祈愿记录</value>
+  </data>
+  <data name="ViewPageSettingGameHeader" xml:space="preserve">
+    <value>游戏</value>
+  </data>
+  <data name="ViewPageSettingGeetestCustomUrlAction" xml:space="preserve">
+    <value>配置</value>
+  </data>
+  <data name="ViewPageSettingGeetestCustomUrlDescription" xml:space="preserve">
+    <value>配置当请求触发人机验证时使用的验证接口</value>
+  </data>
+  <data name="ViewPageSettingGeetestCustomUrlHeader" xml:space="preserve">
+    <value>配置验证请求接口</value>
+  </data>
+  <data name="ViewPageSettingGeetestVerificationHeader" xml:space="preserve">
+    <value>无感验证</value>
+  </data>
+  <data name="ViewPageSettingHomeAnnouncementRegionDescription" xml:space="preserve">
+    <value>选择想要获取公告的游戏服务器</value>
+  </data>
+  <data name="ViewPageSettingHomeAnnouncementRegionHeader" xml:space="preserve">
+    <value>游戏公告所属服务器</value>
+  </data>
+  <data name="ViewPageSettingHomeCalendarServerTimeZoneOffsetDescription" xml:space="preserve">
+    <value>选择材料日历获取当天日期时使用的游戏服务器时区</value>
+  </data>
+  <data name="ViewPageSettingHomeCalendarServerTimeZoneOffsetHeader" xml:space="preserve">
+    <value>日历服务器</value>
+  </data>
+  <data name="ViewPageSettingHomeHeader" xml:space="preserve">
+    <value>公告</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportCdnExpiredAtHeader" xml:space="preserve">
+    <value>云 CDN 到期时间</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportDangerZoneDescription" xml:space="preserve">
+    <value>三思而后行</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportDangerZoneHeader" xml:space="preserve">
+    <value>危险操作</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportGachaLogExpiredAtHeader" xml:space="preserve">
+    <value>云祈愿记录服务到期时间</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportHeader" xml:space="preserve">
+    <value>通行证账号</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportLicensedDeveloperDescription" xml:space="preserve">
+    <value>您可以无限制使用任何基于云服务的功能</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportLicensedDeveloperHeader" xml:space="preserve">
+    <value>已认证的合作开发者</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportLoginAction" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportLogoutAction" xml:space="preserve">
+    <value>退出登录</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportMaintainerDescription" xml:space="preserve">
+    <value>您可以无限制的使用任何测试功能</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportMaintainerHeader" xml:space="preserve">
+    <value>开发 / 运维</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportRedeemCodeDescription" xml:space="preserve">
+    <value>我们有时会向某些用户赠送云兑换码</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportRedeemCodeHeader" xml:space="preserve">
+    <value>使用兑换码</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportRefreshAction" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportRegisterAction" xml:space="preserve">
+    <value>注册</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportResetPasswordAction" xml:space="preserve">
+    <value>修改密码</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportResetUserNameAction" xml:space="preserve">
+    <value>修改邮箱</value>
+  </data>
+  <data name="ViewPageSettingLauncherPassportUnregisterAction" xml:space="preserve">
+    <value>注销账号</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutAutoClickingDescription" xml:space="preserve">
+    <value>更改鼠标左键自动连点功能的快捷键</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutAutoClickingHeader" xml:space="preserve">
+    <value>鼠标左键自动连点</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutAutoPressingDescription" xml:space="preserve">
+    <value>更改键盘 F 键自动连按功能的快捷键</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutAutoPressingHeader" xml:space="preserve">
+    <value>键盘 F 键自动连按</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutInGameOnlyDescription" xml:space="preserve">
+    <value>快捷键仅在游戏启动后生效</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutInGameOnlyHeader" xml:space="preserve">
+    <value>游戏启动后生效</value>
+  </data>
+  <data name="ViewPageSettingKeyShortcutWarningDescription" xml:space="preserve">
+    <value>对不同的功能设置相同的快捷键可能会导致非预期的结果，且需要额外的操作或重启应用才能恢复正常</value>
+  </data>
+  <data name="ViewPageSettingOfficialSiteNavigate" xml:space="preserve">
+    <value>前往官网</value>
+  </data>
+  <data name="ViewPageSettingDocsNavigate" xml:space="preserve">
+    <value>查看文档</value>
+  </data>
+  <data name="ViewPageSettingSetDataFolderDescription" xml:space="preserve">
+    <value>更改目录后将会自动复制文件夹并自动重启，重启后自动删除之前的文件夹</value>
+  </data>
+  <data name="ViewPageSettingSetDataFolderHeader" xml:space="preserve">
+    <value>更改数据目录</value>
+  </data>
+  <data name="ViewPageSettingSetGamePathAction" xml:space="preserve">
+    <value>设置路径</value>
+  </data>
+  <data name="ViewPageSettingSetGamePathHeader" xml:space="preserve">
+    <value>游戏路径</value>
+  </data>
+  <data name="ViewPageSettingSetGamePathHint" xml:space="preserve">
+    <value>设置游戏路径时，请选择游戏本体（YuanShen.exe 或 GenshinImpact.exe）而不是启动器（launcher.exe）</value>
+  </data>
+  <data name="ViewPageSettingSponsorNavigate" xml:space="preserve">
+    <value>赞助我们</value>
+  </data>
+  <data name="ViewPageSettingStorageHeader" xml:space="preserve">
+    <value>存储空间</value>
+  </data>
+  <data name="ViewPageSettingStorageSetAction" xml:space="preserve">
+    <value>更改</value>
+  </data>
+  <data name="ViewPageSettingThemeDescription" xml:space="preserve">
+    <value>更改窗体的颜色主题</value>
+  </data>
+  <data name="ViewPageSettingThemeHeader" xml:space="preserve">
+    <value>颜色主题</value>
+  </data>
+  <data name="ViewPageSettingTranslateNavigate" xml:space="preserve">
+    <value>贡献翻译</value>
+  </data>
+  <data name="ViewPageSettingUIGFExportContent" xml:space="preserve">
+    <value>导出</value>
+  </data>
+  <data name="ViewPageSettingUIGFExportImportDescription" xml:space="preserve">
+    <value>导出/导入 UIGF 4 文件</value>
+  </data>
+  <data name="ViewPageSettingUIGFExportImportHeader" xml:space="preserve">
+    <value>数据迁移</value>
+  </data>
+  <data name="ViewPageSettingUIGFImportContent" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="ViewPageSettingUIGFUpgradeLegacyVersionContent" xml:space="preserve">
+    <value>升级较早版本的 UIGF 文件</value>
+  </data>
+  <data name="ViewPageSettingUnobtainedWishItemVisibleDescription" xml:space="preserve">
+    <value>在「祈愿记录-角色」与「祈愿记录-武器」中显示未抽取到的祈愿物品</value>
+  </data>
+  <data name="ViewPageSettingUnobtainedWishItemVisibleHeader" xml:space="preserve">
+    <value>未抽取到的祈愿物品</value>
+  </data>
+  <data name="ViewPageSettingWebview2Header" xml:space="preserve">
+    <value>Webview2 运行时</value>
+  </data>
+  <data name="ViewPageSpiralAbyssTeamAppearanceDownHeader" xml:space="preserve">
+    <value>下半</value>
+  </data>
+  <data name="ViewPageSpiralAbyssTeamAppearanceUpHeader" xml:space="preserve">
+    <value>上半</value>
+  </data>
+  <data name="ViewPageWiKiAvatarArtifactSetCombinationHeader" xml:space="preserve">
+    <value>搭配圣遗物</value>
+  </data>
+  <data name="ViewPageWiKiAvatarAscensionMaterialsHeader" xml:space="preserve">
+    <value>养成材料</value>
+  </data>
+  <data name="ViewPageWiKiAvatarAutoSuggestBoxPlaceHolder" xml:space="preserve">
+    <value>筛选角色</value>
+  </data>
+  <data name="ViewPageWiKiAvatarChineseCVNameTitle" xml:space="preserve">
+    <value>汉语 CV</value>
+  </data>
+  <data name="ViewPageWiKiAvatarConstellationNameTitle" xml:space="preserve">
+    <value>命之座</value>
+  </data>
+  <data name="ViewPageWiKiAvatarDateofBirthTitle" xml:space="preserve">
+    <value>生日</value>
+  </data>
+  <data name="ViewPageWiKiAvatarEnglishCVNameTitle" xml:space="preserve">
+    <value>英语 CV</value>
+  </data>
+  <data name="ViewPageWiKiAvatarFoodHeader" xml:space="preserve">
+    <value>料理</value>
+  </data>
+  <data name="ViewPageWiKiAvatarGnosisTitle" xml:space="preserve">
+    <value>神之心</value>
+  </data>
+  <data name="ViewPageWiKiAvatarJapaneseCVNameTitle" xml:space="preserve">
+    <value>日语 CV</value>
+  </data>
+  <data name="ViewPageWiKiAvatarKoreanCVNameTitle" xml:space="preserve">
+    <value>韩语 CV</value>
+  </data>
+  <data name="ViewPageWiKiAvatarNameCardHeader" xml:space="preserve">
+    <value>名片</value>
+  </data>
+  <data name="ViewPageWiKiAvatarOccupationNameTitle" xml:space="preserve">
+    <value>所属</value>
+  </data>
+  <data name="ViewPageWiKiAvatarOriginalFoodTitle" xml:space="preserve">
+    <value>原料理</value>
+  </data>
+  <data name="ViewPageWiKiAvatarQuotesHeader" xml:space="preserve">
+    <value>资料</value>
+  </data>
+  <data name="ViewPageWiKiAvatarSpecialFoodTitle" xml:space="preserve">
+    <value>特殊料理</value>
+  </data>
+  <data name="ViewPageWiKiAvatarStoriesHeader" xml:space="preserve">
+    <value>故事</value>
+  </data>
+  <data name="ViewPageWiKiAvatarStrategyBilibiliButtonLabel" xml:space="preserve">
+    <value>哔哩哔哩 Wiki 角色攻略</value>
+  </data>
+  <data name="ViewPageWiKiAvatarStrategyChineseButtonLabel" xml:space="preserve">
+    <value>米游社角色攻略</value>
+  </data>
+  <data name="ViewPageWiKiAvatarStrategyOverseaButtonLabel" xml:space="preserve">
+    <value>HoYoLAB 角色攻略</value>
+  </data>
+  <data name="ViewPageWiKiAvatarTeamCombinationHeader" xml:space="preserve">
+    <value>搭配角色</value>
+  </data>
+  <data name="ViewPageWiKiAvatarTraceEffectHeader" xml:space="preserve">
+    <value>游迹</value>
+  </data>
+  <data name="ViewPageWiKiAvatarVisionTitle" xml:space="preserve">
+    <value>神之眼</value>
+  </data>
+  <data name="ViewPageWiKiAvatarWeaponCombinationHeader" xml:space="preserve">
+    <value>搭配武器</value>
+  </data>
+  <data name="ViewPageWiKiGeneralAddToDevPlanButtonLabel" xml:space="preserve">
+    <value>添加到养成计划</value>
+  </data>
+  <data name="ViewPageWiKiWeaponAfterAscensionTitle" xml:space="preserve">
+    <value>突破后</value>
+  </data>
+  <data name="ViewPageWiKiWeaponAutoSuggestBoxPlaceHolder" xml:space="preserve">
+    <value>筛选武器</value>
+  </data>
+  <data name="ViewPageWikiArchonQuestAutoSuggestBoxPlaceHolder" xml:space="preserve">
+    <value>筛选任务</value>
+  </data>
+  <data name="ViewPageWiKiWeaponBeforeAscensionTitle" xml:space="preserve">
+    <value>突破前</value>
+  </data>
+  <data name="ViewPageWiKiWeaponStoryHeader" xml:space="preserve">
+    <value>武器故事</value>
+  </data>
+  <data name="ViewPageWikiMonsterDropItems" xml:space="preserve">
+    <value>掉落物品</value>
+  </data>
+  <data name="ViewPeriodHeader" xml:space="preserve">
+    <value>周期</value>
+  </data>
+  <data name="ViewRoleCombatHeader" xml:space="preserve">
+    <value>幻想真境剧诗</value>
+  </data>
+  <data name="ViewServiceLauncherUserCdnNotAllowedDescription" xml:space="preserve">
+    <value>未开通云 CDN 或已到期</value>
+  </data>
+  <data name="ViewServiceLauncherUserCloudNotAllowedDescription" xml:space="preserve">
+    <value>未开通祈愿记录上传服务或已到期</value>
+  </data>
+  <data name="ViewServiceLauncherUserLoginFailHint" xml:space="preserve">
+    <value>登录失败，请重新登录</value>
+  </data>
+  <data name="ViewServiceLauncherUserLoginOrRegisterHint" xml:space="preserve">
+    <value>立即登录或注册</value>
+  </data>
+  <data name="ViewSettingFolderViewOpenFolderAction" xml:space="preserve">
+    <value>打开文件夹</value>
+  </data>
+  <data name="ViewSettingHeader" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="ViewSpiralAbyssAvatarAppearanceRankDescription" xml:space="preserve">
+    <value>角色出场率 = 本层上阵该角色次数（层内重复出现只记一次）/ 深渊记录总数</value>
+  </data>
+  <data name="ViewSpiralAbyssAvatarUsageRankDescription" xml:space="preserve">
+    <value>角色使用率 = 本层上阵该角色次数（层内重复出现只记一次）/ 持有该角色的深渊记录总数</value>
+  </data>
+  <data name="ViewSpiralAbyssBattleTimes" xml:space="preserve">
+    <value>战斗次数</value>
+  </data>
+  <data name="ViewSpiralAbyssDamage" xml:space="preserve">
+    <value>最强一击</value>
+  </data>
+  <data name="ViewSpiralAbyssDefeat" xml:space="preserve">
+    <value>最多击破</value>
+  </data>
+  <data name="ViewSpiralAbyssDetail" xml:space="preserve">
+    <value>分期详情</value>
+  </data>
+  <data name="ViewSpiralAbyssEnergySkill" xml:space="preserve">
+    <value>元素爆发</value>
+  </data>
+  <data name="ViewSpiralAbyssHeader" xml:space="preserve">
+    <value>深境螺旋</value>
+  </data>
+  <data name="ViewSpiralAbyssLauncherStatistics" xml:space="preserve">
+    <value>本期统计</value>
+  </data>
+  <data name="ViewSpiralAbyssLevelBattleCaptionDown" xml:space="preserve">
+    <value>下半</value>
+  </data>
+  <data name="ViewSpiralAbyssLevelBattleCaptionUp" xml:space="preserve">
+    <value>上半</value>
+  </data>
+  <data name="ViewSpiralAbyssMaxFloor" xml:space="preserve">
+    <value>最深抵达</value>
+  </data>
+  <data name="ViewSpiralAbyssNormalSkill" xml:space="preserve">
+    <value>元素战技</value>
+  </data>
+  <data name="ViewSpiralAbyssRecordBattleAvatars" xml:space="preserve">
+    <value>上场角色</value>
+  </data>
+  <data name="ViewSpiralAbyssRecordMonsterAttacksMonolith" xml:space="preserve">
+    <value>攻击地脉镇石</value>
+  </data>
+  <data name="ViewSpiralAbyssRefresh" xml:space="preserve">
+    <value>刷新数据</value>
+  </data>
+  <data name="ViewSpiralAbyssReveal" xml:space="preserve">
+    <value>出战次数</value>
+  </data>
+  <data name="ViewSpiralAbyssStatistics" xml:space="preserve">
+    <value>统计数据</value>
+  </data>
+  <data name="ViewSpiralAbyssTakeDamage" xml:space="preserve">
+    <value>最多承伤</value>
+  </data>
+  <data name="ViewSpiralAbyssTotalStar" xml:space="preserve">
+    <value>获得渊星</value>
+  </data>
+  <data name="ViewSpiralAbyssUploadRecord" xml:space="preserve">
+    <value>上传数据</value>
+  </data>
+  <data name="ViewTitileUpdatePackageAvailableContent" xml:space="preserve">
+    <value>是否立即更新？</value>
+  </data>
+  <data name="ViewTitleAutoClicking" xml:space="preserve">
+    <value>自动连点</value>
+  </data>
+  <data name="ViewTitleAutoPressing" xml:space="preserve">
+    <value>自动连按</value>
+  </data>
+  <data name="ViewTitleMetadataInitializing" xml:space="preserve">
+    <value>正在初始化元数据</value>
+  </data>
+  <data name="ViewTitleUpdatePackageAvailableTitle" xml:space="preserve">
+    <value> {0} 版本现已可用</value>
+  </data>
+  <data name="ViewToolHeader" xml:space="preserve">
+    <value>工具</value>
+  </data>
+  <data name="ViewUserCookieOperation" xml:space="preserve">
+    <value>米游社</value>
+  </data>
+  <data name="ViewUserCookieOperation2" xml:space="preserve">
+    <value>HoYoLAB</value>
+  </data>
+  <data name="ViewUserCookieOperation3" xml:space="preserve">
+    <value>当前用户</value>
+  </data>
+  <data name="ViewUserCookieOperationGameRecordIndexAction" xml:space="preserve">
+    <value>旅行工具</value>
+  </data>
+  <data name="ViewUserCookieOperationLoginByPasswordAction" xml:space="preserve">
+    <value>账密登录</value>
+  </data>
+  <data name="ViewUserCookieOperationLoginMobileCaptchaAction" xml:space="preserve">
+    <value>手机验证码</value>
+  </data>
+  <data name="ViewUserCookieOperationLoginQRCodeAction" xml:space="preserve">
+    <value>扫码登录</value>
+  </data>
+  <data name="ViewUserCookieOperationManualInputAction" xml:space="preserve">
+    <value>手动输入</value>
+  </data>
+  <data name="ViewUserCookieOperationRefreshCookieAction" xml:space="preserve">
+    <value>刷新 Cookie</value>
+  </data>
+  <data name="ViewUserCopyCookieAction" xml:space="preserve">
+    <value>复制 Cookie</value>
+  </data>
+  <data name="ViewUserDefaultDescription" xml:space="preserve">
+    <value>请先登录</value>
+  </data>
+  <data name="ViewUserNoUserHint" xml:space="preserve">
+    <value>尚未登录</value>
+  </data>
+  <data name="ViewUserRefreshCookieTokenSuccess" xml:space="preserve">
+    <value>刷新 CookieToken 成功</value>
+  </data>
+  <data name="ViewUserRefreshCookieTokenWarning" xml:space="preserve">
+    <value>刷新 CookieToken 失败</value>
+  </data>
+  <data name="ViewUserRemoveAction" xml:space="preserve">
+    <value>移除用户</value>
+  </data>
+  <data name="ViewUserRole" xml:space="preserve">
+    <value>角色</value>
+  </data>
+  <data name="ViewUserUser" xml:space="preserve">
+    <value>用户</value>
+  </data>
+  <data name="ViewWebView2WindowLoadFailedHint" xml:space="preserve">
+    <value>WebView2 加载失败</value>
+  </data>
+  <data name="ViewWelcomeBase" xml:space="preserve">
+    <value>我们将为你下载最基本的图像资源</value>
+  </data>
+  <data name="ViewEmotionIconHeader" xml:space="preserve">
+    <value>派蒙画作</value>
+  </data>
+  <data name="ViewWikiAvatarHeader" xml:space="preserve">
+    <value>角色资料</value>
+  </data>
+  <data name="ViewWikiMonsterHeader" xml:space="preserve">
+    <value>怪物资料</value>
+  </data>
+  <data name="ViewWikiWeaponHeader" xml:space="preserve">
+    <value>武器资料</value>
+  </data>
+  <data name="ViewWikiArchonQuestHeader" xml:space="preserve">
+    <value>任务合集</value>
+  </data>
+  <data name="ViewWikiFoodHeader" xml:space="preserve">
+    <value>食物资料</value>
+  </data>
+  <data name="ViewWikiFoodEffectRecoveryHp" xml:space="preserve">
+    <value>恢复生命</value>
+  </data>
+  <data name="ViewWikiFoodEffectRecoveryHpAll" xml:space="preserve">
+    <value>恢复全队</value>
+  </data>
+  <data name="ViewWikiFoodEffectRevive" xml:space="preserve">
+    <value>复苏</value>
+  </data>
+  <data name="ViewWikiFoodEffectAtkAdd" xml:space="preserve">
+    <value>攻击力</value>
+  </data>
+  <data name="ViewWikiFoodEffectCritRate" xml:space="preserve">
+    <value>暴击率</value>
+  </data>
+  <data name="ViewWikiFoodEffectDefAdd" xml:space="preserve">
+    <value>防御力</value>
+  </data>
+  <data name="ViewWikiFoodEffectSPAdd" xml:space="preserve">
+    <value>体力恢复</value>
+  </data>
+  <data name="ViewWikiFoodEffectSPReduce" xml:space="preserve">
+    <value>体力消耗</value>
+  </data>
+  <data name="ViewWikiFoodEffectClimate" xml:space="preserve">
+    <value>耐寒耐热</value>
+  </data>
+  <data name="ViewWikiFoodEffectAdventure" xml:space="preserve">
+    <value>探索</value>
+  </data>
+  <data name="ViewWikiFoodEffectSpecial" xml:space="preserve">
+    <value>特殊效果</value>
+  </data>
+  <data name="ViewWikiFoodRankStar" xml:space="preserve">
+    <value>{0}星</value>
+  </data>
+  <data name="ViewWikiFoodEffectTitle" xml:space="preserve">
+    <value>效果</value>
+  </data>
+  <data name="ViewWikiFoodRecipeTitle" xml:space="preserve">
+    <value>配方材料</value>
+  </data>
+  <data name="ViewWikiFoodCookingTitle" xml:space="preserve">
+    <value>手工烹饪</value>
+  </data>
+  <data name="ViewWikiFoodCategorySpecial" xml:space="preserve">
+    <value>特色料理</value>
+  </data>
+  <data name="ViewWikiFoodElementalSkill" xml:space="preserve">
+    <value>元素战技</value>
+  </data>
+  <data name="ViewWikiFoodSearchPlaceholder" xml:space="preserve">
+    <value>搜索食物...</value>
+  </data>
+  <data name="ViewWikiFoodInventoryHeader" xml:space="preserve">
+    <value>背包食物</value>
+  </data>
+  <data name="ViewWindowCompactWebViewTitle" xml:space="preserve">
+    <value>紧凑网页窗口</value>
+  </data>
+  <data name="ViewWindowCompactWebView2HotKeyDisabledMessage" xml:space="preserve">
+    <value>以管理员身份运行以启用全局快捷键功能</value>
+  </data>
+  <data name="ViewWindowExceptionClose" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="ViewWindowExceptionHeader" xml:space="preserve">
+    <value>遇到了无法恢复的致命错误</value>
+  </data>
+  <data name="ViewWindowExceptionTitle" xml:space="preserve">
+    <value>我们遇到了一点问题</value>
+  </data>
+  <data name="ViewWindowScriptingExecute" xml:space="preserve">
+    <value>执行</value>
+  </data>
+  <data name="ViewWindowScriptingTitle" xml:space="preserve">
+    <value>执行调试脚本</value>
+  </data>
+  <data name="WebAnnouncementTimeDaysBegin" xml:space="preserve">
+    <value>{0} 天后开始</value>
+  </data>
+  <data name="WebAnnouncementTimeDaysEnd" xml:space="preserve">
+    <value>{0} 天后结束</value>
+  </data>
+  <data name="WebAnnouncementTimeHoursBegin" xml:space="preserve">
+    <value>{0} 小时后开始</value>
+  </data>
+  <data name="WebAnnouncementTimeHoursEnd" xml:space="preserve">
+    <value>{0} 小时后结束</value>
+  </data>
+  <data name="WebAnnouncementTimeEnded" xml:space="preserve">
+    <value>已结束</value>
+  </data>
+  <data name="WebAnnouncementTimeSuffixBegin" xml:space="preserve">
+    <value>后开始</value>
+  </data>
+  <data name="WebAnnouncementTimeSuffixEnd" xml:space="preserve">
+    <value>后结束</value>
+  </data>
+  <data name="WebBridgeShareCopyToClipboardFailed" xml:space="preserve">
+    <value>打开剪贴板失败</value>
+  </data>
+  <data name="WebBridgeShareCopyToClipboardSuccess" xml:space="preserve">
+    <value>已复制到剪贴板</value>
+  </data>
+  <data name="WebBridgeShareFilePickerTitle" xml:space="preserve">
+    <value>保存分享图片</value>
+  </data>
+  <data name="WebBridgeShareSaveAsFileFailed" xml:space="preserve">
+    <value>图片保存失败</value>
+  </data>
+  <data name="WebBridgeShareSaveAsFileSuccess" xml:space="preserve">
+    <value>图片保存成功</value>
+  </data>
+  <data name="WebBridgeShareSaveKindCopyToClipboard" xml:space="preserve">
+    <value>复制到剪贴板</value>
+  </data>
+  <data name="WebBridgeShareSaveKindSaveAsFile" xml:space="preserve">
+    <value>保存为文件</value>
+  </data>
+  <data name="WebDailyNoteArchonQuestChapterFinished" xml:space="preserve">
+    <value>所有魔神任务已完成</value>
+  </data>
+  <data name="WebDailyNoteArchonQuestStatusFinished" xml:space="preserve">
+    <value>全部完成</value>
+  </data>
+  <data name="WebDailyNoteArchonQuestStatusNotOpen" xml:space="preserve">
+    <value>尚未开启</value>
+  </data>
+  <data name="WebDailyNoteArchonQuestStatusOngoing" xml:space="preserve">
+    <value>进行中</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusFinishedNonReward" xml:space="preserve">
+    <value>已完成</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusForbid" xml:space="preserve">
+    <value>禁止领取</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusInvalid" xml:space="preserve">
+    <value>无效</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusTakenAward" xml:space="preserve">
+    <value>已领取</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusUnfinished" xml:space="preserve">
+    <value>尚未完成</value>
+  </data>
+  <data name="WebDailyNoteAttendanceRewardStatusWaitTaken" xml:space="preserve">
+    <value>等待领取</value>
+  </data>
+  <data name="WebDailyNoteExpeditionRemainTime" xml:space="preserve">
+    <value>{0} 时 {1} 分</value>
+  </data>
+  <data name="WebDailyNoteExtraTaskRewardNotAllowed" xml:space="preserve">
+    <value>今日完成委托数量不足</value>
+  </data>
+  <data name="WebDailyNoteExtraTaskRewardNotTaken" xml:space="preserve">
+    <value>「每日委托」奖励未领取</value>
+  </data>
+  <data name="WebDailyNoteExtraTaskRewardReceived" xml:space="preserve">
+    <value>「每日委托」奖励已领取</value>
+  </data>
+  <data name="WebDailyNoteHomeCoinRecovery" xml:space="preserve">
+    <value>预计 {0} {1:HH:mm} 达到存储上限</value>
+  </data>
+  <data name="WebDailyNoteHomeCoinRecoveryCompleted" xml:space="preserve">
+    <value>洞天宝钱已达存储上限</value>
+  </data>
+  <data name="WebDailyNoteHomeCoinRecoveryTargetTime" xml:space="preserve">
+    <value>将于 {0:MM.dd HH:mm} 达到存储上限</value>
+  </data>
+  <data name="WebDailyNoteHomeLocked" xml:space="preserve">
+    <value>尚未解锁洞天</value>
+  </data>
+  <data name="WebDailyNoteResinRecovery" xml:space="preserve">
+    <value>将于 {0} {1:HH:mm} 后全部恢复</value>
+  </data>
+  <data name="WebDailyNoteResinRecoveryCompleted" xml:space="preserve">
+    <value>原粹树脂已完全恢复</value>
+  </data>
+  <data name="WebDailyNoteResinRecoveryTargetTime" xml:space="preserve">
+    <value>将于 {0:MM.dd HH:mm} 全部恢复</value>
+  </data>
+  <data name="WebDailyNoteStoredAttendanceRefreshCountdown" xml:space="preserve">
+    <value>{0:c} 后重置</value>
+  </data>
+  <data name="WebDailyNoteTransformerAppend" xml:space="preserve">
+    <value>后可再次使用</value>
+  </data>
+  <data name="WebDailyNoteTransformerDays" xml:space="preserve">
+    <value>{0} 天</value>
+  </data>
+  <data name="WebDailyNoteTransformerHours" xml:space="preserve">
+    <value>{0} 时</value>
+  </data>
+  <data name="WebDailyNoteTransformerMinutes" xml:space="preserve">
+    <value>{0} 分</value>
+  </data>
+  <data name="WebDailyNoteTransformerNotObtained" xml:space="preserve">
+    <value>尚未获得</value>
+  </data>
+  <data name="WebDailyNoteTransformerNotObtainedDetail" xml:space="preserve">
+    <value>尚未获得参量质变仪</value>
+  </data>
+  <data name="WebDailyNoteTransformerNotReached" xml:space="preserve">
+    <value>冷却中</value>
+  </data>
+  <data name="WebDailyNoteTransformerReached" xml:space="preserve">
+    <value>可使用</value>
+  </data>
+  <data name="WebDailyNoteTransformerReady" xml:space="preserve">
+    <value>已准备完成</value>
+  </data>
+  <data name="WebDailyNoteTransformerSeconds" xml:space="preserve">
+    <value>{0} 秒</value>
+  </data>
+  <data name="WebDailyNoteVerificationFailed" xml:space="preserve">
+    <value>验证失败，请手动验证或前往「米游社-旅行工具-原神战绩-实时便笺」页面查看</value>
+  </data>
+  <data name="WebDailyNoteWeekActiveProgressFinished" xml:space="preserve">
+    <value>本周已完成</value>
+  </data>
+  <data name="WebDailyNoteWeekActiveProgressLocked" xml:space="preserve">
+    <value>尚未解锁</value>
+  </data>
+  <data name="WebDailyNoteWeekActiveProgressPeriod" xml:space="preserve">
+    <value>阶段进度 {0}/{1}</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode400" xml:space="preserve">
+    <value>错误的 UID 格式</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode404" xml:space="preserve">
+    <value>角色 UID 不存在，请稍候再试</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode424" xml:space="preserve">
+    <value>游戏维护中</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode429" xml:space="preserve">
+    <value>请求过快，请稍后再试</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode500" xml:space="preserve">
+    <value>服务器偶发错误</value>
+  </data>
+  <data name="WebEnkaResponseStatusCode503" xml:space="preserve">
+    <value>服务器严重错误</value>
+  </data>
+  <data name="WebEnkaResponseStatusCodeUnknown" xml:space="preserve">
+    <value>未知的服务器错误</value>
+  </data>
+  <data name="WebGachaConfigTypeAvatarEventWish" xml:space="preserve">
+    <value>角色活动祈愿</value>
+  </data>
+  <data name="WebGachaConfigTypeAvatarEventWish2" xml:space="preserve">
+    <value>角色活动祈愿-2</value>
+  </data>
+  <data name="WebGachaConfigTypeChronicledWish" xml:space="preserve">
+    <value>集录祈愿</value>
+  </data>
+  <data name="WebGachaConfigTypeNoviceWish" xml:space="preserve">
+    <value>新手祈愿</value>
+  </data>
+  <data name="WebGachaConfigTypePermanentWish" xml:space="preserve">
+    <value>常驻祈愿</value>
+  </data>
+  <data name="WebGachaConfigTypeWeaponEventWish" xml:space="preserve">
+    <value>武器活动祈愿</value>
+  </data>
+  <data name="WebGameResourcePathCopySucceed" xml:space="preserve">
+    <value>下载链接复制成功</value>
+  </data>
+  <data name="WebHardChallengeBestAvatarTypeAllAttack" xml:space="preserve">
+    <value>最高总伤害</value>
+  </data>
+  <data name="WebHardChallengeBestAvatarTypeOneAttack" xml:space="preserve">
+    <value>最强一击</value>
+  </data>
+  <data name="WebHoyolabInvalidRegion" xml:space="preserve">
+    <value>无效的服务器</value>
+  </data>
+  <data name="WebHoyolabInvalidUid" xml:space="preserve">
+    <value>无效的 UID</value>
+  </data>
+  <data name="WebHoyolabRegionCNGF01" xml:space="preserve">
+    <value>国服 官方服</value>
+  </data>
+  <data name="WebHoyolabRegionCNQD01" xml:space="preserve">
+    <value>国服 渠道服</value>
+  </data>
+  <data name="WebHoyolabRegionOSASIA" xml:space="preserve">
+    <value>国际服 亚服</value>
+  </data>
+  <data name="WebHoyolabRegionOSCHT" xml:space="preserve">
+    <value>国际服 港澳台服</value>
+  </data>
+  <data name="WebHoyolabRegionOSEURO" xml:space="preserve">
+    <value>国际服 欧服</value>
+  </data>
+  <data name="WebHoyolabRegionOSUSA" xml:space="preserve">
+    <value>国际服 美服</value>
+  </data>
+  <data name="WebLauncherServiceUnAvailable" xml:space="preserve">
+    <value>服务维护中</value>
+  </data>
+  <data name="WebIndexOrSpiralAbyssVerificationFailed" xml:space="preserve">
+    <value>验证失败，请手动验证或前往「米游社-旅行工具-原神战绩」页面查看</value>
+  </data>
+  <data name="WebRequestBuilderExceptionDescription" xml:space="preserve">
+    <value>在请求 {0} 时遇到问题</value>
+  </data>
+  <data name="WebResponse" xml:space="preserve">
+    <value>状态：{0} | 信息：{1}</value>
+  </data>
+  <data name="WebResponseRefreshCookieHint" xml:space="preserve">
+    <value>请刷新 Cookie，原始消息：{0}</value>
+  </data>
+  <data name="WebResponseRequestException" xml:space="preserve">
+    <value>[{0}] 中的 [{1}] 网络请求异常，请稍后再试</value>
+  </data>
+  <data name="WebResponseSignInErrorHint" xml:space="preserve">
+    <value>登录失败，请前往 HoYoLAB 初始化账号，原始消息：{0}</value>
+  </data>
+  <data name="WindowIdentifyMonitorHeader" xml:space="preserve">
+    <value>显示器编号</value>
+  </data>
+  <data name="UIViewMainTitleBarInvertTheme" xml:space="preserve">
+    <value>主题切换</value>
+  </data>
+  <data name="ViewPageSettingAlwaysRunAsAdminText" xml:space="preserve">
+    <value>始终以管理员身份运行</value>
+  </data>
+  <data name="ViewPageSettingAlwaysRunAsAdminTextDes" xml:space="preserve">
+    <value>将在手动启动应用时生效，建议开启自启动和管理员自启动以免启动各种功能时可能的UAC弹窗打扰</value>
+  </data>
+  <data name="ViewPageSettingAutoStartHeader" xml:space="preserve">
+    <value>开机自启动</value>
+  </data>
+  <data name="ViewPageSettingAutoStartDescription" xml:space="preserve">
+    <value>程序将在当前用户登录时启动，是否以管理员运行仅在修改时同步管理员模式选项（修改需以管理员身份运行）</value>
+  </data>
+  <data name="ViewPageSettingAppBehaviorHeader" xml:space="preserve">
+    <value>应用行为</value>
+  </data>
+  <data name="ViewCardSignInAutoSignIn" xml:space="preserve">
+    <value>自动签到</value>
+  </data>
+  <data name="ServiceMetadataWeaponIdNotFound" xml:space="preserve">
+    <value>未找到武器元数据</value>
+  </data>
+  <data name="ServiceMetadataAvatarIdNotFound" xml:space="preserve">
+    <value>未找到角色元数据</value>
+  </data>
+  <data name="ServiceGachaLogIdPlacesUnsupported" xml:space="preserve">
+    <value>不支持的祈愿记录 ID 来源</value>
+  </data>
+  <data name="ServiceGachaLogWeaponIdNotFound" xml:space="preserve">
+    <value>未找到武器 ID</value>
+  </data>
+  <data name="ServiceGachaLogAvatarIdNotFound" xml:space="preserve">
+    <value>未找到角色 ID</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartOptionsHeader" xml:space="preserve">
+    <value>自定义启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartDescription" xml:space="preserve">
+    <value>自定义启动选项允许快速启动其他路径的程序，内的游戏选项包括启动参数将不会生效</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartCustomizeHeader" xml:space="preserve">
+    <value>用户自定义程序启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartPickPathHeader" xml:space="preserve">
+    <value>选择启动程序</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartPickPathDescription" xml:space="preserve">
+    <value>选择需要启动的程序路径，以 '.exe' 结尾</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartOpenCommunityAction" xml:space="preserve">
+    <value>前往社区获取分享的程序</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartGame" xml:space="preserve">
+    <value>启动自定义程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartLoading" xml:space="preserve">
+    <value>正在加载自定义启动列表</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartFeedMissing" xml:space="preserve">
+    <value>未配置自定义启动源地址</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartPick" xml:space="preserve">
+    <value>请选择一个自定义启动程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartLoadFailed" xml:space="preserve">
+    <value>加载自定义启动列表失败</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartPickWarning" xml:space="preserve">
+    <value>请先选择自定义启动程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartCompleted" xml:space="preserve">
+    <value>已完成，程序路径：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartFailed" xml:space="preserve">
+    <value>下载或解压失败，请重试</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartExecutableMissing" xml:space="preserve">
+    <value>未找到可执行文件</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartDownloading" xml:space="preserve">
+    <value>正在下载 {0}（{1}/{2}）</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartExtracting" xml:space="preserve">
+    <value>正在解压 {0}（{1}/{2}）</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartTitle" xml:space="preserve">
+    <value>下载来自自定义源的自定义程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartPrimary" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartEmpty" xml:space="preserve">
+    <value>暂无可用的自定义启动程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartStatusHeader" xml:space="preserve">
+    <value>当前执行状态</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartOpenDownloaderAction" xml:space="preserve">
+    <value>快速获取并下载清单列表中的程序</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartUnknownServer" xml:space="preserve">
+    <value>未知服务器</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartDnsFailed" xml:space="preserve">
+    <value>无法连接到服务器 '{0}'：DNS 解析失败。 可能原因：
+1.	域名不存在或拼写错误
+2.	DNS 服务器故障
+3.	网络连接问题
+4.	防火墙或安全软件阻止了 DNS 查询 请检查网络设置后重试。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartConnectionRefused" xml:space="preserve">
+    <value>服务器拒绝连接，请稍后重试。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartTimedOut" xml:space="preserve">
+    <value>连接超时，请检查网络连接。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartNetworkDown" xml:space="preserve">
+    <value>网络连接不可用，请检查网络状态。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartNetworkUnreachable" xml:space="preserve">
+    <value>网络不可达，请检查网络连接。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartDnsNoData" xml:space="preserve">
+    <value>DNS 查询成功但未找到服务器记录，请确认地址正确性。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartNetworkError" xml:space="preserve">
+    <value>网络连接错误：{0} (错误代码: {1})</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartHttpError" xml:space="preserve">
+    <value>服务器返回错误：{0} {1}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartUnknownServerResponse" xml:space="preserve">
+    <value>服务器返回未知错误：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartSecurityFailed" xml:space="preserve">
+    <value>安全连接失败：{0}，请检查系统时间和证书设置。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartNetworkRequestFailed" xml:space="preserve">
+    <value>网络请求失败：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartDownloadCanceled" xml:space="preserve">
+    <value>下载 {0} 已被取消。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartDownloadTimeout" xml:space="preserve">
+    <value>下载 {0} 超时，请检查网络连接并重试。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartOperationCanceled" xml:space="preserve">
+    <value>操作已取消：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartIOError" xml:space="preserve">
+    <value>文件读写错误：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartUnsupportedContentType" xml:space="preserve">
+    <value>不支持的响应内容类型：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartInvalidHeaders" xml:space="preserve">
+    <value>无效的 HTTP 头设置：{0}</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartUnknownError" xml:space="preserve">
+    <value>下载 {0} 时发生未知错误。 错误类型: {1} 请重试或联系支持。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStart7zEntryDataError" xml:space="preserve">
+    <value>7z 解压失败（条目: {0}）：数据错误，归档可能损坏或使用了不受支持的 7z 压缩格式。请重试下载或使用 ZIP 包。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStart7zDataError" xml:space="preserve">
+    <value>7z 解压失败：归档数据损坏或采用了不受支持的 7z 压缩方式。请重试下载或提供 ZIP 格式包。</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartUnsupportedArchiveFormat" xml:space="preserve">
+    <value>不支持的归档格式！</value>
+  </data>
+  <data name="ViewModelLaunchGameAdvancedStartProgramPathNotSet" xml:space="preserve">
+    <value>未设置自定义启动程序路径</value>
+  </data>
+  <data name="ViewModelLaunchGameAdvancedStartProgramNotExists" xml:space="preserve">
+    <value>自定义启动程序不存在</value>
+  </data>
+  <data name="ViewModelLaunchGameAdvancedStartProgramLaunched" xml:space="preserve">
+    <value>已启动自定义程序</value>
+  </data>
+  <data name="ViewModelLaunchGameAdvancedStartProgramPathSaved" xml:space="preserve">
+    <value>已保存自定义启动程序路径</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartManager" xml:space="preserve">
+    <value>管理自定义程序启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartListSetter" xml:space="preserve">
+    <value>设置程序清单源</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartGameDelayedStart" xml:space="preserve">
+    <value>启动延迟启动清单中程序</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartDelayedStartList" xml:space="preserve">
+    <value>延时启动程序列表</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartSourceDescription" xml:space="preserve">
+    <value>填写目标 json 格式的 http 链接</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedDelayedStartTitle" xml:space="preserve">
+    <value>延迟启动程序清单表</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartSourceSetterTitle" xml:space="preserve">
+    <value>程序列表获取源设置</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartSourceSetterBackToDefaultButton" xml:space="preserve">
+    <value>恢复默认</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartSourceSetterSaveSuccess" xml:space="preserve">
+    <value>保存成功</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartDelayedStartListDelayedTime" xml:space="preserve">
+    <value>延迟（秒）</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartDelayedStartListPath" xml:space="preserve">
+    <value>应用路径</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartDelayedStartListName" xml:space="preserve">
+    <value>应用名</value>
+  </data>
+  <data name="ViewDialogLaunchGameAdvancedStartInfoBarMessage" xml:space="preserve">
+    <value>将会下载到设置的数据目录的 AdvancedStart 文件夹下，可前往设置调整或自行管理</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartCoStartHeader" xml:space="preserve">
+    <value>连带启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartCoStartDescription" xml:space="preserve">
+    <value>设置不同位置的启动是否触发延迟启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartCoStartAdvancedHeader" xml:space="preserve">
+    <value>启动自定义程序时触发延迟启动</value>
+  </data>
+  <data name="ViewPageLaunchGameAdvancedStartCoStartGameHeader" xml:space="preserve">
+    <value>启动游戏时触发延迟启动</value>
+  </data>
+  <data name="ViewPageSettingOpenSourceSupportHeader" xml:space="preserve">
+    <value>开源支持</value>
+  </data>
+  <data name="ViewCommonLoginRequiredHint" xml:space="preserve">
+    <value>请先登录后使用</value>
+  </data>
+  <data name="ViewCommonLoginQRCodeHeader" xml:space="preserve">
+    <value>扫码登录</value>
+  </data>
+  <data name="ViewCommonLoginQRCodeDescription" xml:space="preserve">
+    <value>使用米游社 App 扫码登录</value>
+  </data>
+  <data name="ViewCommonLoginMobileCaptchaHeader" xml:space="preserve">
+    <value>手机验证码</value>
+  </data>
+  <data name="ViewCommonLoginMobileCaptchaDescription" xml:space="preserve">
+    <value>使用手机号接收验证码登录</value>
+  </data>
+  <data name="ViewCommonLoginManualInputHeader" xml:space="preserve">
+    <value>手动输入</value>
+  </data>
+  <data name="ViewCommonLoginManualInputDescription" xml:space="preserve">
+    <value>手动输入 Cookie 登录</value>
+  </data>
+  <data name="ViewCommonConfirmButton" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="ViewCommonCancelButton" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="ViewHomeHeader" xml:space="preserve">
+    <value>主页</value>
+  </data>
+  <data name="ViewAnnouncementNavHeader" xml:space="preserve">
+    <value>公告</value>
+  </data>
+  <data name="ViewSignInHeader" xml:space="preserve">
+    <value>签到福利</value>
+  </data>
+  <data name="ViewUserOverseaLoginTitle" xml:space="preserve">
+    <value>国际服账号登录 (HoYoLAB)</value>
+  </data>
+  <data name="ViewUserOverseaThirdPartyHeader" xml:space="preserve">
+    <value>第三方登录</value>
+  </data>
+  <data name="ViewUserOverseaThirdPartyDescription" xml:space="preserve">
+    <value>使用第三方账号登录 HoYoLAB</value>
+  </data>
+  <data name="ViewUserOverseaPasswordHeader" xml:space="preserve">
+    <value>账密登录</value>
+  </data>
+  <data name="ViewUserOverseaPasswordDescription" xml:space="preserve">
+    <value>使用 HoYoLAB 账号密码登录</value>
+  </data>
+  <data name="ViewUserOverseaManualInputDescription" xml:space="preserve">
+    <value>手动输入国际服 Cookie 登录</value>
+  </data>
+  <data name="ViewUserCurrentAccountHeader" xml:space="preserve">
+    <value>当前账号</value>
+  </data>
+  <data name="ViewPageAvatarPropertyRefreshLabel" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="ViewPageAvatarPropertyWeaponAffixPrefix" xml:space="preserve">
+    <value>精炼</value>
+  </data>
+  <data name="ViewPageAvatarPropertyWeaponAffixSuffix" xml:space="preserve">
+    <value>阶</value>
+  </data>
+  <data name="ViewPageHomeTabActivity" xml:space="preserve">
+    <value>活动</value>
+  </data>
+  <data name="ViewPageHomeTabAnnouncement" xml:space="preserve">
+    <value>公告</value>
+  </data>
+  <data name="ViewPageHomeTabInfo" xml:space="preserve">
+    <value>资讯</value>
+  </data>
+  <data name="ViewPageHomeLaunchGameButton" xml:space="preserve">
+    <value>开始游戏</value>
+  </data>
+  <data name="ViewPageHomeStopGameButton" xml:space="preserve">
+    <value>停止游戏</value>
+  </data>
+  <data name="ViewPageLaunchGameCleanButton" xml:space="preserve">
+    <value>清理</value>
+  </data>
+  <data name="ViewPageLaunchGameCleanTooltip" xml:space="preserve">
+    <value>清理转换缓存资源，释放磁盘空间</value>
+  </data>
+  <data name="ViewPageLaunchGameServerInfoTooltip" xml:space="preserve">
+    <value>查看服务器说明</value>
+  </data>
+  <data name="ViewPageLaunchGameHdrManualHeader" xml:space="preserve">
+    <value>HDR 手动控制</value>
+  </data>
+  <data name="ViewPageLaunchGameHdrManualDescription" xml:space="preserve">
+    <value>手动开启或关闭显示器 HDR（独立于游戏启动）</value>
+  </data>
+  <data name="ViewPageLaunchGameCommandLineHeader" xml:space="preserve">
+    <value>启动参数</value>
+  </data>
+  <data name="ViewPageLaunchGameCommandLineDescription" xml:space="preserve">
+    <value>自定义游戏启动参数</value>
+  </data>
+  <data name="ViewPageLaunchGameWindowedHeader" xml:space="preserve">
+    <value>窗口</value>
+  </data>
+  <data name="ViewPageLaunchGameWindowedDescription" xml:space="preserve">
+    <value>以窗口模式启动</value>
+  </data>
+  <data name="ViewPageLaunchGameBorderlessHeader" xml:space="preserve">
+    <value>无边框窗口</value>
+  </data>
+  <data name="ViewPageLaunchGameBorderlessDescription" xml:space="preserve">
+    <value>以无边框窗口模式启动</value>
+  </data>
+  <data name="ViewPageLaunchGameFullScreenHeader" xml:space="preserve">
+    <value>全屏</value>
+  </data>
+  <data name="ViewPageLaunchGameFullScreenDescription" xml:space="preserve">
+    <value>以全屏模式启动</value>
+  </data>
+  <data name="ViewPageLaunchGameResolutionPresetHeader" xml:space="preserve">
+    <value>分辨率预设</value>
+  </data>
+  <data name="ViewPageLaunchGameResolutionPresetDescription" xml:space="preserve">
+    <value>快速选择常用分辨率</value>
+  </data>
+  <data name="ViewPageLaunchGameResolutionCustom" xml:space="preserve">
+    <value>自定义</value>
+  </data>
+  <data name="ViewPageLaunchGameScreenWidthHeader" xml:space="preserve">
+    <value>屏幕宽度</value>
+  </data>
+  <data name="ViewPageLaunchGameScreenWidthDescription" xml:space="preserve">
+    <value>自定义屏幕宽度</value>
+  </data>
+  <data name="ViewPageLaunchGameScreenHeightHeader" xml:space="preserve">
+    <value>屏幕高度</value>
+  </data>
+  <data name="ViewPageLaunchGameScreenHeightDescription" xml:space="preserve">
+    <value>自定义屏幕高度</value>
+  </data>
+  <data name="ViewPageLaunchGameProgramLinkHeader" xml:space="preserve">
+    <value>程序联动</value>
+  </data>
+  <data name="ViewPageLaunchGameProgramLinkDescription" xml:space="preserve">
+    <value>启动游戏后自动运行其他程序</value>
+  </data>
+  <data name="ViewPageLaunchGameBgiHeader" xml:space="preserve">
+    <value>BGI 联动启动</value>
+  </data>
+  <data name="ViewPageLaunchGameBgiDescription" xml:space="preserve">
+    <value>启动游戏后自动启动 BetterGI</value>
+  </data>
+  <data name="ViewPageLaunchGameBgiSelectButton" xml:space="preserve">
+    <value>选择 BGI 程序</value>
+  </data>
+  <data name="ViewPageLaunchGameClearSelection" xml:space="preserve">
+    <value>清除选择</value>
+  </data>
+  <data name="ViewPageLaunchGameBgiDelayHeader" xml:space="preserve">
+    <value>BGI 延迟启动</value>
+  </data>
+  <data name="ViewPageLaunchGameDelayParamDescription" xml:space="preserve">
+    <value>延迟/参数</value>
+  </data>
+  <data name="ViewPageLaunchGameDelayNone" xml:space="preserve">
+    <value>无延迟 (0秒)</value>
+  </data>
+  <data name="ViewPageLaunchGameDelay3s" xml:space="preserve">
+    <value>3 秒</value>
+  </data>
+  <data name="ViewPageLaunchGameDelay5s" xml:space="preserve">
+    <value>5 秒</value>
+  </data>
+  <data name="ViewPageLaunchGameDelay10s" xml:space="preserve">
+    <value>10 秒</value>
+  </data>
+  <data name="ViewPageLaunchGameDelay15s" xml:space="preserve">
+    <value>15 秒</value>
+  </data>
+  <data name="ViewPageLaunchGameArgsPlaceholder" xml:space="preserve">
+    <value>启动参数(可选)</value>
+  </data>
+  <data name="ViewPageLaunchGameSelectProgramButton" xml:space="preserve">
+    <value>选择程序</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachProgram1Header" xml:space="preserve">
+    <value>附加程序启动 1</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachProgram1Description" xml:space="preserve">
+    <value>启动游戏后自动运行自定义程序</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachDelay1Header" xml:space="preserve">
+    <value>延迟启动 1</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachProgram2Header" xml:space="preserve">
+    <value>附加程序启动 2</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachDelay2Header" xml:space="preserve">
+    <value>延迟启动 2</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachProgram3Header" xml:space="preserve">
+    <value>附加程序启动 3</value>
+  </data>
+  <data name="ViewPageLaunchGameAttachDelay3Header" xml:space="preserve">
+    <value>延迟启动 3</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFovToggleHeader" xml:space="preserve">
+    <value>视野热开关</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFovAdjustHeader" xml:space="preserve">
+    <value>调整视野</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandDisableFogHeader" xml:space="preserve">
+    <value>移除迷雾</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandCraftRedirectHeader" xml:space="preserve">
+    <value>可合成重定向</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFpsHeader" xml:space="preserve">
+    <value>帧率模式</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFpsTargetHeader" xml:space="preserve">
+    <value>目标帧率</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandDisableCharFadeHeader" xml:space="preserve">
+    <value>禁用角色渐隐</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandDisableVSyncHeader" xml:space="preserve">
+    <value>禁用垂直同步</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandHideQuestBannerHeader" xml:space="preserve">
+    <value>隐藏地图卡片</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandHideMenuUidHeader" xml:space="preserve">
+    <value>隐藏菜单UID</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFixLowFovHeader" xml:space="preserve">
+    <value>低视距修正</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandPortableCraftHeader" xml:space="preserve">
+    <value>随身合成台</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandModifierKeyHeader" xml:space="preserve">
+    <value>修饰键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandVkCodeHeader" xml:space="preserve">
+    <value>VK码</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandRemoveTeamProgressHeader" xml:space="preserve">
+    <value>移除队伍配置进度条</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandDisableQAnimHeader" xml:space="preserve">
+    <value>移除Q动画播放</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandReloadHotkeyHeader" xml:space="preserve">
+    <value>重载配置热键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandRemoveDamageTextHeader" xml:space="preserve">
+    <value>移除战斗伤害数字</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandTouchScreenHeader" xml:space="preserve">
+    <value>手机端模式</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandHideGameUidHeader" xml:space="preserve">
+    <value>隐藏游戏内UID</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandCookingHotkeyHeader" xml:space="preserve">
+    <value>烹饪快捷键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandForgeHotkeyHeader" xml:space="preserve">
+    <value>锻造快捷键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandGuiHotkeyHeader" xml:space="preserve">
+    <value>GUI快捷键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamHeader" xml:space="preserve">
+    <value>自由相机</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamLockHeader" xml:space="preserve">
+    <value>固定镜头</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamMoveSpeedHeader" xml:space="preserve">
+    <value>移动速度</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamSprintMultHeader" xml:space="preserve">
+    <value>加速倍率</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamMouseSensitivityHeader" xml:space="preserve">
+    <value>鼠标灵敏度</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandFreeCamPitchLimitHeader" xml:space="preserve">
+    <value>俯仰角限制</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandNoGrassHeader" xml:space="preserve">
+    <value>除草</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandNoTreeLeafHeader" xml:space="preserve">
+    <value>隐藏树叶</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandDispatchHotkeyHeader" xml:space="preserve">
+    <value>探索派遣快捷键</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandToggleOn" xml:space="preserve">
+    <value>开</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandToggleOff" xml:space="preserve">
+    <value>关</value>
+  </data>
+
+  <data name="ViewPageLaunchGameIslandToggleKeep" xml:space="preserve">
+    <value>保留</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandToggleRemove" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandToggleHide" xml:space="preserve">
+    <value>隐藏</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandToggleShow" xml:space="preserve">
+    <value>显示</value>
+  </data>
+  <data name="ViewPageLaunchGameIslandModifierNone" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="ViewPageLaunchGameAutomationHotkeyHint" xml:space="preserve">
+    <value>快捷键按一下开启，再按一下关闭</value>
+  </data>
+  <data name="ViewPageLaunchGameVkReferenceHeader" xml:space="preserve">
+    <value>VK码参考</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllHeader" xml:space="preserve">
+    <value>自定义插件</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllDescription" xml:space="preserve">
+    <value>允许添加自定义 DLL 文件作为插件加载</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllEnabledHeader" xml:space="preserve">
+    <value>启用自定义插件</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllEnabledDescription" xml:space="preserve">
+    <value>开启后，启动游戏时将加载下方列表中的 DLL 插件</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllListHeader" xml:space="preserve">
+    <value>DLL 文件列表</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllListEmpty" xml:space="preserve">
+    <value>尚未添加任何 DLL 文件</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllAdd" xml:space="preserve">
+    <value>添加 DLL</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllRemove" xml:space="preserve">
+    <value>移除</value>
+  </data>
+  <data name="ViewPageLaunchGameCustomDllWarning" xml:space="preserve">
+    <value>注意：加载第三方 DLL 插件可能导致封号风险，请谨慎使用</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryDigit" xml:space="preserve">
+    <value>数字键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryLetter" xml:space="preserve">
+    <value>字母键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryFunction" xml:space="preserve">
+    <value>功能键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryNumpad" xml:space="preserve">
+    <value>小键盘</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryControl" xml:space="preserve">
+    <value>控制键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryNavigation" xml:space="preserve">
+    <value>导航键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategorySymbol" xml:space="preserve">
+    <value>符号键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryMouse" xml:space="preserve">
+    <value>鼠标按键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryMedia" xml:space="preserve">
+    <value>多媒体键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkCategoryOther" xml:space="preserve">
+    <value>其他按键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkMouseLeft" xml:space="preserve">
+    <value>鼠标左键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkMouseRight" xml:space="preserve">
+    <value>鼠标右键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkMouseMiddle" xml:space="preserve">
+    <value>鼠标中键</value>
+  </data>
+  <data name="ViewPageLaunchGameVkMouseSide1" xml:space="preserve">
+    <value>鼠标侧键1</value>
+  </data>
+  <data name="ViewPageLaunchGameVkMouseSide2" xml:space="preserve">
+    <value>鼠标侧键2</value>
+  </data>
+  <data name="ViewPageLaunchGameServerInfoNoDescription" xml:space="preserve">
+    <value>暂无说明</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionConfirmText" xml:space="preserve">
+    <value>我已知晓此些功能带来的风险并自愿使用</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionInputPlaceholder" xml:space="preserve">
+    <value>请在此手动输入上方红色确认文字</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionDisclaimerTitle" xml:space="preserve">
+    <value>插件功能风险告知协议</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionDisclaimerContent" xml:space="preserve">
+    <value>开启插件功能后，ky3 Launcher 将向原神游戏进程加载消息模块（DLL 插件），以实现以下功能：
+
+· 视野调整 / 移除迷雾
+· 帧率解锁 / 禁用垂直同步
+· 禁用角色渐隐 / 移除 Q 动画播放
+· 隐藏地图卡片 / 隐藏菜单 UID / 隐藏游戏内 UID
+· 随身合成台 / 可合成重定向
+· 移除队伍配置进度条 / 移除战斗伤害数字
+· 探索派遣快捷键 / 烹饪快捷键 / 锻造快捷键
+· 手机端模式 / 重载配置热键
+
+风险提示：
+1. 上述功能通过修改游戏运行时内存实现，属于第三方干预行为。
+2. 使用这些功能违反《原神》用户服务协议，可能导致账号被永久封禁。
+3. 插件加载操作可能引起游戏崩溃、数据异常或与反作弊系统冲突。
+4. 开发者不对因使用插件功能导致的任何后果（包括但不限于封号、数据丢失）承担任何责任。
+5. 您应自行承担使用这些功能所带来的全部风险。
+
+如您已充分了解上述风险并自愿使用，请在下方手动输入以下文字：</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionDialogTitle" xml:space="preserve">
+    <value>风险确认</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionConfirmButton" xml:space="preserve">
+    <value>确认开启</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionErrorTitle" xml:space="preserve">
+    <value>输入不正确</value>
+  </data>
+  <data name="ViewPageLaunchGameInjectionErrorContent" xml:space="preserve">
+    <value>您输入的确认文字与要求不一致，插件功能未开启。</value>
+  </data>
+  <data name="ViewPageLaunchGameHdrUnavailableTitle" xml:space="preserve">
+    <value>HDR 不可用</value>
+  </data>
+  <data name="ViewPageLaunchGameHdrUnavailableContent" xml:space="preserve">
+    <value>当前显示器不支持 HDR，无法开启。</value>
+  </data>
+  <data name="ViewPageAvatarPropertyPropertiesHeader" xml:space="preserve">
+    <value>角色属性</value>
+  </data>
+  <data name="ViewDialogCleanResourceTitle" xml:space="preserve">
+    <value>清理转换资源</value>
+  </data>
+  <data name="ViewDialogCleanResourceCloseButton" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="ViewDialogCleanResourcePrimaryButton" xml:space="preserve">
+    <value>清理选中</value>
+  </data>
+  <data name="ViewDialogCleanResourceDescription" xml:space="preserve">
+    <value>选择要清理的转换缓存资源，此操作不会影响游戏本体。</value>
+  </data>
+  <data name="ViewDialogCleanResourceSelectedText" xml:space="preserve">
+    <value>选中：{0}</value>
+  </data>
+  <data name="ViewDialogCleanResourceChunksName" xml:space="preserve">
+    <value>转换下载分块</value>
+  </data>
+  <data name="ViewDialogCleanResourceOverseaName" xml:space="preserve">
+    <value>国际服备份资源</value>
+  </data>
+  <data name="ViewDialogCleanResourceChineseName" xml:space="preserve">
+    <value>国服备份资源</value>
+  </data>
+  <data name="ViewDialogCleanResourceNoSize" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustReady" xml:space="preserve">
+    <value>已就绪 在使用时执行</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustNotReady" xml:space="preserve">
+    <value>未就绪</value>
+  </data>
+  <data name="ServiceAppOptionsBackdropAcrylic" xml:space="preserve">
+    <value>Acrylic - 亚克力毛玻璃</value>
+  </data>
+  <data name="ServiceAppOptionsBackdropAcrylicThin" xml:space="preserve">
+    <value>AcrylicThin - 薄亚克力</value>
+  </data>
+  <data name="ServiceAppOptionsBackdropMica" xml:space="preserve">
+    <value>Mica - 云母</value>
+  </data>
+  <data name="ServiceAppOptionsBackdropMicaAlt" xml:space="preserve">
+    <value>MicaAlt - 云母变体</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustInit" xml:space="preserve">
+    <value>功能插件组件</value>
+  </data>
+  <data name="ServiceBackgroundActivityFullTrustInitDescription" xml:space="preserve">
+    <value>已就绪</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescCnDefault" xml:space="preserve">
+    <value>官服默认渠道</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescCnOfficialDefault" xml:space="preserve">
+    <value>官服默认启动器，适合大多数玩家</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescCnOfficialOfficial" xml:space="preserve">
+    <value>官服完整启动器，米哈游官方渠道</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescCnOfficialNoTapTap" xml:space="preserve">
+    <value>非TapTap渠道版，适合小米/华为等应用商店</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescCnBili" xml:space="preserve">
+    <value>B站专属服务器，需使用B站账号登录</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescOsDefault" xml:space="preserve">
+    <value>国际服默认渠道</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescOsOfficialDefault" xml:space="preserve">
+    <value>国际服默认启动器，全球通用</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescOsOfficialOfficial" xml:space="preserve">
+    <value>国际服完整启动器，米哈游国际渠道</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescOsEpic" xml:space="preserve">
+    <value>Epic游戏商城版本</value>
+  </data>
+  <data name="ServiceLaunchSchemeDescOsGoogle" xml:space="preserve">
+    <value>Google Play商店版本</value>
+  </data>
+  <data name="ServiceMetadataInitReady" xml:space="preserve">
+    <value>已就绪，可以正常使用全部功能</value>
+  </data>
+  <data name="ViewModelLaunchGameErrorTitle" xml:space="preserve">
+    <value>启动游戏</value>
+  </data>
+  <data name="ViewModelResumeGameErrorTitle" xml:space="preserve">
+    <value>恢复游戏</value>
+  </data>
+  <data name="ViewModelServerConvertTitle" xml:space="preserve">
+    <value>服务器转换</value>
+  </data>
+  <data name="ViewModelServerConvertAccessDeniedAdmin" xml:space="preserve">
+    <value>游戏目录权限不足，即使以管理员身份运行仍无法写入，请检查目录权限设置</value>
+  </data>
+  <data name="ViewModelServerConvertAccessDenied" xml:space="preserve">
+    <value>游戏目录权限不足，请以管理员身份重启应用后重试</value>
+  </data>
+  <data name="ViewModelServerConvertRestartAsAdmin" xml:space="preserve">
+    <value>以管理员重启</value>
+  </data>
+  <data name="ViewModelServerConvertSuccessText" xml:space="preserve">
+    <value>服务器转换完成，当前服务器：{0}</value>
+  </data>
+  <data name="ViewModelServerConvertSuccessWithDescText" xml:space="preserve">
+    <value>服务器转换完成，当前服务器：{0}
+{1}</value>
+  </data>
+  <data name="ViewModelCleanResourceSuccessText" xml:space="preserve">
+    <value>已清理 {0} 项资源，释放 {1} 空间</value>
+  </data>
+  <data name="ViewModelCleanResourcePartialError" xml:space="preserve">
+    <value>部分资源清理失败</value>
+  </data>
+  <data name="ViewModelGamePackageSchemeText" xml:space="preserve">
+    <value>服务器: {0}</value>
+  </data>
+  <data name="ViewModelGamePackageSizeText" xml:space="preserve">
+    <value>占用大小: {0} GB</value>
+  </data>
+  <data name="WebResponseAccountNotLoggedIn" xml:space="preserve">
+    <value>账号未登录或登录已过期，请在软件内重新登录米游社账号</value>
+  </data>
+  <data name="WebResponseAccountRisk" xml:space="preserve">
+    <value>当前账号存在风险，请不要担心这是米游社防人机验证，请先通过验证或过段时间再试</value>
+  </data>
+  <data name="WebResponseDataNotPublic" xml:space="preserve">
+    <value>用户数据未公开，请前往 HoYoLAB 将战绩设为公开</value>
+  </data>
+  <data name="WebResponseTooManyRequests" xml:space="preserve">
+    <value>请求过于频繁，请稍后再试</value>
+  </data>
+  <data name="WebResponseAccountOrPasswordError" xml:space="preserve">
+    <value>账号或密码错误</value>
+  </data>
+  <data name="ViewModelLaunchGameUnsupportedChannelOptions" xml:space="preserve">
+    <value>不支持的 ChannelOptions: {0}</value>
+  </data>
+  <data name="ViewGuideTitle" xml:space="preserve">
+    <value>ky3 Launcher 用户使用协议与隐私政策</value>
+  </data>
+  <data name="ViewGuideWarning" xml:space="preserve">
+    <value>重要提示：请您务必仔细阅读以下全部内容（特别是关于免责、风险提示及管辖权的条款）。在适用法律允许的最大范围内，使用本软件即表示您已完全理解、同意并自愿承担本协议的全部约束。本软件包含的插件加载等高级功能明确违反游戏官方用户协议，存在导致游戏账号被永久封禁的绝对风险。如您不同意本协议的任何内容，请立即停止使用并彻底卸载本软件。</value>
+  </data>
+  <data name="ViewGuideFooter" xml:space="preserve">
+    <value>最后更新时间：2026 年
+
+点击下方复选框即表示您已仔细阅读、充分理解本协议中的所有免责与风险条款，并自愿承担使用本软件带来的全部后果。
+感谢您对本项目的支持与信任，祝您在提瓦特大陆旅途愉快！</value>
+  </data>
+  <data name="ViewGuide1Title" xml:space="preserve">
+    <value>第一章  软件概述与授权许可</value>
+  </data>
+  <data name="ViewGuide1_1Title" xml:space="preserve">
+    <value>【1.1 软件简介】</value>
+  </data>
+  <data name="ViewGuide1_1Text1" xml:space="preserve">
+    <value>ky3 Launcher（以下简称"本软件"）是一款基于 Snap Hutao 开源项目进行二次开发的原神第三方辅助工具。本软件遵循 MIT 开源许可协议发布，旨在为原神玩家提供优化体验，体感，等便捷功能。</value>
+  </data>
+  <data name="ViewGuide1_1Text2" xml:space="preserve">
+    <value>本软件的原始项目 Snap Hutao(现已停止维护） 由 DGP Studio 开发并维护，Launcher 基于其开源代码进行功能定制、界面优化与持续更新。</value>
+  </data>
+  <data name="ViewGuide1_2Title" xml:space="preserve">
+    <value>【1.2 授权许可】</value>
+  </data>
+  <data name="ViewGuide1_2Text" xml:space="preserve">
+    <value>根据 MIT 开源许可协议，您可以自由地使用、复制、修改和分发本软件，但须遵守以下条件：</value>
+  </data>
+  <data name="ViewGuide1_2Bullet1" xml:space="preserve">
+    <value>在所有副本或重要部分中保留原始版权声明与 MIT 许可证文本。</value>
+  </data>
+  <data name="ViewGuide1_2Bullet2" xml:space="preserve">
+    <value>在二次分发或修改版本中明确标注您的修改内容，不得冒充原始项目。</value>
+  </data>
+  <data name="ViewGuide1_2Bullet3" xml:space="preserve">
+    <value>本软件按"原样"（AS IS）提供，不附带任何明示或暗示的担保。</value>
+  </data>
+  <data name="ViewGuide1_3Title" xml:space="preserve">
+    <value>【1.3 使用限制】</value>
+  </data>
+  <data name="ViewGuide1_3Text" xml:space="preserve">
+    <value>您在使用本软件时，应当严格遵守以下限制：</value>
+  </data>
+  <data name="ViewGuide1_3Bullet1" xml:space="preserve">
+    <value>不得将本软件用于任何违反您所在国家或地区法律法规的用途。</value>
+  </data>
+  <data name="ViewGuide1_3Bullet2" xml:space="preserve">
+    <value>不得利用本软件进行任何形式的游戏作弊、外挂制作、传播或非法牟利。</value>
+  </data>
+  <data name="ViewGuide1_3Bullet3" xml:space="preserve">
+    <value>不得对本软件进行反编译、反汇编或逆向工程（法律明确允许且不可通过协议排除的除外）。</value>
+  </data>
+  <data name="ViewGuide1_3Bullet4" xml:space="preserve">
+    <value>不得删除或篡改本软件中的版权声明、许可声明或其他权利标识。</value>
+  </data>
+  <data name="ViewGuide2Title" xml:space="preserve">
+    <value>第二章  核心功能说明</value>
+  </data>
+  <data name="ViewGuide2Text" xml:space="preserve">
+    <value>本软件提供以下核心功能，所有功能均在本地运行，通过调用游戏官方公开接口获取数据：</value>
+  </data>
+  <data name="ViewGuide2_1Title" xml:space="preserve">
+    <value>【2.1 游戏启动管理】</value>
+  </data>
+  <data name="ViewGuide2_1Bullet1" xml:space="preserve">
+    <value>支持自定义游戏启动参数（分辨率、窗口模式、HDR、附加程序选择等）。</value>
+  </data>
+  <data name="ViewGuide2_1Bullet2" xml:space="preserve">
+    <value>支持多账号管理与快速切换，登录凭证存储在本地 SQLite 数据库中。</value>
+  </data>
+  <data name="ViewGuide2_1Bullet3" xml:space="preserve">
+    <value>支持 FPS 解锁功能，通过插件加载技术修改游戏帧率限制。</value>
+  </data>
+  <data name="ViewGuide2_1Bullet4" xml:space="preserve">
+    <value>支持 Island 游戏内增强功能（包括帧率解锁、游戏内辅助等）。</value>
+  </data>
+  <data name="ViewGuide2_2Title" xml:space="preserve">
+    <value>【2.2 祈愿记录分析】</value>
+  </data>
+  <data name="ViewGuide2_2Bullet1" xml:space="preserve">
+    <value>通过读取游戏日志文件获取祈愿记录查询地址。</value>
+  </data>
+  <data name="ViewGuide2_2Bullet2" xml:space="preserve">
+    <value>使用您的账号凭证直接访问米哈游官方 API 拉取祈愿数据。</value>
+  </data>
+  <data name="ViewGuide2_2Bullet3" xml:space="preserve">
+    <value>在本地进行数据统计分析，包括出货率、保底计数、历史记录等。</value>
+  </data>
+  <data name="ViewGuide2_2Bullet4" xml:space="preserve">
+    <value>支持 UIGF 标准格式的数据导入与导出，便于与其他工具互通。</value>
+  </data>
+  <data name="ViewGuide2_3Title" xml:space="preserve">
+    <value>【2.3 成就管理】</value>
+  </data>
+  <data name="ViewGuide2_3Bullet1" xml:space="preserve">
+    <value>本地记录与追踪您的游戏成就完成进度。</value>
+  </data>
+  <data name="ViewGuide2_3Bullet2" xml:space="preserve">
+    <value>支持成就数据的存档与管理。</value>
+  </data>
+  <data name="ViewGuide2_3Bullet3" xml:space="preserve">
+    <value>所有成就数据仅存储在本地数据库中。</value>
+  </data>
+  <data name="ViewGuide2_4Title" xml:space="preserve">
+    <value>【2.4 深境螺旋与幻想真境剧诗记录】</value>
+  </data>
+  <data name="ViewGuide2_4Bullet1" xml:space="preserve">
+    <value>获取并记录您的深境螺旋挑战数据。</value>
+  </data>
+  <data name="ViewGuide2_4Bullet2" xml:space="preserve">
+    <value>获取并记录您的幻想真境剧诗挑战数据。</value>
+  </data>
+  <data name="ViewGuide2_4Bullet3" xml:space="preserve">
+    <value>所有记录数据存储在本地 SQLite 数据库中。</value>
+  </data>
+  <data name="ViewGuide2_5Title" xml:space="preserve">
+    <value>【2.5 角色展柜（Enka.Network）】</value>
+  </data>
+  <data name="ViewGuide2_5Bullet1" xml:space="preserve">
+    <value>通过 Enka.Network 第三方 API 获取您的角色展柜数据。</value>
+  </data>
+  <data name="ViewGuide2_5Bullet2" xml:space="preserve">
+    <value>展示角色装备、圣遗物、属性等详细信息。</value>
+  </data>
+  <data name="ViewGuide2_5Bullet3" xml:space="preserve">
+    <value>此功能依赖第三方服务 Enka.Network 的可用性。</value>
+  </data>
+  <data name="ViewGuide2_6Title" xml:space="preserve">
+    <value>【2.6 实时便笺】</value>
+  </data>
+  <data name="ViewGuide2_6Bullet1" xml:space="preserve">
+    <value>通过米哈游官方 API 查询您的实时游戏数据。</value>
+  </data>
+  <data name="ViewGuide2_6Bullet2" xml:space="preserve">
+    <value>包括树脂恢复、每日委托、探索派遣等信息。</value>
+  </data>
+  <data name="ViewGuide2_6Bullet3" xml:space="preserve">
+    <value>需要您的账号 Cookie 授权。</value>
+  </data>
+  <data name="ViewGuide2_7Title" xml:space="preserve">
+    <value>【2.7 插件加载】</value>
+  </data>
+  <data name="ViewGuide2_7Bullet1" xml:space="preserve">
+    <value>本软件包含的插件选项功能，通过向游戏进程加载动态链接库（DLL 插件）实现。</value>
+  </data>
+  <data name="ViewGuide2_7Bullet2" xml:space="preserve">
+    <value>插件加载过程通过共享内存与游戏进程通信，传递配置参数。</value>
+  </data>
+  <data name="ViewGuide2_7Bullet3" xml:space="preserve">
+    <value>此功能可能被部分安全软件误报，但不包含任何恶意代码。</value>
+  </data>
+  <data name="ViewGuide3Title" xml:space="preserve">
+    <value>第三章  知识产权与开源声明</value>
+  </data>
+  <data name="ViewGuide3_1Title" xml:space="preserve">
+    <value>【3.1 版权归属】</value>
+  </data>
+  <data name="ViewGuide3_1Bullet1" xml:space="preserve">
+    <value>本软件的原始代码版权归 DGP Studio 所有，基于 MIT 许可协议开源。</value>
+  </data>
+  <data name="ViewGuide3_1Bullet2" xml:space="preserve">
+    <value>Launcher 对二次开发部分的代码享有相应权利，同样遵循 MIT 许可协议。</value>
+  </data>
+  <data name="ViewGuide3_1Bullet3" xml:space="preserve">
+    <value>本软件使用的游戏素材（角色图片、武器图标等）版权归上海米哈游网络科技股份有限公司（miHoYo / HoYoverse）所有。</value>
+  </data>
+  <data name="ViewGuide3_2Title" xml:space="preserve">
+    <value>【3.2 开源许可】</value>
+  </data>
+  <data name="ViewGuide3_2Text" xml:space="preserve">
+    <value>本软件基于 MIT License 发布，完整许可证文本如下：</value>
+  </data>
+  <data name="ViewGuide3_3Title" xml:space="preserve">
+    <value>【3.3 商标声明】</value>
+  </data>
+  <data name="ViewGuide3_3Bullet1" xml:space="preserve">
+    <value>"原神"（Genshin Impact）是上海米哈游网络科技股份有限公司的合法注册商标。</value>
+  </data>
+  <data name="ViewGuide3_3Bullet2" xml:space="preserve">
+    <value>"Snap Hutao" 是 DGP Studio 的项目名称。</value>
+  </data>
+  <data name="ViewGuide3_3Bullet3" xml:space="preserve">
+    <value>本软件名称 "ky3 Launcher" 仅用于标识本二次开发项目，不构成对任何官方商标的侵犯。</value>
+  </data>
+  <data name="ViewGuide3_3Bullet4" xml:space="preserve">
+    <value>本软件的所有界面设计、文案排版如涉及官方游戏元素，均属于米哈游公司的合理使用范畴，本软件不主张对其拥有任何商业或排他性权利。</value>
+  </data>
+  <data name="ViewGuide4Title" xml:space="preserve">
+    <value>第四章  用户数据与隐私政策</value>
+  </data>
+  <data name="ViewGuide4Text" xml:space="preserve">
+    <value>我们深知用户数据安全的重要性，特此详细说明本软件的数据处理方式和隐私保护措施。</value>
+  </data>
+  <data name="ViewGuide4_1Title" xml:space="preserve">
+    <value>【4.1 数据存储方式】</value>
+  </data>
+  <data name="ViewGuide4_1Bullet1" xml:space="preserve">
+    <value>默认情况下的本地化：除非您主动开启并授权使用云端同步等在线增值服务（详见4.5节），否则您的所有基础用户数据均仅存储在您的本地设备中，不会被隐蔽上传到任何服务器。</value>
+  </data>
+  <data name="ViewGuide4_1Bullet2" xml:space="preserve">
+    <value>数据位置：默认存储在 %LOCALAPPDATA%\ky3 Launcher 目录下，您可以在设置中自定义数据文件夹位置。</value>
+  </data>
+  <data name="ViewGuide4_1Bullet3" xml:space="preserve">
+    <value>数据格式：数据使用 SQLite 数据库和 JSON 文件存储，均为标准开放格式，您可以使用任何兼容工具查看。</value>
+  </data>
+  <data name="ViewGuide4_1Bullet4" xml:space="preserve">
+    <value>加密存储：账号 Cookie 等敏感信息使用 Windows 数据保护 API（DPAPI）进行加密存储，确保只有当前 Windows 用户账户才能解密访问。</value>
+  </data>
+  <data name="ViewGuide4_2Title" xml:space="preserve">
+    <value>【4.2 数据收集声明】</value>
+  </data>
+  <data name="ViewGuide4_2Bullet1" xml:space="preserve">
+    <value>本软件不包含任何商业广告 SDK、恶意用户行为追踪组件或隐蔽的数据埋点代码。</value>
+  </data>
+  <data name="ViewGuide4_2Bullet2" xml:space="preserve">
+    <value>除您主动使用的在线功能（如数据同步）外，本软件不会主动将您的游戏账号、密码、Cookie 或个人数据上传至任何开发者服务器。</value>
+  </data>
+  <data name="ViewGuide4_2Bullet3" xml:space="preserve">
+    <value>使用在线功能时，仅传输提供该功能所必需的最少数据量。</value>
+  </data>
+  <data name="ViewGuide4_3Title" xml:space="preserve">
+    <value>【4.3 网络通信说明】</value>
+  </data>
+  <data name="ViewGuide4_3Text" xml:space="preserve">
+    <value>本软件在运行过程中可能进行以下网络通信，所有通信均为实现软件功能所必需：</value>
+  </data>
+  <data name="ViewGuide4_3Bullet1" xml:space="preserve">
+    <value>米哈游官方 API：使用您的账号凭证（Cookie）直接访问米哈游官方服务器获取游戏数据（祈愿记录、实时便笺、深渊数据等）。</value>
+  </data>
+  <data name="ViewGuide4_3Bullet2" xml:space="preserve">
+    <value>Enka.Network API：访问 enka.network 获取角色展柜数据，仅需提供游戏 UID（非敏感信息）即可查询。</value>
+  </data>
+  <data name="ViewGuide4_3Bullet3" xml:space="preserve">
+    <value>GitHub：访问 GitHub 检查软件是否有新版本可用，此过程仅传输版本号等基础握手信息。</value>
+  </data>
+  <data name="ViewGuide4_3Bullet4" xml:space="preserve">
+    <value>静态资源 CDN：首次使用时从开发者服务器或对象存储OSS下载游戏角色、武器等静态资源图片。</value>
+  </data>
+  <data name="ViewGuide4_3Bullet5" xml:space="preserve">
+    <value>开发者服务器：本软件可能与开发者运营的服务器通信，用于提供数据同步、展柜代理等在线增值功能。</value>
+  </data>
+  <data name="ViewGuide4_4Title" xml:space="preserve">
+    <value>【4.4 崩溃报告服务（Sentry）】</value>
+  </data>
+  <data name="ViewGuide4_4Text" xml:space="preserve">
+    <value>本软件集成了 Sentry 崩溃报告服务，用于收集匿名的应用崩溃信息和性能数据，以帮助开发者改进软件质量。</value>
+  </data>
+  <data name="ViewGuide4_4Bullet1" xml:space="preserve">
+    <value>收集的信息包括：软件版本号、操作系统版本、崩溃堆栈信息、性能指标等纯技术数据。</value>
+  </data>
+  <data name="ViewGuide4_4Bullet2" xml:space="preserve">
+    <value>严格禁止收集：您的游戏账号、Cookie、真实姓名、物理位置或其他任何可直接识别您身份的敏感数据。</value>
+  </data>
+  <data name="ViewGuide4_4Bullet3" xml:space="preserve">
+    <value>本软件会在首次启动时或设置菜单中提供崩溃报告的明确开启/关闭选项，您可以自由决定是否参与。</value>
+  </data>
+  <data name="ViewGuide4_5Title" xml:space="preserve">
+    <value>【4.5 开发者服务器】</value>
+  </data>
+  <data name="ViewGuide4_5Text1" xml:space="preserve">
+    <value>本软件可能连接开发者运营的后端服务器，用于提供以下增值功能：</value>
+  </data>
+  <data name="ViewGuide4_5Bullet1" xml:space="preserve">
+    <value>数据同步与云备份：在您明确授权的情况下，将祈愿记录等数据同步至开发者服务器，便于跨设备使用。</value>
+  </data>
+  <data name="ViewGuide4_5Bullet2" xml:space="preserve">
+    <value>Enka 展柜代理：通过开发者服务器代理 Enka.Network 请求，提升访问稳定性与速度。</value>
+  </data>
+  <data name="ViewGuide4_5Bullet3" xml:space="preserve">
+    <value>其他在线功能：随软件版本更新，可能新增更多需要服务器支持的功能。</value>
+  </data>
+  <data name="ViewGuide4_5Text2" xml:space="preserve">
+    <value>使用上述功能时，开发者承诺：</value>
+  </data>
+  <data name="ViewGuide4_5Promise1" xml:space="preserve">
+    <value>仅收集提供服务所必需的最少数据，并采取合理的技术措施保障传输及存储安全。</value>
+  </data>
+  <data name="ViewGuide4_5Promise2" xml:space="preserve">
+    <value>绝对不会将您的任何数据出售、共享或非法提供给无关的第三方。</value>
+  </data>
+  <data name="ViewGuide4_5Promise3" xml:space="preserve">
+    <value>您可以随时选择不使用需要服务器连接的功能，软件的核心本地功能不受任何影响。</value>
+  </data>
+  <data name="ViewGuide4_6Title" xml:space="preserve">
+    <value>【4.6 第三方服务与跨境数据流动】</value>
+  </data>
+  <data name="ViewGuide4_6Text" xml:space="preserve">
+    <value>本软件可能使用以下第三方服务，这些服务有其独立的隐私政策，且其服务器可能位于您所在国家或地区境外：</value>
+  </data>
+  <data name="ViewGuide4_6Bullet1" xml:space="preserve">
+    <value>米哈游官方 API：受米哈游用户协议和隐私政策约束。</value>
+  </data>
+  <data name="ViewGuide4_6Bullet2" xml:space="preserve">
+    <value>GitHub：受 GitHub 隐私政策约束，用于软件更新检查和版本下载。</value>
+  </data>
+  <data name="ViewGuide4_6Bullet3" xml:space="preserve">
+    <value>Enka.Network：受其独立的隐私政策约束，用于角色展柜数据查询。</value>
+  </data>
+  <data name="ViewGuide4_6Bullet4" xml:space="preserve">
+    <value>开发者服务器：用于下载静态资源（角色图片、武器图标等）。</value>
+  </data>
+  <data name="ViewGuide4_6Bullet5" xml:space="preserve">
+    <value>Sentry：受 Sentry 隐私政策约束，用于匿名崩溃报告。</value>
+  </data>
+  <data name="ViewGuide4_6Bullet6" xml:space="preserve">
+    <value>使用涉及第三方接口的功能（如 Enka 展柜、GitHub 更新、Sentry 报错），即视为您知晓并同意相关非敏感数据可能发生合法的跨境传输。</value>
+  </data>
+  <data name="ViewGuide4_7Title" xml:space="preserve">
+    <value>【4.7 数据安全建议】</value>
+  </data>
+  <data name="ViewGuide4_7Bullet1" xml:space="preserve">
+    <value>定期备份：强烈建议您定期备份数据文件夹，以防不可预见的硬件故障导致意外数据丢失。</value>
+  </data>
+  <data name="ViewGuide4_7Bullet2" xml:space="preserve">
+    <value>妥善保管：请绝对保密您的数据文件夹，其中包含可直接登录您账号的加密凭证，请勿分享给他人。</value>
+  </data>
+  <data name="ViewGuide4_7Bullet3" xml:space="preserve">
+    <value>系统安全：建议保持操作系统和安全软件更新，防范木马或恶意软件窃取您的本地数据。</value>
+  </data>
+  <data name="ViewGuide4_7Bullet4" xml:space="preserve">
+    <value>官方渠道：请务必仅从官方 GitHub 仓库或认定的可信来源下载本软件，拒绝使用来路不明的魔改版本。</value>
+  </data>
+  <data name="ViewGuide4_8Title" xml:space="preserve">
+    <value>【4.8 用户数据权利】</value>
+  </data>
+  <data name="ViewGuide4_8Bullet1" xml:space="preserve">
+    <value>完全控制权：您对存储在本地的所有数据拥有 100% 的控制权和所有权。</value>
+  </data>
+  <data name="ViewGuide4_8Bullet2" xml:space="preserve">
+    <value>随时删除：您可以随时删除数据文件夹或卸载软件，无需担心云端产生无法清除的残留数据。</value>
+  </data>
+  <data name="ViewGuide4_8Bullet3" xml:space="preserve">
+    <value>数据导出：所有数据以标准格式存储，您可以自由导出、备份和迁移。</value>
+  </data>
+  <data name="ViewGuide4_8Bullet4" xml:space="preserve">
+    <value>数据可移植：祈愿记录支持 UIGF 标准格式导出，可无缝迁移至其他兼容该标准的工具。</value>
+  </data>
+  <data name="ViewGuide5Title" xml:space="preserve">
+    <value>第五章  免责声明与风险提示（必读）</value>
+  </data>
+  <data name="ViewGuide5_1Title" xml:space="preserve">
+    <value>【5.1 与游戏官方的关系】</value>
+  </data>
+  <data name="ViewGuide5_1Bullet1" xml:space="preserve">
+    <value>本软件是完全独立的第三方辅助体验工具，与上海米哈游网络科技股份有限公司（miHoYo / HoYoverse）没有任何形式的关联、合作或官方授权。</value>
+  </data>
+  <data name="ViewGuide5_1Bullet2" xml:space="preserve">
+    <value>本软件不代表、不暗示获得任何游戏官方的认可、背书或推荐。</value>
+  </data>
+  <data name="ViewGuide5_1Bullet3" xml:space="preserve">
+    <value>因使用本软件引发的任何游戏内资产损失或连带后果，游戏官方及本软件开发者均不承担任何责任。</value>
+  </data>
+  <data name="ViewGuide5_2Title" xml:space="preserve">
+    <value>【5.2 账号安全与封禁风险】</value>
+  </data>
+  <data name="ViewGuide5_2Bullet1" xml:space="preserve">
+    <value>虽然本软件的大部分功能通过官方公开接口合法获取数据，但根据游戏官方政策，使用任何第三方工具均可能存在违规风险。</value>
+  </data>
+  <data name="ViewGuide5_2Bullet2" xml:space="preserve">
+    <value>开发者绝对无法保证使用本软件不会导致您的游戏账号受到警告、限制登录或永久封禁。</value>
+  </data>
+  <data name="ViewGuide5_2Bullet3" xml:space="preserve">
+    <value>您应当利用自身判断力评估使用本软件的风险，并对使用的所有后果承担 100% 的独立责任。</value>
+  </data>
+  <data name="ViewGuide5_2Bullet4" xml:space="preserve">
+    <value>如发生账号封禁等处罚事件，开发者不承担任何形式的申诉协助义务，亦不提供任何经济赔偿或补偿。</value>
+  </data>
+  <data name="ViewGuide5_3Title" xml:space="preserve">
+    <value>【5.3 插件加载风险】</value>
+  </data>
+  <data name="ViewGuide5_3Bullet1" xml:space="preserve">
+    <value>FPS 解锁与 Island 等功能通过插件加载技术实现，此类技术明确违反游戏官方《用户协议》及反作弊系统（如 mhyprot）的运行规则。</value>
+  </data>
+  <data name="ViewGuide5_3Bullet2" xml:space="preserve">
+    <value>开启并使用此类功能即代表您"明知故犯"地主动违反游戏官方服务条款。</value>
+  </data>
+  <data name="ViewGuide5_3Bullet3" xml:space="preserve">
+    <value>此功能随时可能被游戏反作弊机制精准检测，由此导致的账号连带处罚风险完全由您自行承担。</value>
+  </data>
+  <data name="ViewGuide5_3Bullet4" xml:space="preserve">
+    <value>此功能极易被 Windows Defender 或其他杀毒软件识别为恶意威胁并拦截，此属技术层面的正常现象，并非软件包含病毒。</value>
+  </data>
+  <data name="ViewGuide5_4Title" xml:space="preserve">
+    <value>【5.4 软件担保的绝对免责】</value>
+  </data>
+  <data name="ViewGuide5_4Text" xml:space="preserve">
+    <value>在适用法律允许的最大范围内，本软件按"原样"（AS IS）且"可用"（AS AVAILABLE）的状态提供，开发者明确否认任何形式的明示或暗示担保，包括但不限于：</value>
+  </data>
+  <data name="ViewGuide5_4Bullet1" xml:space="preserve">
+    <value>对适销性、特定用途的适用性、可靠性及非侵权性的暗示担保。</value>
+  </data>
+  <data name="ViewGuide5_4Bullet2" xml:space="preserve">
+    <value>对本软件完全无错误、不中断运行或绝对满足您特定期望的担保。</value>
+  </data>
+  <data name="ViewGuide5_4Bullet3" xml:space="preserve">
+    <value>对因下载、安装、使用本软件而导致的任何直接、间接、偶发、特殊或惩罚性的损害赔偿（包括但不限于设备损坏、数据丢失、利润损失）。</value>
+  </data>
+  <data name="ViewGuide5_5Title" xml:space="preserve">
+    <value>【5.5 数据丢失与服务异常免责】</value>
+  </data>
+  <data name="ViewGuide5_5Text" xml:space="preserve">
+    <value>虽然本软件尽力确保数据的完整性和功能性，但在适用法律允许的最大范围内，开发者不对以下情况导致的任何损失承担责任：</value>
+  </data>
+  <data name="ViewGuide5_5Bullet1" xml:space="preserve">
+    <value>用户误操作（如误删、误格式化）导致的数据不可逆丢失。</value>
+  </data>
+  <data name="ViewGuide5_5Bullet2" xml:space="preserve">
+    <value>操作系统崩溃、硬盘物理损坏或第三方恶意软件攻击造成的数据毁损。</value>
+  </data>
+  <data name="ViewGuide5_5Bullet3" xml:space="preserve">
+    <value>游戏官方 API 变更、接口加密机制强制升级导致的数据抓取永久或暂时性失效。</value>
+  </data>
+  <data name="ViewGuide5_5Bullet4" xml:space="preserve">
+    <value>第三方服务（如 Enka.Network 限流、宕机）导致的功能异常。</value>
+  </data>
+  <data name="ViewGuide5_5Bullet5" xml:space="preserve">
+    <value>开发者对上述第三方因素引发的问题不承担强制修复的义务。</value>
+  </data>
+  <data name="ViewGuide6Title" xml:space="preserve">
+    <value>第六章  用户行为规范</value>
+  </data>
+  <data name="ViewGuide6_1Title" xml:space="preserve">
+    <value>【6.1 合法使用】</value>
+  </data>
+  <data name="ViewGuide6_1Bullet1" xml:space="preserve">
+    <value>您应当确保下载和使用本软件的行为完全符合您所在国家或地区的全部现行法律法规。</value>
+  </data>
+  <data name="ViewGuide6_1Bullet2" xml:space="preserve">
+    <value>严禁利用本软件从事任何涉嫌诈骗、侵权、破坏计算机信息系统等违法活动。</value>
+  </data>
+  <data name="ViewGuide6_1Bullet3" xml:space="preserve">
+    <value>不得利用本软件的高级功能恶意干扰游戏服务器的正常运营或破坏游戏公平性。</value>
+  </data>
+  <data name="ViewGuide6_2Title" xml:space="preserve">
+    <value>【6.2 严禁行为】</value>
+  </data>
+  <data name="ViewGuide6_2Bullet1" xml:space="preserve">
+    <value>以营利为目的，将本软件包装、倒卖或作为收费外挂的一部分进行商业分发。</value>
+  </data>
+  <data name="ViewGuide6_2Bullet2" xml:space="preserve">
+    <value>对本软件的开源代码进行恶意篡改，植入计算机病毒、广告后门或木马程序后向公众散播。</value>
+  </data>
+  <data name="ViewGuide6_2Bullet3" xml:space="preserve">
+    <value>冒用本软件官方名义或开发者身份建立虚假社群进行钓鱼或欺诈。</value>
+  </data>
+  <data name="ViewGuide6_2Bullet4" xml:space="preserve">
+    <value>利用本软件的账号记忆功能从事非法盗号、游戏账号地下交易等黑色产业链活动。</value>
+  </data>
+  <data name="ViewGuide6_2Bullet5" xml:space="preserve">
+    <value>利用工具脚本自动化、高频次地恶意请求 API 接口，对游戏官方或第三方服务器造成实质性攻击（如 DDoS）。</value>
+  </data>
+  <data name="ViewGuide6_3Title" xml:space="preserve">
+    <value>【6.3 未成年人特别保护声明】</value>
+  </data>
+  <data name="ViewGuide6_3Bullet1" xml:space="preserve">
+    <value>若您是未满 18 周岁（或您所在地区法定成年年龄）的未成年人，请务必在您的父母或其他法定监护人陪同、指导下共同仔细阅读并同意本协议。</value>
+  </data>
+  <data name="ViewGuide6_3Bullet2" xml:space="preserve">
+    <value>未成年人使用本软件可能带来的沉迷游戏或账号违规风险，应由监护人加强监督与引导。</value>
+  </data>
+  <data name="ViewGuide6_3Bullet3" xml:space="preserve">
+    <value>因监护人未尽到监护义务，导致未成年人使用本软件引发的一切不良后果及法律责任，均由法定监护人完全承担。</value>
+  </data>
+  <data name="ViewGuide7Title" xml:space="preserve">
+    <value>第七章  其他条款</value>
+  </data>
+  <data name="ViewGuide7_1Title" xml:space="preserve">
+    <value>【7.1 协议的生效与更新】</value>
+  </data>
+  <data name="ViewGuide7_1Bullet1" xml:space="preserve">
+    <value>开发者保留在必要时随时修改本协议的权利，修改后的最新协议将随新版本软件一同发布生效。</value>
+  </data>
+  <data name="ViewGuide7_1Bullet2" xml:space="preserve">
+    <value>在协议更新后，您继续运行或使用本软件的行为，即视为您已无条件接受并同意修改后的全部条款。</value>
+  </data>
+  <data name="ViewGuide7_1Bullet3" xml:space="preserve">
+    <value>如果您拒绝接受更新后的条款，您唯一的救济途径是立即卸载本软件并清空相关数据。</value>
+  </data>
+  <data name="ViewGuide7_2Title" xml:space="preserve">
+    <value>【7.2 协议可分割性】</value>
+  </data>
+  <data name="ViewGuide7_2Bullet1" xml:space="preserve">
+    <value>如本协议中的任何条款被拥有管辖权的法院或机构认定为部分或全部无效、不合法或不可执行，该条款将被视为从本协议中独立剔除。</value>
+  </data>
+  <data name="ViewGuide7_2Bullet2" xml:space="preserve">
+    <value>上述无效条款的剔除绝不影响本协议其余所有条款的完全法律效力和可执行性。</value>
+  </data>
+  <data name="ViewGuide7_3Title" xml:space="preserve">
+    <value>【7.3 法律适用与争议解决（管辖权）】</value>
+  </data>
+  <data name="ViewGuide7_3Bullet1" xml:space="preserve">
+    <value>本协议的成立、生效、履行、解释及争议解决，均严格适用中华人民共和国大陆地区法律（排除冲突法的适用）。</value>
+  </data>
+  <data name="ViewGuide7_3Bullet2" xml:space="preserve">
+    <value>因本协议或使用本软件引发的任何纠纷或争议，双方应首先本着诚实信用原则进行友好协商。</value>
+  </data>
+  <data name="ViewGuide7_3Bullet3" xml:space="preserve">
+    <value>若协商不成，任何一方均必须向【本软件核心开发者或主要项目维护团队所在地】有管辖权的人民法院提起诉讼，排除其他任何法院的管辖权。</value>
+  </data>
+  <data name="ViewGuide7_4Title" xml:space="preserve">
+    <value>【7.4 完整协议】</value>
+  </data>
+  <data name="ViewGuide7_4Text" xml:space="preserve">
+    <value>本协议及随附的隐私政策构成了您与开发者之间关于使用本软件的唯一、完整且最终的协议，并自动取代双方此前就此达成的任何口头、书面或电子形式的声明与共识。</value>
+  </data>
+  <data name="ViewInventoryHeader" xml:space="preserve">
+    <value>背包物品</value>
+  </data>
+  <data name="ViewInventoryTitle" xml:space="preserve">
+    <value>背包武器</value>
+  </data>
+  <data name="ViewInventoryInjectButton" xml:space="preserve">
+    <value>插件获取</value>
+  </data>
+  <data name="ViewInventoryLoadButton" xml:space="preserve">
+    <value>读取数据</value>
+  </data>
+  <data name="ViewInventoryDumpPathPlaceholder" xml:space="preserve">
+    <value>PacketDump 目录路径</value>
+  </data>
+  <data name="ViewInventoryStatusReady" xml:space="preserve">
+    <value>点击“插件获取”开始</value>
+  </data>
+  <data name="ViewInventoryEmptyHint" xml:space="preserve">
+    <value>尚未获取背包信息</value>
+  </data>
+  <data name="ViewInventoryCaptureDescription" xml:space="preserve">
+    <value>自动启动游戏并加载 DLL 插件获取背包武器数据</value>
+  </data>
+  <data name="ViewInventoryWeaponLevel" xml:space="preserve">
+    <value>等级</value>
+  </data>
+  <data name="ViewInventoryWeaponPromote" xml:space="preserve">
+    <value>突破等级</value>
+  </data>
+  <data name="ViewInventoryWeaponRefinement" xml:space="preserve">
+    <value>精炼等级</value>
+  </data>
+  <data name="ViewInventoryWeaponType" xml:space="preserve">
+    <value>武器类型</value>
+  </data>
+  <data name="ViewInventoryStatusFindingProcess" xml:space="preserve">
+    <value>正在查找游戏进程...</value>
+  </data>
+  <data name="ViewInventoryStatusNoProcess" xml:space="preserve">
+    <value>未找到游戏进程，请确保游戏已启动</value>
+  </data>
+  <data name="ViewInventoryStatusInjecting" xml:space="preserve">
+    <value>找到游戏进程，正在加载插件...</value>
+  </data>
+  <data name="ViewInventoryStatusNoDll" xml:space="preserve">
+    <value>找不到 PacketSniffer.dll，请将拦截 DLL 放到程序目录</value>
+  </data>
+  <data name="ViewInventoryStatusInjectFailed" xml:space="preserve">
+    <value>插件加载失败，可能需要管理员权限</value>
+  </data>
+  <data name="ViewInventoryStatusWaitingCapture" xml:space="preserve">
+    <value>插件加载成功，等待数据包捕获...</value>
+  </data>
+  <data name="ViewInventoryStatusParsing" xml:space="preserve">
+    <value>正在解析背包数据...</value>
+  </data>
+  <data name="ViewInventoryStatusNoData" xml:space="preserve">
+    <value>未找到武器数据，请确保已捕获 CmdId=24104 的数据包</value>
+  </data>
+  <data name="ViewInventoryStatusDirNotExist" xml:space="preserve">
+    <value>数据目录不存在</value>
+  </data>
+  <data name="ViewInventoryStatusParseFailed" xml:space="preserve">
+    <value>解析失败</value>
+  </data>
+  <data name="ViewInventoryTotalCount" xml:space="preserve">
+    <value>武器总数:</value>
+  </data>
+  <data name="ViewInventoryTypeCount" xml:space="preserve">
+    <value>武器种类:</value>
+  </data>
+  <data name="ViewInventoryColumnRefinement" xml:space="preserve">
+    <value>精炼</value>
+  </data>
+  <data name="ViewInventoryUnknownWeapon" xml:space="preserve">
+    <value>未知武器</value>
+  </data>
+  <data name="ViewInventoryStatusDone" xml:space="preserve">
+    <value>解析完成: {0} 把武器，{1} 种</value>
+  </data>
+  <data name="ViewInventoryRefreshButton" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="ServiceFeedbackReplyNotification" xml:space="preserve">
+    <value>您的反馈已收到回复：{0}</value>
+  </data>
+  <data name="ViewNavigationThrottleTitle" xml:space="preserve">
+    <value>操作过快</value>
+  </data>
+  <data name="ViewNavigationThrottleMessage" xml:space="preserve">
+    <value>请稍后再切换页面</value>
+  </data>
+  <data name="ServiceGameLaunchingCustomDllInjectFailed" xml:space="preserve">
+    <value>以下自定义 DLL 注入失败（架构不匹配、依赖缺失、被安全软件拦截等）：</value>
+  </data>
+  <data name="ServiceGameLaunchingCannotGetLauncherPath" xml:space="preserve">
+    <value>无法获取启动器路径</value>
+  </data>
+  <data name="ServiceGameLaunchingUserCancelledElevation" xml:space="preserve">
+    <value>用户取消了管理员授权</value>
+  </data>
+  <data name="ServiceGameLaunchingStartInjectionProcessFailed" xml:space="preserve">
+    <value>启动注入进程失败</value>
+  </data>
+  <data name="ServiceGameLaunchingInjectionReasonInvalidArgs" xml:space="preserve">
+    <value>参数错误</value>
+  </data>
+  <data name="ServiceGameLaunchingInjectionReasonCreateProcessFailed" xml:space="preserve">
+    <value>创建游戏进程失败</value>
+  </data>
+  <data name="ServiceGameLaunchingInjectionReasonDllInjectFailed" xml:space="preserve">
+    <value>DLL注入失败</value>
+  </data>
+  <data name="ServiceGameLaunchingInjectionReasonUnknown" xml:space="preserve">
+    <value>未知错误 ({0})</value>
+  </data>
+  <data name="ServiceGameLaunchingInjectionFailed" xml:space="preserve">
+    <value>注入失败: {0}</value>
+  </data>
+  <data name="ServiceGameLaunchingCannotGetProcessInfo" xml:space="preserve">
+    <value>无法获取游戏进程信息</value>
+  </data>
+  <data name="ServiceGameLaunchingInvalidProcessId" xml:space="preserve">
+    <value>无效的游戏进程ID</value>
+  </data>
+  <data name="ServiceGameLaunchingCannotConnectToProcess" xml:space="preserve">
+    <value>无法连接到游戏进程</value>
+  </data>
+  <data name="ServiceYaeAchievementImportHint" xml:space="preserve">
+    <value>注意请不要进行任何操作：点击导入 → 自动启动游戏 → 读取成就 → 自动导出</value>
+  </data>
+  <data name="ServiceYaeInventoryImportHint" xml:space="preserve">
+    <value>注意请不要进行任何操作：点击导入 → 自动启动游戏 → 读取背包 → 自动导出</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypeSword" xml:space="preserve">
+    <value>单手剑</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypeCatalyst" xml:space="preserve">
+    <value>法器</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypeClaymore" xml:space="preserve">
+    <value>双手剑</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypeBow" xml:space="preserve">
+    <value>弓</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypePolearm" xml:space="preserve">
+    <value>长柄武器</value>
+  </data>
+  <data name="ServiceInventoryWeaponTypeUnknown" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="ServiceInventoryWeaponUnknown" xml:space="preserve">
+    <value>未知武器({0})</value>
+  </data>
+  <data name="ServiceInventoryPromoteText" xml:space="preserve">
+    <value>突破 {0}</value>
+  </data>
+  <data name="ServiceInventoryRefinementText" xml:space="preserve">
+    <value>精炼 {0}</value>
+  </data>
+  <data name="ViewInventoryStatusNoGamePath" xml:space="preserve">
+    <value>未配置游戏路径，请先在启动游戏页面设置</value>
+  </data>
+  <data name="ViewEmotionIconCopyButton" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="ViewEmotionIconCloseButton" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="ViewFeedbackPickImageTitle" xml:space="preserve">
+    <value>选择反馈图片</value>
+  </data>
+  <data name="ViewFeedbackPickImageFilter" xml:space="preserve">
+    <value>图片文件</value>
+  </data>
+  <data name="ViewFeedbackNoImageSelected" xml:space="preserve">
+    <value>未选择图片</value>
+  </data>
+  <data name="ViewFeedbackContentRequired" xml:space="preserve">
+    <value>请填写反馈内容</value>
+  </data>
+  <data name="ViewFeedbackSubmitSuccess" xml:space="preserve">
+    <value>感谢您的反馈，我们会认真阅读！</value>
+  </data>
+  <data name="ViewFeedbackSubmitFailed" xml:space="preserve">
+    <value>提交失败，请检查网络连接后重试</value>
+  </data>
+</root>


### PR DESCRIPTION
**Summary** 
Added full Vietnamese (`vi-VN`) localization support for ky3 Launcher.

**Details**
- Added `SH.vi-VN.resx` resource file with accurate Genshin Impact official Vietnamese terminology.
- Corrected all in-game exact strings to match the official Vietnamese game client.

Closes #48